### PR TITLE
Transfer Start Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2024-08-xx
+
+### Added
+ 
+ - Setup project structure (multimodule maven project:tools, catalog, negotiation, dataTransfer)
+ - Catalog protocol and API logic implementation (controller, service, model; junit and integration tests)
+ - Negotiation protocol and API logic implementation (controller, service, model; junit and integration tests) - Agreement enforcement is currently checking only if agreement is present, it does not check for constraints
+ - Data Transfer protocol and API logic implementation (controller, service, model; junit and integration tests) - REST pull implementation without authorization, with hardcoded value/artifact
+ - Postman collection for testing endpoints	
+ - Configured GitHub actions to run tests
+ 
 ## [0.0.1] - 2024-07-22
 
 ### Added
@@ -12,8 +23,9 @@ All notable changes to this project will be documented in this file.
  
 ## Updated
 
- - code coverage (junit and integration)
+ - Code coverage (junit and integration)
  - TransferRequestMessage - call to negotiation for agreement validity check before proceeding
+ - Negotiation module - renamed ModelUtil to MockObjectUtil (aligned with other modules)
  - postman collection
  
 ## [0.0.1] - 2024-07-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.0.1] - 2024-07-17
+
+### Added
+
+ - TransferStartMessage logic for provider and consumer callback (controller and service layer)
+ - Negotiation module - API endpoint for agreement check (valid or not)
+ 
+## Updated
+
+ - code coverage (junit and integration)
+ - TransferRequestMessage - call to negotiation for agreement validity check before proceeding
+ - postman collection
+ 
 ## [0.0.1] - 2024-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.0.1] - 2024-07-17
+## [0.0.1] - 2024-07-22
 
 ### Added
 
  - TransferStartMessage logic for provider and consumer callback (controller and service layer)
+ - DataTransfer API controller, service, junit and integration tests (get TransferProcess, by state and all)
  - Negotiation module - API endpoint for agreement check (valid or not)
+ - AbstractTransferMessage implements Serializable
  
 ## Updated
 

--- a/True_connector_DSP.environment.json
+++ b/True_connector_DSP.environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "cd693373-d4a6-4cfd-a97f-be2e0da3d728",
+	"id": "effbfb9d-feb4-4213-b5ef-f0916613c1f2",
 	"name": "TC_V2_ENV",
 	"values": [
 		{
@@ -34,7 +34,7 @@
 		},
 		{
 			"key": "CONSUMER_SERVER_API_NEGOTIATION",
-			"value": "{{CONSUMER}}/api/negotiations",
+			"value": "{{CONSUMER}}/api/v1/negotiations",
 			"type": "default",
 			"enabled": true
 		},
@@ -76,7 +76,7 @@
 		},
 		{
 			"key": "PROVIDER_SERVER_API_NEGOTIATION",
-			"value": "{{PROVIDER}}/api/negotiations",
+			"value": "{{PROVIDER}}/api/v1/negotiations",
 			"type": "default",
 			"enabled": true
 		},
@@ -99,6 +99,12 @@
 			"enabled": true
 		},
 		{
+			"key": "PROVIDER_SERVER_API_TRANSFERS",
+			"value": "{{PROVIDER}}/api/transfers",
+			"type": "default",
+			"enabled": true
+		},
+		{
 			"key": "PROVIDER_SERVER_PROTOCOL_DATA_TRANSFER",
 			"value": "{{PROVIDER}}/transfers",
 			"type": "default",
@@ -109,9 +115,21 @@
 			"value": "{{CONSUMER}}/consumer/transfers",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "transfer_consumerPid",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "transfer_providerPid",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-06-28T10:42:50.623Z",
-	"_postman_exported_using": "Postman/11.2.24"
+	"_postman_exported_at": "2024-07-22T11:00:47.529Z",
+	"_postman_exported_using": "Postman/11.4.0"
 }

--- a/True_connector_DSP.postman_collection.json
+++ b/True_connector_DSP.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "67215636-7b7f-4eba-b31e-0145ee0680e8",
+		"_postman_id": "32c09097-d276-4f47-b0cb-305438f1a05d",
 		"name": "TC_V2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "36278855",
-		"_collection_link": "https://true-connector.postman.co/workspace/My-Workspace~6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/36278855-67215636-7b7f-4eba-b31e-0145ee0680e8?action=share&source=collection_link&creator=36278855"
+		"_exporter_id": "36278855"
 	},
 	"item": [
 		{
@@ -811,6 +810,49 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Check if agreement is valid",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@mail.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "password",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "http://localhost:8090/api/agreement/urn:uuid:AGREEMENT_ID_OK/valid",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8090",
+									"path": [
+										"api",
+										"agreement",
+										"urn:uuid:AGREEMENT_ID_OK",
+										"valid"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},
@@ -1178,6 +1220,24 @@
 								},
 								{
 									"name": "Provider Request transfer - initiate",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Check if status code is 200\", function () {\r",
+													"    pm.response.to.have.status(200);\r",
+													"});\r",
+													"\r",
+													"let responseData = pm.response.json();\r",
+													"pm.environment.set(\"transfer_consumerPid\", responseData['dspace:consumerPid']);\r",
+													"pm.environment.set(\"transfer_providerPid\", responseData['dspace:providerPid']);"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
 									"request": {
 										"method": "POST",
 										"header": [
@@ -1188,7 +1248,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferRequestMessage\",\r\n \"dspace:consumerPid\": \"urn:uuid:CONSUMER_PID_UUID_TRANSFER\",\r\n \"dspace:agreementId\": \"urn:uuid:AGREEMENT_ID_NEW\",\r\n \"dct:format\": \"example:HTTP_PULL\",\r\n \"dspace:callbackAddress\": \"https://localhost:8080/consumer/transfers/urn:uuid:CONSUMER_PID_UUID_TRANSFER/start\"\r\n}",
+											"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferRequestMessage\",\r\n \"dspace:consumerPid\": \"urn:uuid:CONSUMER_PID_UUID_TRANSFER\",\r\n \"dspace:agreementId\": \"urn:uuid:AGREEMENT_ID_OK\",\r\n \"dct:format\": \"example:HTTP_PULL\",\r\n \"dspace:callbackAddress\": \"https://localhost:8080/consumer/transfers/urn:uuid:CONSUMER_PID_UUID_TRANSFER/start\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -1209,12 +1269,26 @@
 								},
 								{
 									"name": "Provider Start transfer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Check if status code is 200\", function () {\r",
+													"    pm.response.to.have.status(200);\r",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
 									"request": {
 										"method": "POST",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferStartMessage\",\r\n \"dspace:providerPid\": \"urn:uuid:PROVIDER_PID_UUID_TRANSFER\",\r\n \"dspace:consumerPid\": \"urn:uuid:CONSUMER_PID_UUID_TRANSFER\"\r\n}",
+											"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferStartMessage\",\r\n \"dspace:providerPid\": \"{{transfer_providerPid}}\",\r\n \"dspace:consumerPid\": \"{{transfer_consumerPid}}\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -1222,12 +1296,12 @@
 											}
 										},
 										"url": {
-											"raw": "{{PROVIDER_SERVER_PROTOCOL_DATA_TRANSFER}}/PROVIDER_PID_UUID_TRANSFER/start",
+											"raw": "{{PROVIDER_SERVER_PROTOCOL_DATA_TRANSFER}}/{{transfer_providerPid}}/start",
 											"host": [
 												"{{PROVIDER_SERVER_PROTOCOL_DATA_TRANSFER}}"
 											],
 											"path": [
-												"PROVIDER_PID_UUID_TRANSFER",
+												"{{transfer_providerPid}}",
 												"start"
 											]
 										}

--- a/True_connector_DSP.postman_collection.json
+++ b/True_connector_DSP.postman_collection.json
@@ -838,7 +838,7 @@
 									}
 								],
 								"url": {
-									"raw": "http://localhost:8090/api/agreement/urn:uuid:AGREEMENT_ID_OK/valid",
+									"raw": "http://localhost:8090/api/v1/agreement/urn:uuid:AGREEMENT_ID_OK/valid",
 									"protocol": "http",
 									"host": [
 										"localhost"
@@ -846,6 +846,7 @@
 									"port": "8090",
 									"path": [
 										"api",
+										"v1",
 										"agreement",
 										"urn:uuid:AGREEMENT_ID_OK",
 										"valid"
@@ -971,6 +972,34 @@
 									],
 									"path": [
 										"{$ID}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "DataTransfer",
+					"item": [
+						{
+							"name": "Get TransferProcess",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{PROVIDER_SERVER_API_TRANSFERS}}/abc45798-5553-4932-8baf-ab7fd66ql4d5",
+									"host": [
+										"{{PROVIDER_SERVER_API_TRANSFERS}}"
+									],
+									"path": [
+										"abc45798-5553-4932-8baf-ab7fd66ql4d5"
 									]
 								}
 							},

--- a/catalog/src/main/java/it/eng/catalog/rest/api/OfferAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/OfferAPIController.java
@@ -12,10 +12,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import it.eng.catalog.model.Offer;
 import it.eng.catalog.serializer.Serializer;
 import it.eng.catalog.service.CatalogService;
+import it.eng.tools.controller.ApiEndpoints;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/offer")
+@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, 
+	path = ApiEndpoints.CATALOG_OFFERS_V1)
 @Slf4j
 public class OfferAPIController {
 	

--- a/catalog/src/main/java/it/eng/catalog/rest/api/OfferAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/OfferAPIController.java
@@ -12,11 +12,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import it.eng.catalog.model.Offer;
 import it.eng.catalog.serializer.Serializer;
 import it.eng.catalog.service.CatalogService;
-import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/offer")
-@Log
+@Slf4j
 public class OfferAPIController {
 	
 	private final CatalogService catalogService;

--- a/ci/docker/test-cases/datatransfer-tests/datatransfer-tests.json
+++ b/ci/docker/test-cases/datatransfer-tests/datatransfer-tests.json
@@ -7,7 +7,7 @@
 	},
 	"item": [
 		{
-			"name": "Get TransfrProcess",
+			"name": "Get TransferProcess",
 			"event": [
 				{
 					"listen": "test",

--- a/ci/docker/test-cases/datatransfer-tests/datatransfer-tests.json
+++ b/ci/docker/test-cases/datatransfer-tests/datatransfer-tests.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "c32a4af8-b522-4adc-81ec-8e9871bfd5ac",
+		"_postman_id": "bfa875f5-4ba9-49e2-8a1c-60c512308054",
 		"name": "datatransfer-tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "36278855",
-		"_collection_link": "https://true-connector.postman.co/workspace/My-Workspace~6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/36278855-c32a4af8-b522-4adc-81ec-8e9871bfd5ac?action=share&source=collection_link&creator=36278855"
+		"_exporter_id": "36278855"
 	},
 	"item": [
 		{
@@ -69,23 +68,23 @@
 			"response": []
 		},
 		{
-			"name": "Initiate transfer process - already exists agreement",
+			"name": "Initiate transfer process - agreement not found",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"Status code is 201\", function () {\r",
-							"  pm.response.to.have.status(201);\r",
+							"pm.test(\"Status code is 400\", function () {\r",
+							"  pm.response.to.have.status(400);\r",
 							"});\r",
-							"pm.test(\"The response is TransferProcess\", () => {\r",
+							"pm.test(\"The response is TransferError\", () => {\r",
 							"    //parse the response JSON and test three properties\r",
 							"    const responseJson = pm.response.json();\r",
-							"    pm.expect(responseJson['@type']).to.eq('dspace:TransferProcess');\r",
+							"    pm.expect(responseJson['@type']).to.eq('dspace:TransferError');\r",
 							"    pm.expect(responseJson['@context']).to.eq('https://w3id.org/dspace/2024/1/context.json');\r",
 							"    pm.expect(responseJson['dspace:consumerPid']).is.not.empty;\r",
 							"    pm.expect(responseJson['dspace:providerPid']).is.not.empty;\r",
-							"    pm.expect(responseJson['dspace:state']).to.eq('dspace:REQUESTED');\r",
+							"    pm.expect(responseJson['dspace:code']).to.eq('Bad Request');\r",
 							"});"
 						],
 						"type": "text/javascript",
@@ -113,7 +112,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferRequestMessage\",\r\n \"dspace:consumerPid\": \"urn:uuid:CONSUMER_PID_UUID_TRANSFER\",\r\n \"dspace:agreementId\": \"urn:uuid:AGREEMENT_ID_NEW5\",\r\n \"dct:format\": \"example:HTTP_PULL\",\r\n \"dspace:callbackAddress\": \"https://localhost:8080/consumer/transfers/urn:uuid:CONSUMER_PID_UUID_TRANSFER/start\"\r\n}",
+					"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferRequestMessage\",\r\n \"dspace:consumerPid\": \"urn:uuid:CONSUMER_PID_UUID_TRANSFER\",\r\n \"dspace:agreementId\": \"urn:uuid:AGREEMENT_ID_NOT_FOUND\",\r\n \"dct:format\": \"example:HTTP_PULL\",\r\n \"dspace:callbackAddress\": \"https://localhost:8080/consumer/transfers/urn:uuid:CONSUMER_PID_UUID_TRANSFER/start\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -133,7 +132,7 @@
 			"response": []
 		},
 		{
-			"name": "Initiate transfer process - already exists agreement",
+			"name": "Initiate transfer process - data transfer already exists",
 			"event": [
 				{
 					"listen": "test",
@@ -191,6 +190,138 @@
 					],
 					"path": [
 						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Initiate transfer process - OK",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 201\", function () {\r",
+							"  pm.response.to.have.status(201);\r",
+							"});\r",
+							"pm.test(\"The response is TransferError\", () => {\r",
+							"    //parse the response JSON and test three properties\r",
+							"    const responseJson = pm.response.json();\r",
+							"    pm.expect(responseJson['@context']).to.eq('https://w3id.org/dspace/2024/1/context.json');\r",
+							"    pm.expect(responseJson['@type']).to.eq('dspace:TransferProcess');\r",
+							"    pm.expect(responseJson['dspace:consumerPid']).is.not.empty;\r",
+							"    pm.expect(responseJson['dspace:providerPid']).is.not.empty;\r",
+							"    pm.expect(responseJson['dspace:state']).to.eq('dspace:REQUESTED');\r",
+							"\r",
+							"    pm.environment.set(\"transfer_consumerPid\", responseJson['dspace:consumerPid']);\r",
+							"    pm.environment.set(\"transfer_providerPid\", responseJson['dspace:providerPid']);\r",
+							"});\r",
+							"\r",
+							"\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "password",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "connector@mail.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferRequestMessage\",\r\n \"dspace:consumerPid\": \"urn:uuid:{{$randomUUID}}\",\r\n \"dspace:agreementId\": \"urn:uuid:AGREEMENT_ID_OK\",\r\n \"dct:format\": \"example:HTTP_PULL\",\r\n \"dspace:callbackAddress\": \"https://localhost:8080/consumer/transfers/urn:uuid:CONSUMER_PID_UUID_TRANSFER/start\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{PROVIDER_PROTOCOL_ENDPOINT}}/request",
+					"host": [
+						"{{PROVIDER_PROTOCOL_ENDPOINT}}"
+					],
+					"path": [
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Start data transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "username",
+							"value": "connector@mail.com",
+							"type": "string"
+						},
+						{
+							"key": "password",
+							"value": "password",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n \"@context\":  \"https://w3id.org/dspace/2024/1/context.json\",\r\n \"@type\": \"dspace:TransferStartMessage\",\r\n \"dspace:providerPid\": \"{{transfer_providerPid}}\",\r\n \"dspace:consumerPid\": \"{{transfer_consumerPid}}\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{PROVIDER_PROTOCOL_ENDPOINT}}/{{transfer_providerPid}}/start",
+					"host": [
+						"{{PROVIDER_PROTOCOL_ENDPOINT}}"
+					],
+					"path": [
+						"{{transfer_providerPid}}",
+						"start"
 					]
 				}
 			},

--- a/connector/src/main/resources/initial_data.json
+++ b/connector/src/main/resources/initial_data.json
@@ -189,6 +189,28 @@
       "version": 0
     }
   ],
+  "agreements" : [
+  	{
+  		"_id": "urn:uuid:AGREEMENT_ID_OK",
+  		"_class": "it.eng.negotiation.model.Agreement",
+  		"target": "urn:uuid:3dd1add4-4d2d-569e-d634-8394a8836d23",
+  		"timestamp": "2023-01-01T01:00:00Z",
+  		"assigner": "urn:tsdshhs636378",
+  		"assignee": "urn:jashd766",
+  		"permission": [
+  			{
+  				"action": "USE",
+  				"constraint": [
+  					{
+  						"leftOperand": "COUNT",
+  						"operator": "EQ",
+  						"rightOperand": "5"
+  					}
+  				]
+  			}
+  		]
+  	}
+    ],
   "transfer_request_messages" : [
   	{
 	  "_id": "abc45797-4444-4932-8baf-ab7fd66ql4d5",
@@ -212,7 +234,49 @@
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
       "version": 0
-	}
+	},
+	{
+	  "_id": "abc45798-5555-4932-8baf-ab7fd66ql4d5",
+	  "_class": "it.eng.datatransfer.model.TransferProcess",
+      "providerPid": "urn:uuid:PROVIDER_PID_TRANSFER_REQ",
+      "consumerPid": "urn:uuid:CONSUMER_PID_TRANSFER_REQ",
+      "callbackAddress" : "http://localhost:8080/consumer/transfer/callback/",
+      "agreementId" : "urn:uuid:AGREEMENT_ID_REQ",
+	  "state" : "REQUESTED",
+	  "createdBy": "admin@mail.com",
+      "lastModifiedBy": "admin@mail.com",
+      "issued": "2024-04-23T16:26:00.000Z",
+      "modified": "2024-04-23T16:26:00.000Z",
+      "version": 0
+	},
+	{
+	  "_id": "abc45798-5551-4932-8baf-ab7fd66ql4d5",
+	  "_class": "it.eng.datatransfer.model.TransferProcess",
+      "providerPid": "urn:uuid:PROVIDER_PID_TRANSFER_SUSP",
+      "consumerPid": "urn:uuid:CONSUMER_PID_TRANSFER_SUSP",
+      "callbackAddress" : "http://localhost:8080/consumer/transfer/callback/",
+      "agreementId" : "urn:uuid:AGREEMENT_ID_SUSP",
+	  "state" : "SUSPENDED",
+	  "createdBy": "admin@mail.com",
+      "lastModifiedBy": "admin@mail.com",
+      "issued": "2024-04-23T16:26:00.000Z",
+      "modified": "2024-04-23T16:26:00.000Z",
+      "version": 0
+	},
+	{
+		  "_id": "abc45798-5553-4932-8baf-ab7fd66ql4d5",
+		  "_class": "it.eng.datatransfer.model.TransferProcess",
+	      "providerPid": "urn:uuid:PROVIDER_PID_TRANSFER_C_REQ",
+	      "consumerPid": "urn:uuid:CONSUMER_PID_TRANSFER_C_REQ",
+	      "callbackAddress" : "http://localhost:8080/consumer/transfer/callback/",
+	      "agreementId" : "urn:uuid:AGREEMENT_ID_C_REQ",
+		  "state" : "REQUESTED",
+		  "createdBy": "admin@mail.com",
+	      "lastModifiedBy": "admin@mail.com",
+	      "issued": "2024-04-23T16:26:00.000Z",
+	      "modified": "2024-04-23T16:26:00.000Z",
+	      "version": 0
+		}
   ],
    "transfer_start_messages" : [
     {

--- a/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
@@ -1,6 +1,8 @@
 package it.eng.connector.integration;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -8,22 +10,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.UUID;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
 import it.eng.connector.util.TestUtil;
+import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
 import it.eng.datatransfer.model.Serializer;
 import it.eng.datatransfer.model.TransferError;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferRequestMessage;
+import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.model.TransferState;
 import it.eng.tools.model.DSpaceConstants;
 
 public class DataTransferTest extends BaseIntegrationTest {
 
 	public static final String CONSUMER_PID = "urn:uuid:CONSUMER_PID";
+	public static final String PROVIDER_PID = "urn:uuid:PROVIDER_PID";
 	public static final String AGREEMENT_ID = "urn:uuid:" + UUID.randomUUID().toString();
 	public static final String CALLBACK_ADDRESS = "https://example.com/callback";
 	
@@ -32,7 +38,7 @@ public class DataTransferTest extends BaseIntegrationTest {
     public void initiateDataTransfer() throws Exception {
 		TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
 	    		.consumerPid(CONSUMER_PID)
-	    		.agreementId(AGREEMENT_ID)
+	    		.agreementId("urn:uuid:AGREEMENT_ID_OK")
 	    		.format("HTTP_PULL")
 	    		.callbackAddress(CALLBACK_ADDRESS)
 	    		.build();
@@ -75,4 +81,130 @@ public class DataTransferTest extends BaseIntegrationTest {
     			is(DSpaceConstants.DSPACE + TransferError.class.getSimpleName())))
     	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     }
+	
+	@Test
+	@DisplayName("Start transfer process - from requested")
+	@WithUserDetails(TestUtil.CONNECTOR_USER)
+	public void startTransferProcess_requested() throws Exception {
+		// from init_data.json
+		String providerPid = "urn:uuid:PROVIDER_PID_TRANSFER_REQ";
+		String consumerPid = "urn:uuid:CONSUMER_PID_TRANSFER_REQ";
+	      
+		TransferStartMessage transferStartMessage = TransferStartMessage.Builder.newInstance()
+				.consumerPid(consumerPid)
+				.providerPid(providerPid)
+				.build();
+		
+		String body = Serializer.serializeProtocol(transferStartMessage);
+		
+		final ResultActions result =
+    			mockMvc.perform(
+    					post("/transfers/" + providerPid +"/start")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	result.andExpect(status().isOk());
+    	
+    	ResultActions transferProcessStarted = mockMvc.perform(
+    			get("/transfers/" + providerPid).contentType(MediaType.APPLICATION_JSON));
+    	// check if status is STARTED
+    	transferProcessStarted.andExpect(status().isOk())
+    	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    	.andExpect(jsonPath("['" + DSpaceConstants.TYPE + "']", 
+    			is(DSpaceConstants.DSPACE + TransferProcess.class.getSimpleName())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.DSPACE_STATE + "']", is(TransferState.STARTED.toString())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
+    	
+    	// try again to start - error
+		mockMvc.perform(
+				post("/transfers/" + providerPid +"/start")
+				.content(body)
+				.contentType(MediaType.APPLICATION_JSON))
+		.andExpect(err -> assertTrue(err.getResolvedException() instanceof TransferProcessInvalidStateException))
+		.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    	.andExpect(jsonPath("['" + DSpaceConstants.TYPE + "']", 
+    			is(DSpaceConstants.DSPACE + TransferError.class.getSimpleName())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
+	}
+	
+	@Test
+	@DisplayName("Start transfer process - from suspended")
+	@WithUserDetails(TestUtil.CONNECTOR_USER)
+	public void startTransferProcess_suspended() throws Exception {
+		// from init_data.json
+		String providerPid = "urn:uuid:PROVIDER_PID_TRANSFER_SUSP";
+		String consumerPid = "urn:uuid:CONSUMER_PID_TRANSFER_SUSP";
+	      
+		TransferStartMessage transferStartMessage = TransferStartMessage.Builder.newInstance()
+				.consumerPid(consumerPid)
+				.providerPid(providerPid)
+				.build();
+		
+		String body = Serializer.serializeProtocol(transferStartMessage);
+		
+		final ResultActions result =
+    			mockMvc.perform(
+    					post("/transfers/" + providerPid +"/start")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	result.andExpect(status().isOk());
+    	
+    	ResultActions transferProcessStarted = mockMvc.perform(
+    			get("/transfers/" + providerPid).contentType(MediaType.APPLICATION_JSON));
+    	// check if status is STARTED
+    	transferProcessStarted.andExpect(status().isOk())
+    	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    	.andExpect(jsonPath("['" + DSpaceConstants.TYPE + "']", 
+    			is(DSpaceConstants.DSPACE + TransferProcess.class.getSimpleName())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.DSPACE_STATE + "']", is(TransferState.STARTED.toString())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
+	}
+	
+	// consumer callback start transfer
+	@Test
+	@DisplayName("Start transfer process - consumer callback")
+	@WithUserDetails(TestUtil.CONNECTOR_USER)
+	public void startTransferProcess_requested_consumer() throws Exception {
+		// from init_data.json
+		String providerPid = "urn:uuid:PROVIDER_PID_TRANSFER_C_REQ";
+		String consumerPid = "urn:uuid:CONSUMER_PID_TRANSFER_C_REQ";
+	      
+		TransferStartMessage transferStartMessage = TransferStartMessage.Builder.newInstance()
+				.consumerPid(consumerPid)
+				.providerPid(providerPid)
+				.build();
+		
+		String body = Serializer.serializeProtocol(transferStartMessage);
+		// sends using providerPid in URL - bad request
+		ResultActions error =
+				mockMvc.perform(
+						post("/consumer/transfers/" + providerPid +"/start")
+						.content(body)
+						.contentType(MediaType.APPLICATION_JSON));
+		error.andExpect(status().is4xxClientError())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+	    	.andExpect(jsonPath("['" + DSpaceConstants.TYPE + "']", 
+	    			is(DSpaceConstants.DSPACE + TransferError.class.getSimpleName())))
+	    	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
+		
+		final ResultActions result =
+    			mockMvc.perform(
+    					post("/consumer/transfers/" + consumerPid +"/start")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	result.andExpect(status().isOk());
+    	
+    	// TODO when API logic for provider sends start message, uncomment this code to check on PROVIDER side
+    	// if status is updated once consumer returns 200 OK
+    	/*
+    	ResultActions transferProcessStarted = mockMvc.perform(
+    			get("/transfers/" + providerPid).contentType(MediaType.APPLICATION_JSON));
+    	// check if status is STARTED
+    	transferProcessStarted.andExpect(status().isOk())
+    	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    	.andExpect(jsonPath("['" + DSpaceConstants.TYPE + "']", 
+    			is(DSpaceConstants.DSPACE + TransferProcess.class.getSimpleName())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.DSPACE_STATE + "']", is(TransferState.STARTED.toString())))
+    	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
+    	*/
+	}
 }

--- a/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
@@ -39,6 +39,7 @@ import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferRequestMessage;
 import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.model.TransferState;
+import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.model.DSpaceConstants;
 import it.eng.tools.response.GenericApiResponse;
 
@@ -241,14 +242,14 @@ public class DataTransferTest extends BaseIntegrationTest {
                 .build();
 		
 		mockMvc.perform(
-    			get("/api/transfers").contentType(MediaType.APPLICATION_JSON))
+    			get(ApiEndpoints.TRANSFER_DATATRANSFER_V1).contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 	    	.andExpect(content().contentType(MediaType.APPLICATION_JSON));
 		
 		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ArrayList.class);
 
 		MvcResult resultStarted =mockMvc.perform(
-    			get("/api/transfers?state=STARTED").contentType(MediaType.APPLICATION_JSON))
+    			get(ApiEndpoints.TRANSFER_DATATRANSFER_V1 + "?state=STARTED").contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 			.andReturn();
@@ -261,7 +262,7 @@ public class DataTransferTest extends BaseIntegrationTest {
 		
 		String TRANSFER_PROCESS_ID = "abc45798-4444-4932-8baf-ab7fd66ql4d5";
 		MvcResult result = mockMvc.perform(
-    			get("/api/transfers/" + TRANSFER_PROCESS_ID).contentType(MediaType.APPLICATION_JSON))
+    			get(ApiEndpoints.TRANSFER_DATATRANSFER_V1 + "/" +TRANSFER_PROCESS_ID).contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andReturn();
 		json = result.getResponse().getContentAsString();

--- a/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/DataTransferTest.java
@@ -1,6 +1,8 @@
 package it.eng.connector.integration;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,14 +10,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import it.eng.catalog.serializer.InstantDeserializer;
+import it.eng.catalog.serializer.InstantSerializer;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
 import it.eng.datatransfer.model.Serializer;
@@ -25,6 +40,7 @@ import it.eng.datatransfer.model.TransferRequestMessage;
 import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.model.TransferState;
 import it.eng.tools.model.DSpaceConstants;
+import it.eng.tools.response.GenericApiResponse;
 
 public class DataTransferTest extends BaseIntegrationTest {
 
@@ -207,4 +223,58 @@ public class DataTransferTest extends BaseIntegrationTest {
     	.andExpect(jsonPath("['" + DSpaceConstants.CONTEXT + "']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     	*/
 	}
+	
+	
+	/* API Endpoints tests  */
+	@Test
+	@DisplayName("TransferProcess API - get")
+	@WithUserDetails(TestUtil.API_USER)
+	public void getTransferProcess() throws Exception {
+		SimpleModule instantConverterModule = new SimpleModule();
+		instantConverterModule.addSerializer(Instant.class, new InstantSerializer());
+		instantConverterModule.addDeserializer(Instant.class, new InstantDeserializer());
+		JsonMapper jsonMapper = JsonMapper.builder()
+        		.addModule(new JavaTimeModule())
+        		.configure(MapperFeature.USE_ANNOTATIONS, false)
+        		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        		.addModule(instantConverterModule)
+                .build();
+		
+		mockMvc.perform(
+    			get("/api/transfers").contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+	    	.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+		
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ArrayList.class);
+
+		MvcResult resultStarted =mockMvc.perform(
+    			get("/api/transfers?state=STARTED").contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andReturn();
+		String json = resultStarted.getResponse().getContentAsString();
+		GenericApiResponse<List<TransferProcess>> genericApiResponse = jsonMapper.readValue(json, javaType);
+		// so far, must do like this because List<LinkedHashMap> was not able to get it to be List<TransferProcess>
+		TransferProcess transferProcess = jsonMapper.convertValue(genericApiResponse.getData().get(0), TransferProcess.class);
+		assertNotNull(transferProcess);
+		assertEquals(TransferState.STARTED, transferProcess.getState());
+		
+		String TRANSFER_PROCESS_ID = "abc45798-4444-4932-8baf-ab7fd66ql4d5";
+		MvcResult result = mockMvc.perform(
+    			get("/api/transfers/" + TRANSFER_PROCESS_ID).contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andReturn();
+		json = result.getResponse().getContentAsString();
+		genericApiResponse = jsonMapper.readValue(json, javaType);
+
+		assertNotNull(genericApiResponse);
+		assertTrue(genericApiResponse.isSuccess());
+		assertEquals(1, genericApiResponse.getData().size());
+		// so far, must do like this because List<LinkedHashMap> was not able to get it to be List<TransferProcess>
+		transferProcess = jsonMapper.convertValue(genericApiResponse.getData().get(0), TransferProcess.class);
+		assertNotNull(transferProcess);
+		assertEquals(TRANSFER_PROCESS_ID, transferProcess.getId());
+	}
 }
+
+

--- a/connector/src/test/java/it/eng/connector/integration/NegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/NegotiationIntegrationTest.java
@@ -28,7 +28,7 @@ import it.eng.negotiation.model.ContractAgreementVerificationMessage;
 import it.eng.negotiation.model.ContractNegotiationEventMessage;
 import it.eng.negotiation.model.ContractNegotiationEventType;
 import it.eng.negotiation.model.ContractRequestMessage;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.model.Offer;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.tools.model.DSpaceConstants;
@@ -52,7 +52,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isBadRequest())
     	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(ModelUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
+    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     }
 
@@ -64,14 +64,14 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     	//needs to match offer in initial.data
     	Offer offer = Offer.Builder.newInstance()
     			.id("fdc45798-a123-4955-8baf-ab7fd66ac4d5")
-    			.target(ModelUtil.TARGET)
-    			.assigner(ModelUtil.ASSIGNER)
-    			.permission(Arrays.asList(ModelUtil.PERMISSION_COUNT_5))
+    			.target(MockObjectUtil.TARGET)
+    			.assigner(MockObjectUtil.ASSIGNER)
+    			.permission(Arrays.asList(MockObjectUtil.PERMISSION_COUNT_5))
     			.build();
     	
     	ContractRequestMessage contractRequestMessage = ContractRequestMessage.Builder.newInstance()
-    			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-    			.consumerPid(ModelUtil.CONSUMER_PID)
+    			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+    			.consumerPid(MockObjectUtil.CONSUMER_PID)
     			.offer(offer)
     			.build();
     	
@@ -82,7 +82,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isCreated())
     	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
+    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     	
     	JsonNode jsonNode = mapper.readTree(result.andReturn().getResponse().getContentAsString());
@@ -94,10 +94,10 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void negotiationExistsTests() throws Exception {
     	ContractRequestMessage crm = ContractRequestMessage.Builder.newInstance()
-			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
+			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
 			.consumerPid(TestUtil.CONSUMER_PID)
 			.providerPid(TestUtil.PROVIDER_PID)
-			.offer(ModelUtil.OFFER)
+			.offer(MockObjectUtil.OFFER)
 			.build();
 
     	final ResultActions result =
@@ -107,7 +107,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isBadRequest())
     	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(ModelUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
+    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     }
     
@@ -122,7 +122,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isOk())
     	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
+    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     }
     
@@ -137,7 +137,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isNotFound())
     	.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(ModelUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
+    	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     }
     
@@ -147,15 +147,15 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     public void handleAgreementTest() throws Exception {
 		
 		ContractAgreementMessage agreementMessage = ContractAgreementMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
 				.providerPid(providerPid)
-				.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-				.agreement(ModelUtil.AGREEMENT)
+				.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+				.agreement(MockObjectUtil.AGREEMENT)
 				.build();
     	
     	final ResultActions result =
     			mockMvc.perform(
-    					post("/consumer/negotiations/" + ModelUtil.CONSUMER_PID + "/agreement")
+    					post("/consumer/negotiations/" + MockObjectUtil.CONSUMER_PID + "/agreement")
     					.content(Serializer.serializeProtocol(agreementMessage))
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isOk());
@@ -167,13 +167,13 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     public void handleVerifyAgreementTest() throws Exception {
 		
 		ContractAgreementVerificationMessage verificationMessage = ContractAgreementVerificationMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
 				.providerPid(providerPid)
 				.build();
     	
     	final ResultActions result =
     			mockMvc.perform(
-    					post("/negotiations/" + ModelUtil.PROVIDER_PID + "/agreement/verification")
+    					post("/negotiations/" + MockObjectUtil.PROVIDER_PID + "/agreement/verification")
     					.content(Serializer.serializeProtocol(verificationMessage))
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isOk());
@@ -185,14 +185,14 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     public void handleFinalizeEventTest() throws Exception {
 		
 		ContractNegotiationEventMessage  contractNegotiationEventMessage = ContractNegotiationEventMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
 				.providerPid(providerPid)
 				.eventType(ContractNegotiationEventType.FINALIZED)
 				.build();
     	
     	final ResultActions result =
     			mockMvc.perform(
-    					post("/consumer/negotiations/" + ModelUtil.CONSUMER_PID + "/events")
+    					post("/consumer/negotiations/" + MockObjectUtil.CONSUMER_PID + "/events")
     					.content(Serializer.serializeProtocol(contractNegotiationEventMessage))
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isOk());

--- a/connector/src/test/java/it/eng/connector/util/TestUtil.java
+++ b/connector/src/test/java/it/eng/connector/util/TestUtil.java
@@ -3,6 +3,7 @@ package it.eng.connector.util;
 public class TestUtil {
 	//all values in this class are from the initial_data.json
 	public static final String CONNECTOR_USER = "connector@mail.com";
+	public static final String API_USER = "admin@mail.com";
 	public static final String DATASET_ID = "fdc45798-a222-4955-8baf-ab7fd66ac4d5";
 	public static final String PROVIDER_PID = "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab";
 	public static final String CONSUMER_PID = "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833";

--- a/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferExceptionAdvice.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferExceptionAdvice.java
@@ -54,4 +54,18 @@ public class DataTransferExceptionAdvice extends ResponseEntityExceptionHandler 
 		return handleExceptionInternal(ex, Serializer.serializeProtocolJsonNode(errorMessage), new HttpHeaders(),
 				HttpStatus.BAD_REQUEST, request);
 	}
+	
+	
+	@ExceptionHandler(value = { TransferProcessInvalidStateException.class, AgreementNotFoundException.class })
+	protected ResponseEntity<Object> handleTransferProcessInvalidStateException(TransferProcessInvalidStateException ex,
+			WebRequest request) {
+		TransferError errorMessage = TransferError.Builder.newInstance()
+				.consumerPid(ex.getConsumerPid())
+				.providerPid(ex.getProviderPid())
+				.code(HttpStatus.BAD_REQUEST.getReasonPhrase())
+				.reason(Collections.singletonList(ex.getLocalizedMessage()))
+				.build();
+		return handleExceptionInternal(ex, Serializer.serializeProtocolJsonNode(errorMessage), new HttpHeaders(),
+				HttpStatus.BAD_REQUEST, request);
+	}
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferExceptionAdvice.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferExceptionAdvice.java
@@ -13,9 +13,10 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import it.eng.datatransfer.model.Serializer;
 import it.eng.datatransfer.model.TransferError;
 import it.eng.datatransfer.rest.protocol.ProviderDataTransferController;
+import it.eng.datatransfer.service.DataTransferService;
 import jakarta.validation.ValidationException;
 
-@RestControllerAdvice(basePackageClasses = { ProviderDataTransferController.class })
+@RestControllerAdvice(basePackageClasses = { ProviderDataTransferController.class, DataTransferService.class })
 public class DataTransferExceptionAdvice extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(value = { ValidationException.class })
@@ -55,9 +56,21 @@ public class DataTransferExceptionAdvice extends ResponseEntityExceptionHandler 
 				HttpStatus.BAD_REQUEST, request);
 	}
 	
-	
-	@ExceptionHandler(value = { TransferProcessInvalidStateException.class, AgreementNotFoundException.class })
+	@ExceptionHandler(value = { TransferProcessInvalidStateException.class })
 	protected ResponseEntity<Object> handleTransferProcessInvalidStateException(TransferProcessInvalidStateException ex,
+			WebRequest request) {
+		TransferError errorMessage = TransferError.Builder.newInstance()
+				.consumerPid(ex.getConsumerPid())
+				.providerPid(ex.getProviderPid())
+				.code(HttpStatus.BAD_REQUEST.getReasonPhrase())
+				.reason(Collections.singletonList(ex.getLocalizedMessage()))
+				.build();
+		return handleExceptionInternal(ex, Serializer.serializeProtocolJsonNode(errorMessage), new HttpHeaders(),
+				HttpStatus.BAD_REQUEST, request);
+	}
+	
+	@ExceptionHandler(value = { AgreementNotFoundException.class })
+	protected ResponseEntity<Object> handleAgreementNotFoundException(AgreementNotFoundException ex,
 			WebRequest request) {
 		TransferError errorMessage = TransferError.Builder.newInstance()
 				.consumerPid(ex.getConsumerPid())

--- a/data-transfer/src/main/java/it/eng/datatransfer/exceptions/TransferProcessInvalidStateException.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/exceptions/TransferProcessInvalidStateException.java
@@ -1,22 +1,22 @@
 package it.eng.datatransfer.exceptions;
 
-public class AgreementNotFoundException extends RuntimeException {
+public class TransferProcessInvalidStateException extends RuntimeException {
 
-	private static final long serialVersionUID = -7682192238680210533L;
+	private static final long serialVersionUID = -8254537435588358784L;
 
 	private String consumerPid;
 	private String providerPid;
 	
-	public AgreementNotFoundException() {
+	public TransferProcessInvalidStateException() {
 		super();
 	}
-	
-	public AgreementNotFoundException(String message, String consumerPid, String providerPid) {
+
+	public TransferProcessInvalidStateException(String message, String consumerPid, String providerPid) {
 		super(message);
 		this.consumerPid = consumerPid;
 		this.providerPid = providerPid;
 	}
-	
+
 	public String getConsumerPid() {
 		return consumerPid;
 	}
@@ -24,4 +24,5 @@ public class AgreementNotFoundException extends RuntimeException {
 	public String getProviderPid() {
 		return providerPid;
 	}
+
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/AbstractTransferMessage.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/AbstractTransferMessage.java
@@ -1,5 +1,6 @@
 package it.eng.datatransfer.model;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,8 +9,10 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import it.eng.tools.model.DSpaceConstants;
 import jakarta.validation.constraints.NotNull;
 
-public abstract class AbstractTransferMessage {
+public abstract class AbstractTransferMessage implements Serializable {
 	
+	private static final long serialVersionUID = -3150306747585657302L;
+
 	@JsonProperty(value = DSpaceConstants.CONTEXT, access = Access.READ_ONLY)
 	private String context = DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE;
 

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferProcess.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferProcess.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -42,7 +43,9 @@ import lombok.NoArgsConstructor;
 @Document(collection = "transfer_process")
 public class TransferProcess extends AbstractTransferMessage {
 
-    @JsonIgnore
+	private static final long serialVersionUID = -6329135422869881158L;
+
+	@JsonIgnore
     @JsonProperty(DSpaceConstants.ID)
     @Id
     private String id;

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferRequestMessage.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferRequestMessage.java
@@ -56,7 +56,9 @@ import lombok.NoArgsConstructor;
 @Document(collection = "transfer_request_messages")
 public class TransferRequestMessage extends AbstractTransferMessage {
 
-    @JsonIgnore
+	private static final long serialVersionUID = 8814457068103190252L;
+
+	@JsonIgnore
     @JsonProperty(DSpaceConstants.ID)
     @Id
     private String id;

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferStartMessage.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferStartMessage.java
@@ -54,7 +54,9 @@ import lombok.NoArgsConstructor;
 @Document(collection = "transfer_start_messages")
 public class TransferStartMessage extends AbstractTransferMessage {
 
-    @JsonIgnore
+	private static final long serialVersionUID = 7918949682633114473L;
+
+	@JsonIgnore
     @JsonProperty(DSpaceConstants.ID)
     @Id
     private String id;

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferSuspensionMessage.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferSuspensionMessage.java
@@ -38,6 +38,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TransferSuspensionMessage extends AbstractTransferMessage {
 
+	private static final long serialVersionUID = 6065245999402269996L;
+
 	@NotNull
 	@JsonProperty(DSpaceConstants.DSPACE_PROVIDER_PID)
 	private String providerPid;

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferTerminationMessage.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferTerminationMessage.java
@@ -38,6 +38,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TransferTerminationMessage extends AbstractTransferMessage {
 
+	private static final long serialVersionUID = 7638790814588039703L;
+
 	@NotNull
 	@JsonProperty(DSpaceConstants.DSPACE_PROVIDER_PID)
 	private String providerPid;

--- a/data-transfer/src/main/java/it/eng/datatransfer/properties/DataTransferProperties.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/properties/DataTransferProperties.java
@@ -1,0 +1,15 @@
+package it.eng.datatransfer.properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataTransferProperties {
+
+	@Value("${server.port}")
+	private String serverPort;
+	
+	public String serverPort() {
+		return serverPort;
+	}
+}

--- a/data-transfer/src/main/java/it/eng/datatransfer/repository/TransferProcessRepository.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/repository/TransferProcessRepository.java
@@ -1,5 +1,6 @@
 package it.eng.datatransfer.repository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -15,4 +16,6 @@ public interface TransferProcessRepository extends MongoRepository<TransferProce
     Optional<TransferProcess> findByProviderPid(String providerPid);
     
     Optional<TransferProcess> findByAgreementId(String agreementId);
+    
+    Collection<TransferProcess> findByState(String state);
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
@@ -14,11 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import it.eng.datatransfer.service.DataTransferAPIService;
+import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.response.GenericApiResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/transfers")
+@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, 
+	path = ApiEndpoints.TRANSFER_DATATRANSFER_V1)
 @Slf4j
 public class DataTransferAPIController {
 

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
@@ -1,0 +1,46 @@
+package it.eng.datatransfer.rest.api;
+
+import java.util.Collection;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import it.eng.datatransfer.service.DataTransferAPIService;
+import it.eng.tools.response.GenericApiResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/transfers")
+@Slf4j
+public class DataTransferAPIController {
+
+	private DataTransferAPIService apiService;
+
+	public DataTransferAPIController(DataTransferAPIService apiService) {
+		this.apiService = apiService;
+	}
+
+	/**
+	 * Find by id if present, next by state and get all
+	 * @param transferProcessId
+	 * @param state
+	 * @return
+	 */
+	@GetMapping(path = { "", "/{transferProcessId}" })
+	public ResponseEntity<GenericApiResponse<Collection<JsonNode>>> getTransfersProcess(
+			@PathVariable(required = false) String transferProcessId, @RequestParam(required = false) String state) {
+		log.info("Ferching transfer process id - {}, state {}", transferProcessId, state);
+		Collection<JsonNode> contractNegotiations = apiService.findDataTransfers(transferProcessId, state);
+		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+				.body(GenericApiResponse.success(contractNegotiations, "Fething transfer process", HttpStatus.OK.value()));
+	}
+
+}

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackController.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.eng.datatransfer.model.Serializer;
 import it.eng.datatransfer.model.TransferCompletionMessage;
+import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.model.TransferSuspensionMessage;
 import it.eng.datatransfer.model.TransferTerminationMessage;
@@ -38,7 +39,9 @@ public class ConsumerDataTransferCallbackController {
 			@RequestBody JsonNode transferStartMessageJsonNode) {
 		TransferStartMessage transferStartMessage = Serializer.deserializeProtocol(transferStartMessageJsonNode, TransferStartMessage.class);
 		log.info("Starting data transfer for consumerPid {} and providerPid {}", consumerPid, transferStartMessage.getProviderPid());
-		return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(notImplemented());
+		TransferProcess transferProcessStarted = dataTransferService.startDataTransfer(transferStartMessage, consumerPid, null);
+		log.info("TransferProcess {} state changed to {}", transferProcessStarted.getId(), transferProcessStarted.getState());
+		return ResponseEntity.ok(null);
 	}
 
 	@PostMapping(path = "/{consumerPid}/completion")

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferController.java
@@ -57,7 +57,9 @@ public class ProviderDataTransferController {
 			@RequestBody JsonNode transferStartMessageJsonNode) {
 		TransferStartMessage transferStartMessage = Serializer.deserializeProtocol(transferStartMessageJsonNode, TransferStartMessage.class);
 		log.info("Starting data transfer for providerPid {} and consumerPid {}", providerPid, transferStartMessage.getConsumerPid());
-		return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(notImplemented());
+		TransferProcess transferProcessStarted = dataTransferService.startDataTransfer(transferStartMessage, null, providerPid);
+		log.info("TransferProcess {} state changed to {}", transferProcessStarted.getId(), transferProcessStarted.getState());
+		return ResponseEntity.ok(null);
 	}
 
 	@PostMapping(path = "/{providerPid}/completion")

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/AgreementService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/AgreementService.java
@@ -34,7 +34,7 @@ public class AgreementService {
 		String agreementId = transferProcessRepository.findByConsumerPidAndProviderPid(consumerPid, providerPid)
 				.map(trm -> trm.getAgreementId())
 				.orElseThrow(() -> new AgreementNotFoundException("Agreement for cosnumerPid '"+ consumerPid +
-						"' and providerPid '" + providerPid + "' not found"));
+						"' and providerPid '" + providerPid + "' not found", consumerPid, providerPid));
 		
 		// TODO once usage policy enforcement is done, call should be made here
 		if(!agreementStorage.containsKey(agreementId)) {

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferAPIService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferAPIService.java
@@ -1,0 +1,41 @@
+package it.eng.datatransfer.service;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import it.eng.datatransfer.model.Serializer;
+import it.eng.datatransfer.repository.TransferProcessRepository;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class DataTransferAPIService {
+
+	private TransferProcessRepository repository;
+	
+	public DataTransferAPIService(TransferProcessRepository repository) {
+		super();
+		this.repository = repository;
+	}
+
+	public Collection<JsonNode> findDataTransfers(String transferProcessId, String state) {
+		if(StringUtils.isNotBlank(transferProcessId)) {
+			return repository.findById(transferProcessId)
+					.stream()
+					.map(dt -> Serializer.serializePlainJsonNode(dt))
+					.collect(Collectors.toList());
+		} else if(StringUtils.isNoneBlank(state)) {
+			return repository.findByState(state)
+					.stream()
+					.map(dt -> Serializer.serializePlainJsonNode(dt))
+					.collect(Collectors.toList());
+		}
+		return repository.findAll().stream().map(dt -> Serializer.serializePlainJsonNode(dt))
+				.collect(Collectors.toList());
+		}
+}

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferService.java
@@ -1,25 +1,42 @@
 package it.eng.datatransfer.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 
+import it.eng.datatransfer.exceptions.AgreementNotFoundException;
 import it.eng.datatransfer.exceptions.TransferProcessExistsException;
+import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
 import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
 import it.eng.datatransfer.model.Serializer;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferRequestMessage;
+import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.properties.DataTransferProperties;
 import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.response.GenericApiResponse;
+import it.eng.tools.util.CredentialUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
 public class DataTransferService {
 
-	private TransferProcessRepository transferProcessRepository;
+	private final TransferProcessRepository transferProcessRepository;
 	
-	public DataTransferService(TransferProcessRepository transferProcessRepository) {
+	private final OkHttpRestClient okHttpRestClient;
+	private final CredentialUtils credentialUtils;
+	private final DataTransferProperties properties;
+	
+	public DataTransferService(TransferProcessRepository transferProcessRepository, OkHttpRestClient okHttpRestClient,
+			CredentialUtils credentialUtils, DataTransferProperties properties) {
 		super();
 		this.transferProcessRepository = transferProcessRepository;
+		this.okHttpRestClient = okHttpRestClient;
+		this.credentialUtils = credentialUtils;
+		this.properties = properties;
 	}
 
 	/**
@@ -46,6 +63,16 @@ public class DataTransferService {
 				throw new TransferProcessExistsException("For agreementId " + tp.getAgreementId() + 
 					" there is already transfer process created.", tp.getConsumerPid());
 				});
+		// check if agreement exists
+//		/{agreementId}/valid
+		GenericApiResponse<String> response = okHttpRestClient.sendRequestProtocol("http://localhost:" + 
+				properties.serverPort() + "/api/agreement/" + transferRequestMessage.getAgreementId() + "/valid", 
+				null, 
+				credentialUtils.getAPICredentials());
+		if (!response.isSuccess()) {
+			throw new AgreementNotFoundException("Agreement with id " + transferRequestMessage.getAgreementId()+ " not found",
+					transferRequestMessage.getConsumerPid(), "urn:uuid:" + UUID.randomUUID());
+		}
 		
 		// TODO save also transferRequestMessage once we implement provider push data - will need information where to push
 		
@@ -61,5 +88,39 @@ public class DataTransferService {
 			log.debug("message: " + Serializer.serializePlain(transferProcessRequested));
 		}
 		return transferProcessRequested;
+	}
+
+	/**
+	 * Transfer from REQUESTED or SUSPENDED to STARTED state
+	 * @param transferStartMessage TransferStartMessage
+	 * @param consumerPid null in case of provider side 
+	 * @param providerPid null in case of consumer callback controller
+	 * @return TransferProcess with STARTED state
+	 */
+	public TransferProcess startDataTransfer(TransferStartMessage transferStartMessage, String consumerPid, String providerPid) {
+		String consumerPidFinal = consumerPid == null ? transferStartMessage.getConsumerPid() : consumerPid;
+		String providerPidFinal = providerPid == null ? transferStartMessage.getProviderPid() : providerPid;
+	
+		TransferProcess transferProcessRequested = findTransferProcess(consumerPidFinal, providerPidFinal);
+		stateTransitionCheck(transferProcessRequested, TransferState.STARTED);
+
+		// TODO publish event here to inform other parts of connector, if required
+		TransferProcess transferProcessStarted = transferProcessRequested.copyWithNewTransferState(TransferState.STARTED);
+		transferProcessRepository.save(transferProcessStarted);
+		return transferProcessStarted;
+	}
+
+	private TransferProcess findTransferProcess(String consumerPid, String providerPidFinal) {
+		TransferProcess transferProcessRequested = transferProcessRepository.findByConsumerPidAndProviderPid(consumerPid, providerPidFinal)
+			.orElseThrow(() -> new TransferProcessNotFoundException("Transfer process for consumerPid " + consumerPid
+			 + " and providerPid " + consumerPid + " not found"));
+		return transferProcessRequested;
+	}
+	
+	private void stateTransitionCheck(TransferProcess transferProcess, TransferState stateToTransit) {
+		if(!transferProcess.getState().canTransitTo(stateToTransit)) {
+			throw new TransferProcessInvalidStateException("TransferProcess is in invalid state " + transferProcess.getState(),
+					transferProcess.getConsumerPid(), transferProcess.getProviderPid());
+		}
 	}
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/DataTransferService.java
@@ -16,6 +16,7 @@ import it.eng.datatransfer.model.TransferState;
 import it.eng.datatransfer.properties.DataTransferProperties;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.util.CredentialUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -66,7 +67,7 @@ public class DataTransferService {
 		// check if agreement exists
 //		/{agreementId}/valid
 		GenericApiResponse<String> response = okHttpRestClient.sendRequestProtocol("http://localhost:" + 
-				properties.serverPort() + "/api/agreement/" + transferRequestMessage.getAgreementId() + "/valid", 
+				properties.serverPort() + ApiEndpoints.NEGOTIATION_AGREEMENTS_V1 + "/"+  transferRequestMessage.getAgreementId() + "/valid", 
 				null, 
 				credentialUtils.getAPICredentials());
 		if (!response.isSuccess()) {

--- a/data-transfer/src/test/java/it/eng/datatransfer/model/ModelUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/model/ModelUtil.java
@@ -22,4 +22,18 @@ public class ModelUtil {
 			.providerPid(PROVIDER_PID)
 			.state(TransferState.REQUESTED)
 			.build();
+	
+	public static TransferProcess TRANSFER_PROCESS_STARTED = TransferProcess.Builder.newInstance()
+			.agreementId(AGREEMENT_ID)
+			.consumerPid(CONSUMER_PID)
+			.providerPid(PROVIDER_PID)
+			.state(TransferState.STARTED)
+			.build();
+	
+	public static TransferProcess TRANSFER_PROCESS_SUSPENDED = TransferProcess.Builder.newInstance()
+			.agreementId(AGREEMENT_ID)
+			.consumerPid(CONSUMER_PID)
+			.providerPid(PROVIDER_PID)
+			.state(TransferState.SUSPENDED)
+			.build();
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
@@ -73,6 +73,33 @@ public class TransferProcessTest {
 		assertEquals(ModelUtil.AGREEMENT_ID, tpCopied.getAgreementId());
 		assertEquals(TransferState.STARTED, tpCopied.getState());
 	}
+	
+	@Test
+	@DisplayName("From Requested")
+	public void fromRequested() {
+		assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.STARTED));
+		assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.TERMINATED));
+		assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.SUSPENDED));
+		assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.COMPLETED));
+	}
+	
+	@Test
+	@DisplayName("From Started")
+	public void fromStarted() {
+		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.SUSPENDED));
+		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.TERMINATED));
+		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.COMPLETED));
+		assertFalse(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.REQUESTED));
+	}
+	
+	@Test
+	@DisplayName("From Suspended")
+	public void fromSuspended() {
+		assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.STARTED));
+		assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.TERMINATED));
+		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.REQUESTED));
+		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.COMPLETED));
+	}
 
 	private void validateJavaObject(TransferProcess javaObj) {
 		assertNotNull(javaObj);

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
@@ -1,0 +1,69 @@
+package it.eng.datatransfer.rest.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import it.eng.datatransfer.model.Serializer;
+import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.service.DataTransferAPIService;
+import it.eng.datatransfer.util.MockObjectUtil;
+import it.eng.tools.response.GenericApiResponse;
+
+@ExtendWith(MockitoExtension.class)
+class DataTransferAPIControllerTest {
+
+	@Mock
+	private DataTransferAPIService apiService;
+	
+	@InjectMocks
+	private DataTransferAPIController controller;
+	
+	@Test
+	@DisplayName("Find transfer process by id, state and all")
+	public void getTransfersProcess() {
+		when(apiService.findDataTransfers(anyString(), anyString()))
+			.thenReturn(Arrays.asList(Serializer.serializePlainJsonNode(MockObjectUtil.TRANSFER_PROCESS_REQUESTED)));
+		ResponseEntity<GenericApiResponse<Collection<JsonNode>>> response = controller.getTransfersProcess("test", TransferState.REQUESTED.name());
+		assertNotNull(response);
+		assertTrue(response.getBody().isSuccess());
+		assertFalse(response.getBody().getData().isEmpty());
+		
+		when(apiService.findDataTransfers(anyString(), isNull()))
+			.thenReturn(new ArrayList<>());
+		response = controller.getTransfersProcess("test_not_found", null);
+		assertNotNull(response);
+		assertTrue(response.getBody().isSuccess());
+		assertTrue(response.getBody().getData().isEmpty());
+		
+		when(apiService.findDataTransfers(isNull(), anyString()))
+			.thenReturn(Arrays.asList(Serializer.serializePlainJsonNode(MockObjectUtil.TRANSFER_PROCESS_STARTED)));
+		response = controller.getTransfersProcess(null, TransferState.STARTED.name());
+		assertNotNull(response);
+		assertTrue(response.getBody().isSuccess());
+		assertFalse(response.getBody().getData().isEmpty());
+	
+		when(apiService.findDataTransfers(isNull(), isNull()))
+			.thenReturn(Arrays.asList(Serializer.serializePlainJsonNode(MockObjectUtil.TRANSFER_PROCESS_REQUESTED),
+					Serializer.serializePlainJsonNode(MockObjectUtil.TRANSFER_PROCESS_STARTED)));
+		response = controller.getTransfersProcess(null, null);
+
+	}
+	
+
+}

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackControllerTest.java
@@ -2,6 +2,9 @@ package it.eng.datatransfer.rest.protocol;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
 import it.eng.datatransfer.model.Serializer;
+import it.eng.datatransfer.model.TransferStartMessage;
 import it.eng.datatransfer.service.DataTransferService;
 import it.eng.datatransfer.util.MockObjectUtil;
 import jakarta.validation.ValidationException;
@@ -28,7 +33,9 @@ public class ConsumerDataTransferCallbackControllerTest {
 	@Test
 	@DisplayName("Start TransferProcess")
 	public void startDataTransfer() {
-		assertEquals(HttpStatus.NOT_IMPLEMENTED, 
+		when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
+			.thenReturn(MockObjectUtil.TRANSFER_PROCESS_STARTED);
+		assertEquals(HttpStatus.OK, 
 				controller.startDataTransfer(MockObjectUtil.CONSUMER_PID,
 						Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE)).getStatusCode());
 	}
@@ -37,8 +44,18 @@ public class ConsumerDataTransferCallbackControllerTest {
 	@DisplayName("Start TransferProcess - invalid request body")
 	public void startDataTransfer_invalidBody() {
 		assertThrows(ValidationException.class, () ->
-			controller.startDataTransfer(MockObjectUtil.CONSUMER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_COMPLETION_MESSAGE))
-		);
+			controller.startDataTransfer(MockObjectUtil.CONSUMER_PID, 
+					Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
+	}
+	
+	@Test
+	@DisplayName("Start TransferProcess - error service")
+	public void startDataTransfer_errorService() {
+		when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
+			.thenThrow(new TransferProcessNotFoundException("TransferProcess not found test"));
+		assertThrows(TransferProcessNotFoundException.class, () ->
+			controller.startDataTransfer(MockObjectUtil.CONSUMER_PID, 
+					Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE)));
 	}
 	
 	@Test
@@ -53,8 +70,8 @@ public class ConsumerDataTransferCallbackControllerTest {
 	@DisplayName("Complete TransferProcess - invalid request body")
 	public void completeDataTransfer_invalidBody() {
 		assertThrows(ValidationException.class, () ->
-			controller.completeDataTransfer(MockObjectUtil.CONSUMER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE))
-		);
+			controller.completeDataTransfer(MockObjectUtil.CONSUMER_PID, 
+					Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE)));
 	}
 	
 	@Test
@@ -69,8 +86,8 @@ public class ConsumerDataTransferCallbackControllerTest {
 	@DisplayName("Terminate TransferProcess - invalid request body")
 	public void terminateDataTransfer_invalidBody() {
 		assertThrows(ValidationException.class, () ->
-			controller.terminateDataTransfer(MockObjectUtil.CONSUMER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE))
-		);
+			controller.terminateDataTransfer(MockObjectUtil.CONSUMER_PID, 
+					Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE)));
 	}
 	
 	@Test
@@ -85,7 +102,7 @@ public class ConsumerDataTransferCallbackControllerTest {
 	@DisplayName("Terminate TransferProcess - invalid request body")
 	public void suspenseDataTransfer_invalidBody() {
 		assertThrows(ValidationException.class, () ->
-			controller.suspenseDataTransfer(MockObjectUtil.CONSUMER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE))
-		);
+			controller.suspenseDataTransfer(MockObjectUtil.CONSUMER_PID, 
+					Serializer.serializeProtocolJsonNode(MockObjectUtil.TRANSFER_START_MESSAGE)));
 	}
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferAPIServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferAPIServiceTest.java
@@ -1,0 +1,61 @@
+package it.eng.datatransfer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.datatransfer.util.MockObjectUtil;
+
+@ExtendWith(MockitoExtension.class)
+
+class DataTransferAPIServiceTest {
+
+	@Mock
+	private TransferProcessRepository repository;
+	@InjectMocks
+	private DataTransferAPIService apiService;
+
+	@Test
+	@DisplayName("Find transfer process by id, state and all")
+	public void findDataTransfers() {
+
+		when(repository.findById(anyString())).thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_REQUESTED));
+		Collection<JsonNode> response = apiService.findDataTransfers("test", TransferState.REQUESTED.name());
+		assertNotNull(response);
+		assertEquals(response.size(), 1);
+
+		when(repository.findById(anyString())).thenReturn(Optional.empty());
+		response = apiService.findDataTransfers("test_not_found", null);
+		assertNotNull(response);
+		assertTrue(response.isEmpty());
+
+		when(repository.findByState(anyString())).thenReturn(Arrays.asList(MockObjectUtil.TRANSFER_PROCESS_STARTED));
+		response =  apiService.findDataTransfers(null, TransferState.STARTED.name());
+		assertNotNull(response);
+		assertEquals(response.size(), 1);
+
+		when(repository.findAll())
+				.thenReturn(Arrays.asList(MockObjectUtil.TRANSFER_PROCESS_REQUESTED, MockObjectUtil.TRANSFER_PROCESS_STARTED));
+		response =  apiService.findDataTransfers(null, null);
+		assertNotNull(response);
+		assertEquals(response.size(), 2);
+	}
+
+}

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -20,18 +22,32 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import it.eng.datatransfer.exceptions.AgreementNotFoundException;
 import it.eng.datatransfer.exceptions.TransferProcessExistsException;
+import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
 import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.properties.DataTransferProperties;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.util.MockObjectUtil;
+import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.response.GenericApiResponse;
+import it.eng.tools.util.CredentialUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class DataTransferServiceTest {
 
 	@Mock
 	private TransferProcessRepository transferProcessRepository;
+	@Mock
+	private OkHttpRestClient okHttpRestClient;
+	@Mock
+	private CredentialUtils credentialUtils;
+	@Mock
+	private DataTransferProperties properties;
+    @Mock
+	private GenericApiResponse<String> apiResponse;
 
 	@InjectMocks
 	private DataTransferService service;
@@ -81,9 +97,13 @@ public class DataTransferServiceTest {
 	
 	@Test
 	@DisplayName("DataTransfer requested - success")
-	public void initiateTransferPRocess() {
+	public void initiateTransferProcess() {
 		when(transferProcessRepository.findByAgreementId(MockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.empty());
-		TransferProcess transferProcessRequested = service.initiateDataTransfer(MockObjectUtil.TRANSFER_REQUEST_MESSAGE);
+    	when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), isNull()))
+    		.thenReturn(apiResponse);
+    	when(apiResponse.isSuccess()).thenReturn(true);
+
+    	TransferProcess transferProcessRequested = service.initiateDataTransfer(MockObjectUtil.TRANSFER_REQUEST_MESSAGE);
 		
 		assertNotNull(transferProcessRequested);
 		assertEquals(TransferState.REQUESTED, transferProcessRequested.getState());
@@ -99,6 +119,105 @@ public class DataTransferServiceTest {
 		assertThrows(TransferProcessExistsException.class,
 				() -> service.initiateDataTransfer(MockObjectUtil.TRANSFER_REQUEST_MESSAGE));
 		
+		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+	}
+	
+	@Test
+	@DisplayName("DataTransfer requested - agreement not valid")
+	public void initiateTransferProcess_agreemen_not_valid() {
+		when(transferProcessRepository.findByAgreementId(MockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.empty());
+    	when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), isNull()))
+    		.thenReturn(apiResponse);
+    	when(apiResponse.isSuccess()).thenReturn(false);
+
+    	assertThrows(AgreementNotFoundException.class,
+    			() -> service.initiateDataTransfer(MockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+		
+		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer from REQUESTED - provider")
+	public void startDataTransfer_fromRequested_provider() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_REQUESTED));
+		
+		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, null, MockObjectUtil.PROVIDER_PID);
+		
+		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+		verify(transferProcessRepository).save(argTransferProcess.capture());
+		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer from REQUESTED - consumer callback")
+	public void startDataTransfer_fromRequested_consumer() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_REQUESTED));
+		
+		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, MockObjectUtil.CONSUMER_PID, null);
+		
+		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+		verify(transferProcessRepository).save(argTransferProcess.capture());
+		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer from SUSPENDED - provider")
+	public void startDataTransfer_fromSuspended_provider() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SSUSPENDED));
+		
+		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, null, MockObjectUtil.PROVIDER_PID);
+		
+		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+		verify(transferProcessRepository).save(argTransferProcess.capture());
+		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer from SUSPENDED - consumer callback")
+	public void startDataTransfer_fromSuspended_consumer() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SSUSPENDED));
+		
+		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, MockObjectUtil.CONSUMER_PID, null);
+		
+		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+		verify(transferProcessRepository).save(argTransferProcess.capture());
+		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer - transfer process not found - provider")
+	public void startDataTransfer_tpNotFound_provider() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.empty());
+		
+		assertThrows(TransferProcessNotFoundException.class, 
+				() -> service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, null, MockObjectUtil.PROVIDER_PID));
+		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer - transfer process not found - consumer callback")
+	public void startDataTransfer_tpNotFound_consumer() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.empty());
+		
+		assertThrows(TransferProcessNotFoundException.class, 
+				() -> service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, MockObjectUtil.CONSUMER_PID, null));
+		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+	}
+	
+	@Test
+	@DisplayName("StartDataTransfer - invalid state")
+	public void startDataTransfer_invalidState() {
+		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_STARTED));
+		
+		assertThrows(TransferProcessInvalidStateException.class, 
+				() -> service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, null, MockObjectUtil.PROVIDER_PID));
 		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
 	}
 

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
@@ -166,7 +166,7 @@ public class DataTransferServiceTest {
 	@DisplayName("StartDataTransfer from SUSPENDED - provider")
 	public void startDataTransfer_fromSuspended_provider() {
 		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SSUSPENDED));
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SUSPENDED));
 		
 		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, null, MockObjectUtil.PROVIDER_PID);
 		
@@ -179,7 +179,7 @@ public class DataTransferServiceTest {
 	@DisplayName("StartDataTransfer from SUSPENDED - consumer callback")
 	public void startDataTransfer_fromSuspended_consumer() {
 		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SSUSPENDED));
+			.thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_SUSPENDED));
 		
 		TransferProcess transferProcessStarted = service.startDataTransfer(MockObjectUtil.TRANSFER_START_MESSAGE, MockObjectUtil.CONSUMER_PID, null);
 		

--- a/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
@@ -42,6 +42,12 @@ public class MockObjectUtil {
     		.state(TransferState.STARTED)
     		.build();
     
+    public static TransferProcess TRANSFER_PROCESS_SSUSPENDED = TransferProcess.Builder.newInstance()
+    		.consumerPid(CONSUMER_PID)
+    		.providerPid(PROVIDER_PID)
+    		.state(TransferState.SUSPENDED)
+    		.build();
+    
     public static TransferRequestMessage TRANSFER_REQUEST_MESSAGE = TransferRequestMessage.Builder.newInstance()
     		.consumerPid(CONSUMER_PID)
     		.agreementId(AGREEMENT_ID)
@@ -70,4 +76,5 @@ public class MockObjectUtil {
     		.providerPid(PROVIDER_PID)
     		.code("123")
     		.build();
+    
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
@@ -42,7 +42,7 @@ public class MockObjectUtil {
     		.state(TransferState.STARTED)
     		.build();
     
-    public static TransferProcess TRANSFER_PROCESS_SSUSPENDED = TransferProcess.Builder.newInstance()
+    public static TransferProcess TRANSFER_PROCESS_SUSPENDED = TransferProcess.Builder.newInstance()
     		.consumerPid(CONSUMER_PID)
     		.providerPid(PROVIDER_PID)
     		.state(TransferState.SUSPENDED)

--- a/negotiation/src/main/java/it/eng/negotiation/model/Agreement.java
+++ b/negotiation/src/main/java/it/eng/negotiation/model/Agreement.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -24,7 +26,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @JsonDeserialize(builder = Agreement.Builder.class)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@JsonPropertyOrder(value = {"@context", "@type", "@id"}, alphabetic =  true) 
+@JsonPropertyOrder(value = {"@context", "@type", "@id"}, alphabetic =  true)
+@Document(collection = "agreements")
 public class Agreement {
 
 	@JsonIgnore

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
@@ -9,11 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import it.eng.negotiation.service.ContractNegotiationAPIService;
+import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.response.GenericApiResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/agreement")
+@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = ApiEndpoints.NEGOTIATION_AGREEMENTS_V1)
 @Slf4j
 public class AgreementAPIController {
 

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
@@ -1,0 +1,36 @@
+package it.eng.negotiation.rest.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import it.eng.negotiation.service.ContractNegotiationAPIService;
+import it.eng.tools.response.GenericApiResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = "/api/agreement")
+@Slf4j
+public class AgreementAPIController {
+
+	private ContractNegotiationAPIService contractNegotiationAPIService;
+
+	public AgreementAPIController(ContractNegotiationAPIService contractNegotiationAPIService) {
+		super();
+		this.contractNegotiationAPIService = contractNegotiationAPIService;
+	}
+	
+	 @PostMapping(path = "/{agreementId}/valid")
+	    public ResponseEntity<GenericApiResponse<String>> validateAgreement(@PathVariable String agreementId) {
+	        log.info("Validating agreement");
+	        contractNegotiationAPIService.validateAgreement(agreementId);
+	        return ResponseEntity.ok()
+	        		.contentType(MediaType.APPLICATION_JSON)
+	        		.body(GenericApiResponse.success("Agreement is ok", "Agreement is ok", HttpStatus.OK.value()));
+	 }
+
+}

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationAPIService.java
@@ -333,4 +333,13 @@ public class ContractNegotiationAPIService {
 				.permission(offer.getPermission())
 				.build();
 	}
+
+	public void validateAgreement(String agreementId) {
+		agreementRepository.findById(agreementId)
+				.orElseThrow(() -> new ContractNegotiationAPIException("Agreement with Id " + agreementId + " not found."));
+		// TODO add additional checks like contract dates
+		//		LocalDateTime agreementStartDate = LocalDateTime.parse(agreement.getTimestamp(), FORMATTER);
+//		agreementStartDate.isBefore(LocalDateTime.now());
+		
+	}
 }

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationProviderService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationProviderService.java
@@ -32,7 +32,7 @@ public class ContractNegotiationProviderService {
     private final ContractNegotiationPublisher publisher;
 	private final ContractNegotiationRepository contractNegotiationRepository;
 	private final OkHttpRestClient okHttpRestClient;
-	private final  ContractNegotiationProperties properties;
+	private final ContractNegotiationProperties properties;
 	private final OfferRepository offerRepository;
 	private final CredentialUtils credentialUtils;
 

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationProviderService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationProviderService.java
@@ -20,6 +20,7 @@ import it.eng.negotiation.repository.ContractNegotiationRepository;
 import it.eng.negotiation.repository.OfferRepository;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.event.contractnegotiation.ContractNegotationOfferRequestEvent;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.util.CredentialUtils;
@@ -99,7 +100,8 @@ public class ContractNegotiationProviderService {
                     throw new ContractNegotiationExistsException("PROVIDER - Contract request message with provider and consumer pid's exists", contractRequestMessage.getProviderPid(), contractRequestMessage.getConsumerPid());
                 });
 
-		GenericApiResponse<String> response = okHttpRestClient.sendRequestProtocol("http://localhost:" + properties.serverPort() + "/api/offer/validateOffer", 
+		GenericApiResponse<String> response = okHttpRestClient.sendRequestProtocol("http://localhost:" + properties.serverPort() + 
+				ApiEndpoints.CATALOG_OFFERS_V1 + "/validateOffer", 
 				Serializer.serializePlainJsonNode(contractRequestMessage.getOffer()), 
 				credentialUtils.getAPICredentials());
         

--- a/negotiation/src/test/java/it/eng/negotiation/exception/ContractNegotiationExceptionAdviceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/exception/ContractNegotiationExceptionAdviceTest.java
@@ -11,7 +11,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import jakarta.validation.ValidationException;
 
 public class ContractNegotiationExceptionAdviceTest {
@@ -26,7 +26,7 @@ public class ContractNegotiationExceptionAdviceTest {
 	
 	@Test
 	public void handleContractNegotiationNotFoundException() {
-		ContractNegotiationNotFoundException ex = new ContractNegotiationNotFoundException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		ContractNegotiationNotFoundException ex = new ContractNegotiationNotFoundException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleContractNegotiationNotFoundException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -42,7 +42,7 @@ public class ContractNegotiationExceptionAdviceTest {
 
 	@Test
 	public void handleContractNegotiationExistsException() {
-		ContractNegotiationExistsException ex =  new ContractNegotiationExistsException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		ContractNegotiationExistsException ex =  new ContractNegotiationExistsException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleContractNegotiationExistsException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -50,7 +50,7 @@ public class ContractNegotiationExceptionAdviceTest {
 
 	@Test
 	public void handleContractNegotiationInvalidStateException() {
-		ContractNegotiationInvalidStateException ex = new ContractNegotiationInvalidStateException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		ContractNegotiationInvalidStateException ex = new ContractNegotiationInvalidStateException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleContractNegotiationInvalidStateException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -58,7 +58,7 @@ public class ContractNegotiationExceptionAdviceTest {
 
 	@Test
 	public void handleContractNegotiationInvalidEventTypeException() {
-		ContractNegotiationInvalidEventTypeException ex = new ContractNegotiationInvalidEventTypeException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		ContractNegotiationInvalidEventTypeException ex = new ContractNegotiationInvalidEventTypeException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleContractNegotiationInvalidEventTypeException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -66,7 +66,7 @@ public class ContractNegotiationExceptionAdviceTest {
 
 	@Test
 	public void handleOfferNotFoundException() {
-		OfferNotFoundException ex = new OfferNotFoundException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		OfferNotFoundException ex = new OfferNotFoundException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleOfferNotFoundException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -82,7 +82,7 @@ public class ContractNegotiationExceptionAdviceTest {
 
 	@Test
 	void handleOfferNotValidException() {
-		OfferNotValidException ex = new OfferNotValidException(TEST_ERROR_MESSAGE, ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID);
+		OfferNotValidException ex = new OfferNotValidException(TEST_ERROR_MESSAGE, MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID);
 		ResponseEntity<Object> response = advice.handleOfferNotValidException(ex, request);
 		assertNotNull(response);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());

--- a/negotiation/src/test/java/it/eng/negotiation/model/AgreementTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/AgreementTest.java
@@ -16,10 +16,10 @@ import jakarta.validation.ValidationException;
 public class AgreementTest {
 
 	Agreement agreement = Agreement.Builder.newInstance()
-			.id(ModelUtil.generateUUID())
-			.assignee(ModelUtil.ASSIGNEE)
-			.assigner(ModelUtil.ASSIGNER)
-			.target(ModelUtil.TARGET)
+			.id(MockObjectUtil.generateUUID())
+			.assignee(MockObjectUtil.ASSIGNEE)
+			.assigner(MockObjectUtil.ASSIGNER)
+			.target(MockObjectUtil.TARGET)
 			.permission(Arrays.asList(Permission.Builder.newInstance()
 					.action(Action.USE)
 					.constraint(Arrays.asList(Constraint.Builder.newInstance()
@@ -41,7 +41,7 @@ public class AgreementTest {
 	public void invalidAgreement() {
 	assertThrows(ValidationException.class, () -> {
 		Agreement.Builder.newInstance()
-				.id(ModelUtil.generateUUID())
+				.id(MockObjectUtil.generateUUID())
 				.build();
 		});
 	}

--- a/negotiation/src/test/java/it/eng/negotiation/model/ConstraintTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ConstraintTest.java
@@ -9,7 +9,7 @@ public class ConstraintTest {
 
 	@Test
 	public void equalsTrue() {
-		assertTrue(ModelUtil.CONSTRAINT.equals(ModelUtil.CONSTRAINT));
+		assertTrue(MockObjectUtil.CONSTRAINT.equals(MockObjectUtil.CONSTRAINT));
 	}
 	
 	@Test

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractAgreementMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractAgreementMessageTest.java
@@ -34,9 +34,9 @@ public class ContractAgreementMessageTest {
 			.build();
 	
 	private Agreement agreement = Agreement.Builder.newInstance()
-			.assignee(ModelUtil.ASSIGNEE)
-			.assigner(ModelUtil.ASSIGNER)
-			.target(ModelUtil.TARGET)
+			.assignee(MockObjectUtil.ASSIGNEE)
+			.assigner(MockObjectUtil.ASSIGNER)
+			.target(MockObjectUtil.TARGET)
 			.timestamp(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mmX")
                     .withZone(ZoneOffset.UTC)
                     .format(Instant.now()))
@@ -44,9 +44,9 @@ public class ContractAgreementMessageTest {
 			.build();
 	
 	private ContractAgreementMessage contractAgreementMessage = ContractAgreementMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
-			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
+			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
 			.agreement(agreement)
 			.build();
 		
@@ -85,8 +85,8 @@ public class ContractAgreementMessageTest {
 	public void validateInvalid() {
 		assertThrows(ValidationException.class, 
 				() -> ContractAgreementMessage.Builder.newInstance()
-					.consumerPid(ModelUtil.CONSUMER_PID)
-					.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
+					.consumerPid(MockObjectUtil.CONSUMER_PID)
+					.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
 					.agreement(agreement)
 					.build());
 	}
@@ -119,9 +119,9 @@ public class ContractAgreementMessageTest {
 	}
 	
 	private void validateAgreement(Agreement agreement) {
-		assertEquals(ModelUtil.ASSIGNEE, agreement.getAssignee());
-		assertEquals(ModelUtil.ASSIGNER, agreement.getAssigner());
-		assertEquals(ModelUtil.TARGET, agreement.getTarget());
+		assertEquals(MockObjectUtil.ASSIGNEE, agreement.getAssignee());
+		assertEquals(MockObjectUtil.ASSIGNER, agreement.getAssigner());
+		assertEquals(MockObjectUtil.TARGET, agreement.getTarget());
 		
 		var permission = agreement.getPermission().get(0);
 		assertNotNull(permission);

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractAgreementVerificationMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractAgreementVerificationMessageTest.java
@@ -18,8 +18,8 @@ public class ContractAgreementVerificationMessageTest {
 
 	private ContractAgreementVerificationMessage contractAgreementVerificationMessage = ContractAgreementVerificationMessage.Builder
 			.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.build();
 	
 	@Test

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationErrorMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationErrorMessageTest.java
@@ -21,8 +21,8 @@ public class ContractNegotiationErrorMessageTest {
 
 	private ContractNegotiationErrorMessage contractNegotiationErrorMessage = ContractNegotiationErrorMessage.Builder
 			.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.code("Negotiation error code 123")
 			.description(Arrays.asList(
 					Description.Builder.newInstance().language("en").value("English description text").build(),

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationEventMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationEventMessageTest.java
@@ -17,8 +17,8 @@ import jakarta.validation.ValidationException;
 public class ContractNegotiationEventMessageTest {
 
 	private ContractNegotiationEventMessage contractNegotiationEventMessage = ContractNegotiationEventMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.eventType(ContractNegotiationEventType.ACCEPTED)
 			.build();
 	

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTerminationMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTerminationMessageTest.java
@@ -21,8 +21,8 @@ public class ContractNegotiationTerminationMessageTest {
 
 	private ContractNegotiationTerminationMessage contractNegotiationTerminationMessage = ContractNegotiationTerminationMessage.Builder
 			.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.code("Termination CD_123")
 			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("Meaningful reas for term").build(),
 					Reason.Builder.newInstance().language("it").value("Meaningful reas for term but in Italian").build()))

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTest.java
@@ -21,8 +21,8 @@ import jakarta.validation.ValidationException;
 public class ContractNegotiationTest {
 
 	private ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.ACCEPTED)
 			.build();
 	
@@ -73,8 +73,8 @@ public class ContractNegotiationTest {
 	@DisplayName("From Requestsed state")
 	public void requestedState() {
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.REQUESTED)
 			.build();
 		assertTrue(cn.getState().nextState().containsAll(Arrays.asList(ContractNegotiationState.OFFERED, ContractNegotiationState.AGREED, ContractNegotiationState.TERMINATED)));
@@ -84,8 +84,8 @@ public class ContractNegotiationTest {
 	@DisplayName("From Offered state")
 	public void offeredState() {
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.OFFERED)
 			.build();
 		assertTrue(cn.getState().nextState().containsAll(Arrays.asList(ContractNegotiationState.REQUESTED, ContractNegotiationState.ACCEPTED, ContractNegotiationState.TERMINATED)));
@@ -95,8 +95,8 @@ public class ContractNegotiationTest {
 	@DisplayName("From Accepted state")
 	public void acceptedState() {
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.ACCEPTED)
 			.build();
 		assertTrue(cn.getState().nextState().containsAll(Arrays.asList(ContractNegotiationState.AGREED, ContractNegotiationState.TERMINATED)));
@@ -106,8 +106,8 @@ public class ContractNegotiationTest {
 	@DisplayName("From Agreed state")
 	public void agreedState() {
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.AGREED)
 			.build();
 		assertTrue(cn.getState().nextState().containsAll(Arrays.asList(ContractNegotiationState.VERIFIED, ContractNegotiationState.TERMINATED)));
@@ -117,8 +117,8 @@ public class ContractNegotiationTest {
 	@DisplayName("From Verified state")
 	public void verifiedState() {
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.VERIFIED)
 			.build();
 		assertTrue(cn.getState().nextState().containsAll(Arrays.asList(ContractNegotiationState.FINALIZED, ContractNegotiationState.TERMINATED)));
@@ -127,11 +127,11 @@ public class ContractNegotiationTest {
 	@Test
 	@DisplayName("From initial ContractNegotiation with new ContractNegotiationState")
 	public void withNewState() {
-		ContractNegotiation contractNegotiationOffered = ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.withNewContractNegotiationState(ContractNegotiationState.OFFERED);
-		assertEquals(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId(), contractNegotiationOffered.getId());
-		assertEquals(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getConsumerPid(), contractNegotiationOffered.getConsumerPid());
-		assertEquals(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getProviderPid(), contractNegotiationOffered.getProviderPid());
-		assertEquals(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getCallbackAddress(), contractNegotiationOffered.getCallbackAddress());
+		ContractNegotiation contractNegotiationOffered = MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.withNewContractNegotiationState(ContractNegotiationState.OFFERED);
+		assertEquals(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId(), contractNegotiationOffered.getId());
+		assertEquals(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getConsumerPid(), contractNegotiationOffered.getConsumerPid());
+		assertEquals(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getProviderPid(), contractNegotiationOffered.getProviderPid());
+		assertEquals(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getCallbackAddress(), contractNegotiationOffered.getCallbackAddress());
 		assertEquals(ContractNegotiationState.OFFERED, contractNegotiationOffered.getState());
 	}
 	

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractOfferMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractOfferMessageTest.java
@@ -21,7 +21,7 @@ public class ContractOfferMessageTest {
 	@Test
 	@DisplayName("Verify valid plain object serialization")
 	public void testPlain() throws JsonProcessingException {
-		String result = Serializer.serializePlain(ModelUtil.CONTRACT_OFFER_MESSAGE);
+		String result = Serializer.serializePlain(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
 		assertFalse(result.contains(DSpaceConstants.CONTEXT));
 		assertFalse(result.contains(DSpaceConstants.TYPE));
 		assertFalse(result.contains(DSpaceConstants.ID));
@@ -36,7 +36,7 @@ public class ContractOfferMessageTest {
 	@Test
 	@DisplayName("Verify valid protocol object serialization")
 	public void testProtocol() throws JsonProcessingException {
-		JsonNode result = Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_OFFER_MESSAGE);
+		JsonNode result = Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
 		assertNotNull(result.get(DSpaceConstants.CONTEXT).asText());
 		assertNotNull(result.get(DSpaceConstants.TYPE).asText());
 		assertNotNull(result.get(DSpaceConstants.DSPACE_CONSUMER_PID).asText());
@@ -62,7 +62,7 @@ public class ContractOfferMessageTest {
 	@Test
 	@DisplayName("Missing @context and @type")
 	public void missingContextAndType() {
-		JsonNode result = Serializer.serializePlainJsonNode(ModelUtil.CONTRACT_OFFER_MESSAGE);
+		JsonNode result = Serializer.serializePlainJsonNode(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
 		assertThrows(ValidationException.class, () -> Serializer.deserializeProtocol(result, ContractOfferMessage.class));
 	}
 	
@@ -79,9 +79,9 @@ public class ContractOfferMessageTest {
 	
 	private void validateJavaObj(ContractOfferMessage javaObj) {
 		assertNotNull(javaObj);
-		assertEquals(ModelUtil.CONSUMER_PID, javaObj.getConsumerPid());
-		assertEquals(ModelUtil.PROVIDER_PID, javaObj.getProviderPid());
-		assertEquals(ModelUtil.CALLBACK_ADDRESS, javaObj.getCallbackAddress());
+		assertEquals(MockObjectUtil.CONSUMER_PID, javaObj.getConsumerPid());
+		assertEquals(MockObjectUtil.PROVIDER_PID, javaObj.getProviderPid());
+		assertEquals(MockObjectUtil.CALLBACK_ADDRESS, javaObj.getCallbackAddress());
 		assertNotNull(javaObj.getOffer());
 	}
 	

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractRequestMessageTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractRequestMessageTest.java
@@ -19,10 +19,10 @@ import jakarta.validation.ValidationException;
 public class ContractRequestMessageTest {
 
 	private ContractRequestMessage contractRequestMessage = ContractRequestMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
-			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-			.offer(ModelUtil.OFFER)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
+			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+			.offer(MockObjectUtil.OFFER)
 			.build();
 	
 	@Test
@@ -44,9 +44,9 @@ public class ContractRequestMessageTest {
 	@DisplayName("Verify valid plain object serialization - initial ContractRequestMessage")
 	public void testContractRequest_consumer() {
 		ContractRequestMessage contractRequestMessage = ContractRequestMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-				.offer(ModelUtil.OFFER)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+				.offer(MockObjectUtil.OFFER)
 				.build();
 		String result = Serializer.serializePlain(contractRequestMessage);
 		assertFalse(result.contains(DSpaceConstants.CONTEXT));
@@ -61,10 +61,10 @@ public class ContractRequestMessageTest {
 	@DisplayName("Verify valid plain object serialization - contains offer")
 	public void testPlain_offer() throws JsonProcessingException {
 		ContractRequestMessage contractRequestMessageOffer = ContractRequestMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.providerPid(ModelUtil.PROVIDER_PID)
-				.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-				.offer(ModelUtil.OFFER)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
+				.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+				.offer(MockObjectUtil.OFFER)
 				.build();
 		String result = Serializer.serializePlain(contractRequestMessageOffer);
 		assertFalse(result.contains(DSpaceConstants.CONTEXT));
@@ -124,9 +124,9 @@ public class ContractRequestMessageTest {
 	
 	private void validateJavaObj(ContractRequestMessage javaObj) {
 		assertNotNull(javaObj);
-		assertEquals(ModelUtil.CONSUMER_PID, javaObj.getConsumerPid());
-		assertEquals(ModelUtil.PROVIDER_PID, javaObj.getProviderPid());
-		assertEquals(ModelUtil.CALLBACK_ADDRESS, javaObj.getCallbackAddress());
+		assertEquals(MockObjectUtil.CONSUMER_PID, javaObj.getConsumerPid());
+		assertEquals(MockObjectUtil.PROVIDER_PID, javaObj.getProviderPid());
+		assertEquals(MockObjectUtil.CALLBACK_ADDRESS, javaObj.getCallbackAddress());
 		assertNotNull(javaObj.getOffer());
 	}
 }

--- a/negotiation/src/test/java/it/eng/negotiation/model/MockObjectUtil.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/MockObjectUtil.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 
-public class ModelUtil {
+public class MockObjectUtil {
 
 	public static final String CONSUMER_PID = "urn:uuid:CONSUMER_PID";
 	public static final String PROVIDER_PID = "urn:uuid:PROVIDER_PID";
@@ -27,20 +27,20 @@ public class ModelUtil {
 	
 	public static ContractNegotiationEventMessage getEventMessage(ContractNegotiationEventType eventType) {
 		return ContractNegotiationEventMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.providerPid(ModelUtil.PROVIDER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
 				.eventType(eventType)
 				.build();
 	}
 	
 	public static final ContractAgreementVerificationMessage CONTRACT_AGREEMENT_VERIFICATION_MESSAGE = ContractAgreementVerificationMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.build();
 
 	public static final ContractNegotiationTerminationMessage TERMINATION_MESSAGE = ContractNegotiationTerminationMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.code("Test")
 			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
 			.build();
@@ -59,42 +59,42 @@ public class ModelUtil {
 	
 	public static final Permission PERMISSION = Permission.Builder.newInstance()
 			.action(Action.USE)
-			.target(ModelUtil.TARGET)
-			.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+			.target(MockObjectUtil.TARGET)
+			.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 			.build();
 	
 	public static final Permission PERMISSION_COUNT_5 = Permission.Builder.newInstance()
 			.action(Action.USE)
-			.target(ModelUtil.TARGET)
-			.constraint(Arrays.asList(ModelUtil.CONSTRAINT_COUNT_5))
+			.target(MockObjectUtil.TARGET)
+			.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT_COUNT_5))
 			.build();
 	
 	public static final Offer OFFER = Offer.Builder.newInstance()
-			.target(ModelUtil.TARGET)
-			.assignee(ModelUtil.ASSIGNEE)
-			.assigner(ModelUtil.ASSIGNER)
-			.permission(Arrays.asList(ModelUtil.PERMISSION))
+			.target(MockObjectUtil.TARGET)
+			.assignee(MockObjectUtil.ASSIGNEE)
+			.assigner(MockObjectUtil.ASSIGNER)
+			.permission(Arrays.asList(MockObjectUtil.PERMISSION))
 			.build();
 	
 	public static final Offer OFFER_COUNT_5 = Offer.Builder.newInstance()
-			.target(ModelUtil.TARGET)
-			.assignee(ModelUtil.ASSIGNEE)
-			.assigner(ModelUtil.ASSIGNER)
-			.permission(Arrays.asList(ModelUtil.PERMISSION_COUNT_5))
+			.target(MockObjectUtil.TARGET)
+			.assignee(MockObjectUtil.ASSIGNEE)
+			.assigner(MockObjectUtil.ASSIGNER)
+			.permission(Arrays.asList(MockObjectUtil.PERMISSION_COUNT_5))
 			.build();
 
 	public static final ContractOfferMessage CONTRACT_OFFER_MESSAGE = ContractOfferMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
-			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-			.offer(ModelUtil.OFFER)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
+			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+			.offer(MockObjectUtil.OFFER)
 			.build();
 
 	public static final Agreement AGREEMENT = Agreement.Builder.newInstance()
-			.id(ModelUtil.generateUUID())
-			.assignee(ModelUtil.ASSIGNEE)
-			.assigner(ModelUtil.ASSIGNER)
-			.target(ModelUtil.TARGET)
+			.id(MockObjectUtil.generateUUID())
+			.assignee(MockObjectUtil.ASSIGNEE)
+			.assigner(MockObjectUtil.ASSIGNER)
+			.target(MockObjectUtil.TARGET)
 			.timestamp(ZonedDateTime.now().minusDays(2).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
 			.permission(Arrays.asList(PERMISSION_COUNT_5))
 			.build();
@@ -106,21 +106,21 @@ public class ModelUtil {
 			.build();
 	
 	public static final ContractAgreementMessage CONTRACT_AGREEMENT_MESSAGE = ContractAgreementMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
-			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
+			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
 			.agreement(AGREEMENT)
 			.build();
 	
 	public static final ContractNegotiationEventMessage CONTRACT_NEGOTIATION_EVENT_MESSAGE = ContractNegotiationEventMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.eventType(ContractNegotiationEventType.FINALIZED)
 			.build();
 	
 	public static final ContractNegotiationEventMessage CONTRACT_NEGOTIATION_EVENT_MESSAGE_ACCEPTED = ContractNegotiationEventMessage.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.eventType(ContractNegotiationEventType.ACCEPTED)
 			.build();
 	
@@ -133,24 +133,24 @@ public class ModelUtil {
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_ACCEPTED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.ACCEPTED)
-			.offer(ModelUtil.OFFER_COUNT_5)
+			.offer(MockObjectUtil.OFFER_COUNT_5)
 			.assigner(ASSIGNER)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_ACCEPTED_NO_OFFER = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.ACCEPTED)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_REQUESTED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.REQUESTED)
 			.offer(OFFER)
@@ -158,39 +158,39 @@ public class ModelUtil {
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_AGREED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.AGREED)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_OFFERED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.OFFERED)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_VERIFIED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.VERIFIED)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_FINALIZED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.FINALIZED)
 			.build();
 	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_TERMINATED = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.callbackAddress(CALLBACK_ADDRESS)
 			.state(ContractNegotiationState.TERMINATED)
-			.offer(ModelUtil.OFFER_COUNT_5)
+			.offer(MockObjectUtil.OFFER_COUNT_5)
 			.assigner(ASSIGNER)
 			.build();
 }

--- a/negotiation/src/test/java/it/eng/negotiation/model/ModelUtil.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ModelUtil.java
@@ -1,5 +1,7 @@
 package it.eng.negotiation.model;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -93,6 +95,7 @@ public class ModelUtil {
 			.assignee(ModelUtil.ASSIGNEE)
 			.assigner(ModelUtil.ASSIGNER)
 			.target(ModelUtil.TARGET)
+			.timestamp(ZonedDateTime.now().minusDays(2).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
 			.permission(Arrays.asList(PERMISSION_COUNT_5))
 			.build();
 	

--- a/negotiation/src/test/java/it/eng/negotiation/model/OfferTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/OfferTest.java
@@ -16,8 +16,8 @@ public class OfferTest {
 	@Test
 	public void validOffer() {
 		Offer offer = Offer.Builder.newInstance()
-				.target(ModelUtil.TARGET)
-				.assigner(ModelUtil.ASSIGNER)
+				.target(MockObjectUtil.TARGET)
+				.assigner(MockObjectUtil.ASSIGNER)
 				.build();
 		assertNotNull(offer, "Offer should be created with mandatory fields");
 		assertNotNull(offer.getId());
@@ -27,7 +27,7 @@ public class OfferTest {
 	public void invalidOffer() {
 		assertThrows(ValidationException.class, 
 				() -> Offer.Builder.newInstance()
-					.assignee(ModelUtil.ASSIGNEE)
+					.assignee(MockObjectUtil.ASSIGNEE)
 					.build());
 	}	
 	
@@ -36,13 +36,13 @@ public class OfferTest {
 		String id = UUID.randomUUID().toString();
 		Offer offer = Offer.Builder.newInstance()
 				.id(id)
-				.assigner(ModelUtil.ASSIGNER)
-				.target(ModelUtil.TARGET)
+				.assigner(MockObjectUtil.ASSIGNER)
+				.target(MockObjectUtil.TARGET)
 				.build();
 		Offer offerB = Offer.Builder.newInstance()
 				.id(id)
-				.assigner(ModelUtil.ASSIGNER)
-				.target(ModelUtil.TARGET)
+				.assigner(MockObjectUtil.ASSIGNER)
+				.target(MockObjectUtil.TARGET)
 				.build();
 		assertTrue(offer.equals(offerB));
 	}
@@ -50,12 +50,12 @@ public class OfferTest {
 	@Test
 	public void equalsFalse() {
 		Offer offer = Offer.Builder.newInstance()
-				.target(ModelUtil.TARGET)
-				.assigner(ModelUtil.ASSIGNER)
+				.target(MockObjectUtil.TARGET)
+				.assigner(MockObjectUtil.ASSIGNER)
 				.build();
 		Offer offerB = Offer.Builder.newInstance()
 				.target("SomeDifferentTarget")
-				.assigner(ModelUtil.ASSIGNER)
+				.assigner(MockObjectUtil.ASSIGNER)
 				.build();
 		assertFalse(offer.equals(offerB));
 	}

--- a/negotiation/src/test/java/it/eng/negotiation/model/PermissionTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/PermissionTest.java
@@ -17,7 +17,7 @@ public class PermissionTest {
 	public void validPermission() {
 		Permission permission = Permission.Builder.newInstance()
 				.action(Action.USE)
-				.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+				.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 				.build();
 		assertNotNull(permission, "Permission creted with mandatory fields");
 	}
@@ -26,8 +26,8 @@ public class PermissionTest {
 	public void invalidPermission() {
 		assertThrows(ValidationException.class, 
 				() -> Permission.Builder.newInstance()
-					.assignee(ModelUtil.ASSIGNEE)
-					.assigner(ModelUtil.ASSIGNER)
+					.assignee(MockObjectUtil.ASSIGNEE)
+					.assigner(MockObjectUtil.ASSIGNER)
 					.build());
 	}
 	
@@ -35,11 +35,11 @@ public class PermissionTest {
 	public void equalsTrue() {
 		Permission permission = Permission.Builder.newInstance()
 				.action(Action.USE)
-				.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+				.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 				.build();
 		Permission permissionB = Permission.Builder.newInstance()
 				.action(Action.USE)
-				.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+				.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 				.build();
 		assertTrue(permission.equals(permissionB));
 	}
@@ -48,11 +48,11 @@ public class PermissionTest {
 	public void equalsFalse() {
 		Permission permissionA = Permission.Builder.newInstance()
 				.action(Action.USE)
-				.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+				.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 				.build();
 		Permission permissionB = Permission.Builder.newInstance()
 				.action(Action.ANONYMIZE)
-				.constraint(Arrays.asList(ModelUtil.CONSTRAINT))
+				.constraint(Arrays.asList(MockObjectUtil.CONSTRAINT))
 				.build();
 		assertFalse(permissionA.equals(permissionB));
 	}

--- a/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import it.eng.negotiation.exception.ContractNegotiationAPIException;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.service.ContractNegotiationAPIService;
 import it.eng.tools.response.GenericApiResponse;
 
@@ -33,7 +33,7 @@ class AgreementAPIControllerTest {
 	@DisplayName("Validate agreement")
 	void testValidateAgreement() {
 		doNothing().when(contractNegotiationAPIService).validateAgreement(any(String.class));
-		ResponseEntity<GenericApiResponse<String>> response = controller.validateAgreement(ModelUtil.AGREEMENT.getId());
+		ResponseEntity<GenericApiResponse<String>> response = controller.validateAgreement(MockObjectUtil.AGREEMENT.getId());
 		assertNotNull(response);
 		assertTrue(response.getBody().isSuccess());
 	}
@@ -44,7 +44,7 @@ class AgreementAPIControllerTest {
 		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
 		.when(contractNegotiationAPIService).validateAgreement(any(String.class));
 		assertThrows(ContractNegotiationAPIException.class, 
-				() -> controller.validateAgreement(ModelUtil.AGREEMENT.getId()));
+				() -> controller.validateAgreement(MockObjectUtil.AGREEMENT.getId()));
 	}
 
 }

--- a/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
@@ -1,0 +1,50 @@
+package it.eng.negotiation.rest.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import it.eng.negotiation.exception.ContractNegotiationAPIException;
+import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.service.ContractNegotiationAPIService;
+import it.eng.tools.response.GenericApiResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AgreementAPIControllerTest {
+
+	@Mock
+	private ContractNegotiationAPIService contractNegotiationAPIService;
+	
+	@InjectMocks
+	private AgreementAPIController controller;
+	
+	@Test
+	@DisplayName("Validate agreement")
+	void testValidateAgreement() {
+		doNothing().when(contractNegotiationAPIService).validateAgreement(any(String.class));
+		ResponseEntity<GenericApiResponse<String>> response = controller.validateAgreement(ModelUtil.AGREEMENT.getId());
+		assertNotNull(response);
+		assertTrue(response.getBody().isSuccess());
+	}
+	
+	@Test
+	@DisplayName("Validate agreement - not valid")
+	void testValidateAgreement_serviceError() {
+		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
+		.when(contractNegotiationAPIService).validateAgreement(any(String.class));
+		assertThrows(ContractNegotiationAPIException.class, 
+				() -> controller.validateAgreement(ModelUtil.AGREEMENT.getId()));
+	}
+
+}

--- a/negotiation/src/test/java/it/eng/negotiation/rest/api/ContractNegotiationAPIControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/api/ContractNegotiationAPIControllerTest.java
@@ -33,7 +33,7 @@ import it.eng.negotiation.model.ContractAgreementVerificationMessage;
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationEventMessage;
 import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.negotiation.service.ContractNegotiationAPIService;
 import it.eng.negotiation.service.ContractNegotiationEventHandlerService;
@@ -59,8 +59,8 @@ public class ContractNegotiationAPIControllerTest {
 	public void findAll() {
 		when(apiService.findContractNegotiations(null))
 				.thenReturn(Arrays.asList(
-						Serializer.serializePlainJsonNode(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED),
-						Serializer.serializePlainJsonNode(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED)));
+						Serializer.serializePlainJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED),
+						Serializer.serializePlainJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED)));
 		ResponseEntity<GenericApiResponse<Collection<JsonNode>>> response = controller.findContractNegotations(null);
 		assertNotNull(response);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -70,7 +70,7 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Find contract negotiations by state")
 	public void findContractNegotiationByState() {
 		when(apiService.findContractNegotiations(ContractNegotiationState.ACCEPTED.name()))
-				.thenReturn(Arrays.asList(Serializer.serializePlainJsonNode(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED)));
+				.thenReturn(Arrays.asList(Serializer.serializePlainJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED)));
 		ResponseEntity<GenericApiResponse<Collection<JsonNode>>> response = controller.findContractNegotations(ContractNegotiationState.ACCEPTED.name());
 		assertNotNull(response);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -80,11 +80,11 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Start contract negotiation success")
 	public void startNegotiation_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("Forward-To", ModelUtil.FORWARD_TO);
-		map.put("offer", Serializer.serializeProtocolJsonNode(ModelUtil.OFFER));
+		map.put("Forward-To", MockObjectUtil.FORWARD_TO);
+		map.put("offer", Serializer.serializeProtocolJsonNode(MockObjectUtil.OFFER));
 				
 		when(apiService.startNegotiation(any(String.class), any(JsonNode.class)))
-			.thenReturn(Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+			.thenReturn(Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.startNegotiation(mapper.convertValue(map, JsonNode.class));
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -95,9 +95,9 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Approve requested offer success")
 	public void offerApproved_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("offer", Serializer.serializeProtocolJsonNode(ModelUtil.OFFER));
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
+		map.put("offer", Serializer.serializeProtocolJsonNode(MockObjectUtil.OFFER));
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
 		map.put("offerAccepted", true);
 		
 		ResponseEntity<JsonNode> response = controller.handleOfferApproved(mapper.convertValue(map, JsonNode.class));
@@ -109,8 +109,8 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Verify negotiation success")
 	public void verifyNegotiation_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
 		
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.verifyNegotiation(mapper.convertValue(map, JsonNode.class));
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -121,8 +121,8 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Verify negotiation failed")
 	public void verifyNegotiation_failed() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
 		
 		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
 		.when(handlerService).verifyNegotiation(any(ContractAgreementVerificationMessage.class));
@@ -135,11 +135,11 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Provider posts offer - success")
 	public void providerPostsOffer_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("Forward-To", ModelUtil.FORWARD_TO);
-		map.put("offer", Serializer.serializeProtocolJsonNode(ModelUtil.OFFER));
+		map.put("Forward-To", MockObjectUtil.FORWARD_TO);
+		map.put("offer", Serializer.serializeProtocolJsonNode(MockObjectUtil.OFFER));
 		
 		when(apiService.sendContractOffer(any(String.class), any(JsonNode.class)))
-			.thenReturn(Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+			.thenReturn(Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.sendOffer(mapper.convertValue(map, JsonNode.class));
 	
 		assertNotNull(response);
@@ -153,8 +153,8 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Provider posts offer - error")
 	public void providerPostsOffer_error() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("Forward-To", ModelUtil.FORWARD_TO);
-		map.put("offer", Serializer.serializeProtocolJsonNode(ModelUtil.OFFER));
+		map.put("Forward-To", MockObjectUtil.FORWARD_TO);
+		map.put("offer", Serializer.serializeProtocolJsonNode(MockObjectUtil.OFFER));
 		
 		when(apiService.sendContractOffer(any(String.class), any(JsonNode.class)))
 			.thenThrow(new ContractNegotiationAPIException("Something not correct - tests"));
@@ -167,9 +167,9 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Send agreement success")
 	public void sendAgreement_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
-		map.put("agreement", Serializer.serializeProtocolJsonNode(ModelUtil.AGREEMENT));
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
+		map.put("agreement", Serializer.serializeProtocolJsonNode(MockObjectUtil.AGREEMENT));
 				
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.sendAgreement(mapper.convertValue(map, JsonNode.class));
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -180,9 +180,9 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Send agreement failed")
 	public void sendAgreement_failed() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
-		map.put("agreement", Serializer.serializeProtocolJsonNode(ModelUtil.AGREEMENT));
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
+		map.put("agreement", Serializer.serializeProtocolJsonNode(MockObjectUtil.AGREEMENT));
 				
 		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
 		.when(apiService).sendAgreement(any(String.class), any(String.class), any(JsonNode.class));
@@ -195,8 +195,8 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Finalize negotiation success")
 	public void finalizeNegotiation_success() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
 				
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.finalizeNegotiation(mapper.convertValue(map, JsonNode.class));
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -207,8 +207,8 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Finalize negotiation failed")
 	public void finalizeNegotiation_failed() {
 		Map<String, Object> map = new HashMap<>();
-		map.put("consumerPid", ModelUtil.CONSUMER_PID);
-		map.put("providerPid", ModelUtil.PROVIDER_PID);
+		map.put("consumerPid", MockObjectUtil.CONSUMER_PID);
+		map.put("providerPid", MockObjectUtil.PROVIDER_PID);
 				
 		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
 		.when(apiService).finalizeNegotiation(any(ContractNegotiationEventMessage.class));
@@ -222,7 +222,7 @@ public class ContractNegotiationAPIControllerTest {
 	public void providerAcceptsCN() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
 		when(apiService.handleContractNegotiationAgreed(contractNegotaitionId))
-			.thenReturn(ModelUtil.CONTRACT_NEGOTIATION_AGREED);
+			.thenReturn(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED);
 		
 		ResponseEntity<GenericApiResponse<JsonNode>> response =  controller.handleContractNegotationAgreed(contractNegotaitionId);
 		
@@ -245,7 +245,7 @@ public class ContractNegotiationAPIControllerTest {
 	public void providerTerminatesCN() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
 		when(handlerService.handleContractNegotiationTerminated(contractNegotaitionId))
-			.thenReturn(ModelUtil.CONTRACT_NEGOTIATION_TERMINATED);
+			.thenReturn(MockObjectUtil.CONTRACT_NEGOTIATION_TERMINATED);
 
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.handleContractNegotationTerminated(contractNegotaitionId);
 		
@@ -267,7 +267,7 @@ public class ContractNegotiationAPIControllerTest {
 	@DisplayName("Consumer acepts negotiation offered by provider")
 	public void handleContractNegotationAccepted() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
-		when(apiService.handleContractNegotiationAccepted(contractNegotaitionId)).thenReturn(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED);
+		when(apiService.handleContractNegotiationAccepted(contractNegotaitionId)).thenReturn(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED);
 		
 		ResponseEntity<GenericApiResponse<JsonNode>> response = controller.handleContractNegotationAccepted(contractNegotaitionId);
 		

--- a/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackControllerTest.java
@@ -30,7 +30,7 @@ import it.eng.negotiation.model.ContractAgreementMessage;
 import it.eng.negotiation.model.ContractNegotiationEventMessage;
 import it.eng.negotiation.model.ContractNegotiationTerminationMessage;
 import it.eng.negotiation.model.ContractOfferMessage;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.properties.ContractNegotiationProperties;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.negotiation.service.ContractNegotiationConsumerService;
@@ -50,11 +50,11 @@ public class ConsumerContractNegotiationCallbackControllerTest {
 
     @Test
     public void handleNegotiationOffers() throws JsonProcessingException {
-        String json = Serializer.serializeProtocol(ModelUtil.CONTRACT_OFFER_MESSAGE);
+        String json = Serializer.serializeProtocol(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
         JsonNode jsonNode = mapper.readTree(json);
         when(contractNegotiationConsumerService.processContractOffer(any(ContractOfferMessage.class)))
-                .thenReturn(Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
-        when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+                .thenReturn(Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
+        when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
         ResponseEntity<JsonNode> response = controller.handleNegotiationOffers(jsonNode);
         assertNotNull(response);
         assertTrue(response.getStatusCode().is2xxSuccessful());
@@ -62,23 +62,23 @@ public class ConsumerContractNegotiationCallbackControllerTest {
 
     @Test
     public void handleNegotiationOfferConsumerPid() throws InterruptedException, ExecutionException, JsonMappingException, JsonProcessingException {
-        String json = Serializer.serializeProtocol(ModelUtil.CONTRACT_OFFER_MESSAGE);
+        String json = Serializer.serializeProtocol(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
         JsonNode jsonNode = mapper.readTree(json);
         when(contractNegotiationConsumerService.handleNegotiationOfferConsumer(any(String.class), any(ContractOfferMessage.class)))
                 .thenReturn(jsonNode);
 
-        ResponseEntity<JsonNode> response = controller.handleNegotiationOfferConsumerPid(ModelUtil.CONSUMER_PID, jsonNode);
+        ResponseEntity<JsonNode> response = controller.handleNegotiationOfferConsumerPid(MockObjectUtil.CONSUMER_PID, jsonNode);
         assertNotNull(response);
         assertTrue(response.getStatusCode().is2xxSuccessful());
     }
 
     @Test
     public void handleAgreement_success() throws InterruptedException, ExecutionException, JsonMappingException, JsonProcessingException {
-        String json = Serializer.serializeProtocol(ModelUtil.CONTRACT_AGREEMENT_MESSAGE);
+        String json = Serializer.serializeProtocol(MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE);
         JsonNode jsonNode = mapper.readTree(json);
         doNothing().when(contractNegotiationConsumerService).handleAgreement(any(ContractAgreementMessage.class));
 
-        ResponseEntity<JsonNode> response = controller.handleAgreement(ModelUtil.CONSUMER_PID, jsonNode);
+        ResponseEntity<JsonNode> response = controller.handleAgreement(MockObjectUtil.CONSUMER_PID, jsonNode);
         assertNotNull(response);
         assertTrue(response.getStatusCode().is2xxSuccessful());
 
@@ -87,53 +87,53 @@ public class ConsumerContractNegotiationCallbackControllerTest {
     
     @Test
     public void handleAgreement_failed() throws InterruptedException, ExecutionException, JsonMappingException, JsonProcessingException {
-        String json = Serializer.serializeProtocol(ModelUtil.CONTRACT_AGREEMENT_MESSAGE);
+        String json = Serializer.serializeProtocol(MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE);
         JsonNode jsonNode = mapper.readTree(json);
 
-        doThrow(new ContractNegotiationInvalidStateException("Something not correct - tests", ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID))
+        doThrow(new ContractNegotiationInvalidStateException("Something not correct - tests", MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID))
 		.when(contractNegotiationConsumerService).handleAgreement(any(ContractAgreementMessage.class));
 		
 		assertThrows(ContractNegotiationInvalidStateException.class, () ->
-		controller.handleAgreement(ModelUtil.CONSUMER_PID, jsonNode));
+		controller.handleAgreement(MockObjectUtil.CONSUMER_PID, jsonNode));
     }
 
     @Test
     public void handleFinalizeEvent_success() throws InterruptedException, ExecutionException, JsonMappingException, JsonProcessingException {
-        String json = Serializer.serializeProtocol(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
+        String json = Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
         JsonNode jsonNode = mapper.readTree(json);
         doNothing().when(contractNegotiationConsumerService).handleFinalizeEvent(any(ContractNegotiationEventMessage.class));
 
-        ResponseEntity<JsonNode> response = controller.handleFinalizeEvent(ModelUtil.CONSUMER_PID, jsonNode);
+        ResponseEntity<JsonNode> response = controller.handleFinalizeEvent(MockObjectUtil.CONSUMER_PID, jsonNode);
         assertNull(response.getBody());
         assertTrue(response.getStatusCode().is2xxSuccessful());
     }
     
     @Test
     public void handleFinalizeEvent_failed()  {
-		JsonNode jsonNode = Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
+		JsonNode jsonNode = Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
 
-        doThrow(new ContractNegotiationInvalidStateException("Something not correct - tests", ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID))
+        doThrow(new ContractNegotiationInvalidStateException("Something not correct - tests", MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID))
 		.when(contractNegotiationConsumerService).handleFinalizeEvent(any(ContractNegotiationEventMessage.class));
 		
 		assertThrows(ContractNegotiationInvalidStateException.class, () ->
-		controller.handleFinalizeEvent(ModelUtil.CONSUMER_PID, jsonNode));
+		controller.handleFinalizeEvent(MockObjectUtil.CONSUMER_PID, jsonNode));
     }
 
     @Test
     public void handleTerminationResponse() {
-    	JsonNode jsonNode = Serializer.serializeProtocolJsonNode(ModelUtil.TERMINATION_MESSAGE);
+    	JsonNode jsonNode = Serializer.serializeProtocolJsonNode(MockObjectUtil.TERMINATION_MESSAGE);
 
-        ResponseEntity<JsonNode> response = controller.handleTerminationResponse(ModelUtil.CONSUMER_PID, jsonNode);
+        ResponseEntity<JsonNode> response = controller.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, jsonNode);
         assertNotNull(response);
         assertTrue(response.getStatusCode().is2xxSuccessful());
     }
     
     @Test
     public void handleTerminationResponse_error_service() {
-    	JsonNode jsonNode = Serializer.serializeProtocolJsonNode(ModelUtil.TERMINATION_MESSAGE);
+    	JsonNode jsonNode = Serializer.serializeProtocolJsonNode(MockObjectUtil.TERMINATION_MESSAGE);
     	doThrow(ContractNegotiationNotFoundException.class).when(contractNegotiationConsumerService)
     		.handleTerminationResponse(any(String.class), any(ContractNegotiationTerminationMessage.class));
     	assertThrows(ContractNegotiationNotFoundException.class, 
-    			() ->controller.handleTerminationResponse(ModelUtil.CONSUMER_PID, jsonNode));
+    			() ->controller.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, jsonNode));
     }
 }

--- a/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ContractNegotiationCallbackTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ContractNegotiationCallbackTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 
 public class ContractNegotiationCallbackTest {
 	
@@ -18,43 +18,43 @@ public class ContractNegotiationCallbackTest {
 	
 	@Test
 	public void getConsumerOffersCallback() {
-		String replacedUrl = ContractNegotiationCallback.getConsumerOffersCallback(URL_WITHOUT_SLASH, ModelUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = ContractNegotiationCallback.getConsumerOffersCallback(URL_WITH_SLASH, ModelUtil.CONSUMER_PID);
-		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + ModelUtil.CONSUMER_PID + "/offers", replacedUrl);
+		String replacedUrl = ContractNegotiationCallback.getConsumerOffersCallback(URL_WITHOUT_SLASH, MockObjectUtil.CONSUMER_PID);
+		String replacedUrlWithSlash = ContractNegotiationCallback.getConsumerOffersCallback(URL_WITH_SLASH, MockObjectUtil.CONSUMER_PID);
+		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + MockObjectUtil.CONSUMER_PID + "/offers", replacedUrl);
 		assertEquals(replacedUrl, replacedUrlWithSlash);
 	}
 	
 	
 	@Test
 	public void getContractAgreementCallback() {
-		String replacedUrl = ContractNegotiationCallback.getContractAgreementCallback(URL_WITHOUT_SLASH, ModelUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = ContractNegotiationCallback.getContractAgreementCallback(URL_WITH_SLASH, ModelUtil.CONSUMER_PID);
-		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + ModelUtil.CONSUMER_PID + "/agreement", replacedUrl);
+		String replacedUrl = ContractNegotiationCallback.getContractAgreementCallback(URL_WITHOUT_SLASH, MockObjectUtil.CONSUMER_PID);
+		String replacedUrlWithSlash = ContractNegotiationCallback.getContractAgreementCallback(URL_WITH_SLASH, MockObjectUtil.CONSUMER_PID);
+		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + MockObjectUtil.CONSUMER_PID + "/agreement", replacedUrl);
 		assertEquals(replacedUrl, replacedUrlWithSlash);
 	}
 	
 	@Test
 	public void getContractEventsCallback() {
-		String replacedUrl = ContractNegotiationCallback.getContractEventsCallback(URL_WITHOUT_SLASH, ModelUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = ContractNegotiationCallback.getContractEventsCallback(URL_WITH_SLASH, ModelUtil.CONSUMER_PID);
-		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + ModelUtil.CONSUMER_PID + "/events", replacedUrl);
+		String replacedUrl = ContractNegotiationCallback.getContractEventsCallback(URL_WITHOUT_SLASH, MockObjectUtil.CONSUMER_PID);
+		String replacedUrlWithSlash = ContractNegotiationCallback.getContractEventsCallback(URL_WITH_SLASH, MockObjectUtil.CONSUMER_PID);
+		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + MockObjectUtil.CONSUMER_PID + "/events", replacedUrl);
 		assertEquals(replacedUrl, replacedUrlWithSlash);
 	}
 	
 	@Test
 	public void getContractTerminationCallback() {
-		String replacedUrl = ContractNegotiationCallback.getContractTerminationCallback(URL_WITHOUT_SLASH, ModelUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = ContractNegotiationCallback.getContractTerminationCallback(URL_WITH_SLASH, ModelUtil.CONSUMER_PID);
-		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + ModelUtil.CONSUMER_PID + "/termination", replacedUrl);
+		String replacedUrl = ContractNegotiationCallback.getContractTerminationCallback(URL_WITHOUT_SLASH, MockObjectUtil.CONSUMER_PID);
+		String replacedUrlWithSlash = ContractNegotiationCallback.getContractTerminationCallback(URL_WITH_SLASH, MockObjectUtil.CONSUMER_PID);
+		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + MockObjectUtil.CONSUMER_PID + "/termination", replacedUrl);
 		assertEquals(replacedUrl, replacedUrlWithSlash);
 	}
 	
 	
 	@Test
 	public void getProviderAgreementVerificationCallback() {
-		String replacedUrl = ContractNegotiationCallback.getProviderAgreementVerificationCallback(URL_WITHOUT_SLASH, ModelUtil.PROVIDER_PID);
-		String replacedUrlWithSlash = ContractNegotiationCallback.getProviderAgreementVerificationCallback(URL_WITH_SLASH, ModelUtil.PROVIDER_PID);
-		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + ModelUtil.PROVIDER_PID + "/agreement/verification", replacedUrl);
+		String replacedUrl = ContractNegotiationCallback.getProviderAgreementVerificationCallback(URL_WITHOUT_SLASH, MockObjectUtil.PROVIDER_PID);
+		String replacedUrlWithSlash = ContractNegotiationCallback.getProviderAgreementVerificationCallback(URL_WITH_SLASH, MockObjectUtil.PROVIDER_PID);
+		assertEquals(URL_WITHOUT_SLASH + "/negotiations/" + MockObjectUtil.PROVIDER_PID + "/agreement/verification", replacedUrl);
 		assertEquals(replacedUrl, replacedUrlWithSlash);
 	}
 }

--- a/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationControllerTest.java
@@ -31,7 +31,7 @@ import it.eng.negotiation.model.ContractNegotiationEventMessage;
 import it.eng.negotiation.model.ContractNegotiationState;
 import it.eng.negotiation.model.ContractNegotiationTerminationMessage;
 import it.eng.negotiation.model.ContractRequestMessage;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.model.Reason;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.negotiation.service.ContractNegotiationProviderService;
@@ -57,16 +57,16 @@ public class ProviderContractNegotiationControllerTest {
 	}
 	
 	private ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
 			.state(ContractNegotiationState.REQUESTED)
 			.build();
 			
 	@Test
 	public void getNegotiationByProviderPid_success() throws InterruptedException, ExecutionException {
-		when(contractNegotiationService.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID))
+		when(contractNegotiationService.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID))
 			.thenReturn(contractNegotiation);
-		ResponseEntity<JsonNode> response = controller.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID);
+		ResponseEntity<JsonNode> response = controller.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID);
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		assertEquals(response.getBody().get(DSpaceConstants.TYPE).asText(), DSpaceConstants.DSPACE + ContractNegotiation.class.getSimpleName());
@@ -75,10 +75,10 @@ public class ProviderContractNegotiationControllerTest {
 	
 	@Test
 	public void getNegotiationByProviderPid_failed() throws InterruptedException, ExecutionException {
-		when(contractNegotiationService.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID))
+		when(contractNegotiationService.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID))
 			.thenThrow(ContractNegotiationNotFoundException.class);
 		
-		assertThrows(ContractNegotiationNotFoundException.class, () -> controller.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID));
+		assertThrows(ContractNegotiationNotFoundException.class, () -> controller.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID));
 	}
 	
 	@Test
@@ -86,13 +86,13 @@ public class ProviderContractNegotiationControllerTest {
 	   when(attrs.getRequest()).thenReturn(request);
 		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
                 .state(ContractNegotiationState.REQUESTED)
-                .consumerPid(ModelUtil.CONSUMER_PID)
-                .providerPid(ModelUtil.PROVIDER_PID)
+                .consumerPid(MockObjectUtil.CONSUMER_PID)
+                .providerPid(MockObjectUtil.PROVIDER_PID)
                 .build();
 		when(contractNegotiationService.startContractNegotiation(any(ContractRequestMessage.class)))
 			.thenReturn(cn);
 		
-		ResponseEntity<JsonNode> response = controller.createNegotiation(Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_REQUEST_MESSAGE));
+		ResponseEntity<JsonNode> response = controller.createNegotiation(Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_REQUEST_MESSAGE));
 		
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -105,12 +105,12 @@ public class ProviderContractNegotiationControllerTest {
 		when(contractNegotiationService.startContractNegotiation(any(ContractRequestMessage.class)))
 		.thenThrow(ProviderPidNotBlankException.class);
 		
-		assertThrows(ProviderPidNotBlankException.class, () -> controller.createNegotiation(Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_REQUEST_MESSAGE)));
+		assertThrows(ProviderPidNotBlankException.class, () -> controller.createNegotiation(Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_REQUEST_MESSAGE)));
 	}
 	
 	@Test
 	public void handleConsumerMakesOffer_success() {
-		ResponseEntity<JsonNode> response = controller.handleConsumerMakesOffer(ModelUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_REQUEST_MESSAGE));
+		ResponseEntity<JsonNode> response = controller.handleConsumerMakesOffer(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_REQUEST_MESSAGE));
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 	}
@@ -118,9 +118,9 @@ public class ProviderContractNegotiationControllerTest {
 	@Test
 	public void handleNegotiationEventMessage_success() {
 		when(contractNegotiationService.handleContractNegotationEventMessage(any(ContractNegotiationEventMessage.class)))
-			.thenReturn(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED);
+			.thenReturn(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED);
 		ResponseEntity<JsonNode> response = controller
-				.handleNegotiationEventMessage(ModelUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE_ACCEPTED));
+				.handleNegotiationEventMessage(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE_ACCEPTED));
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
@@ -128,10 +128,10 @@ public class ProviderContractNegotiationControllerTest {
 	@Test
 	public void handleVerifyAgreement_success() {
 		ContractAgreementVerificationMessage cavm = ContractAgreementVerificationMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.providerPid(ModelUtil.PROVIDER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
 				.build();
-		ResponseEntity<JsonNode> response = controller.handleVerifyAgreement(ModelUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cavm));
+		ResponseEntity<JsonNode> response = controller.handleVerifyAgreement(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cavm));
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
@@ -141,18 +141,18 @@ public class ProviderContractNegotiationControllerTest {
 		doThrow(ContractNegotiationNotFoundException.class)
 		.when(contractNegotiationService).verifyNegotiation(any(ContractAgreementVerificationMessage.class));
 		
-		assertThrows(ContractNegotiationNotFoundException.class, () -> controller.handleVerifyAgreement(ModelUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)));
+		assertThrows(ContractNegotiationNotFoundException.class, () -> controller.handleVerifyAgreement(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE)));
 	}
 	
 	@Test
 	public void handleTerminationMessage_success() {
 		ContractNegotiationTerminationMessage cntm = ContractNegotiationTerminationMessage.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.providerPid(ModelUtil.PROVIDER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
 				.code("1")
 				.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
 				.build();
-		ResponseEntity<JsonNode> response = controller.handleTerminationMessage(ModelUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cntm));
+		ResponseEntity<JsonNode> response = controller.handleTerminationMessage(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cntm));
 		assertNotNull(response, "Response is not null");
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
 	}

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
@@ -1,5 +1,6 @@
 package it.eng.negotiation.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -386,6 +387,22 @@ public class ContractNegotiationAPIServiceTest {
 		
 		verify(contractNegotiationRepository, times(0)).save(argumentCaptor.capture());
 		verify(agreementRepository, times(0)).save(argCaptorAgreement.capture());
+	}
+	
+	@Test
+	@DisplayName("Validate agreement")
+	public void vaidateAgreement() {
+		when(agreementRepository.findById(any(String.class)))
+			.thenReturn(Optional.of(ModelUtil.AGREEMENT));
+		assertDoesNotThrow(()-> service.validateAgreement(ModelUtil.AGREEMENT.getId()));
+	}
+	
+	@Test
+	@DisplayName("Validate agreement - agreement not found")
+	public void vaidateAgreement_notFound() {
+		when(agreementRepository.findById(any(String.class)))
+			.thenReturn(Optional.empty());
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.validateAgreement(ModelUtil.AGREEMENT.getId()));
 	}
 
 }

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
@@ -31,7 +31,7 @@ import it.eng.negotiation.exception.OfferNotFoundException;
 import it.eng.negotiation.model.Agreement;
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.model.Offer;
 import it.eng.negotiation.properties.ContractNegotiationProperties;
 import it.eng.negotiation.repository.AgreementRepository;
@@ -73,11 +73,11 @@ public class ContractNegotiationAPIServiceTest {
 	public void startNegotiation_success() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(properties.consumerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.consumerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
-		service.startNegotiation(ModelUtil.FORWARD_TO, Serializer.serializePlainJsonNode(ModelUtil.OFFER));
+		service.startNegotiation(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER));
 		
 		verify(contractNegotiationRepository).save(any(ContractNegotiation.class));
 		verify(offerRepository).save(any(Offer.class));
@@ -88,9 +88,9 @@ public class ContractNegotiationAPIServiceTest {
 	public void startNegotiation_failed() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-		when(properties.consumerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.consumerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.startNegotiation(ModelUtil.FORWARD_TO, Serializer.serializePlainJsonNode(ModelUtil.OFFER)));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.startNegotiation(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER)));
 		
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 	}
@@ -102,9 +102,9 @@ public class ContractNegotiationAPIServiceTest {
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.getData()).thenReturn("not a JSON");
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(properties.consumerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.consumerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.startNegotiation(ModelUtil.FORWARD_TO, Serializer.serializePlainJsonNode(ModelUtil.OFFER)));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.startNegotiation(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER)));
 		
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 	}
@@ -112,14 +112,14 @@ public class ContractNegotiationAPIServiceTest {
 	@Test
 	@DisplayName("Process posted offer - success")
 	public void postContractOffer_success() {
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class)))
 			.thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 		// plain jsonNode
-		service.sendContractOffer(ModelUtil.FORWARD_TO, Serializer.serializePlainJsonNode(ModelUtil.OFFER));
+		service.sendContractOffer(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER));
 		
 		verify(contractNegotiationRepository).save(any(ContractNegotiation.class));
 	}
@@ -128,13 +128,13 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Process posted offer - error")
 	public void postContractOffer_error() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class)))
 			.thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);
 		
 		assertThrows(ContractNegotiationAPIException.class, ()->
-			service.sendContractOffer(ModelUtil.FORWARD_TO, Serializer.serializePlainJsonNode(ModelUtil.OFFER)));
+			service.sendContractOffer(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER)));
 	}
 	
 	@Test
@@ -143,10 +143,10 @@ public class ContractNegotiationAPIServiceTest {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		
-		service.sendAgreement(ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(ModelUtil.AGREEMENT));
+		service.sendAgreement(MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(MockObjectUtil.AGREEMENT));
 		
 		verify(contractNegotiationRepository).save(any(ContractNegotiation.class));
 		verify(agreementRepository).save(any(Agreement.class));
@@ -158,10 +158,10 @@ public class ContractNegotiationAPIServiceTest {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		
-		service.sendAgreement(ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(ModelUtil.AGREEMENT));
+		service.sendAgreement(MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(MockObjectUtil.AGREEMENT));
 		
 		verify(contractNegotiationRepository).save(any(ContractNegotiation.class));
 		verify(agreementRepository).save(any(Agreement.class));
@@ -170,7 +170,7 @@ public class ContractNegotiationAPIServiceTest {
 	@Test
 	@DisplayName("Send agreement failed - negotiation not found")
 	public void sendAgreement_failedNegotiationNotFound() {
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.sendAgreement(ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(ModelUtil.AGREEMENT)));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.sendAgreement(MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(MockObjectUtil.AGREEMENT)));
 		
 		verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
@@ -181,11 +181,11 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Send agreement failed - wrong negotiation state")
 	public void sendAgreement_wrongNegotiationState() {
 		
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 
-		assertThrows(ContractNegotiationAPIException.class, () -> service.sendAgreement(ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(ModelUtil.AGREEMENT)));
+		assertThrows(ContractNegotiationAPIException.class, () -> service.sendAgreement(MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(MockObjectUtil.AGREEMENT)));
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 		verify(agreementRepository, times(0)).save(any(Agreement.class));
 	}
@@ -195,10 +195,10 @@ public class ContractNegotiationAPIServiceTest {
 	public void sendAgreement_failedBadRequest() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.sendAgreement(ModelUtil.CONSUMER_PID, ModelUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(ModelUtil.AGREEMENT)));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.sendAgreement(MockObjectUtil.CONSUMER_PID, MockObjectUtil.PROVIDER_PID, Serializer.serializePlainJsonNode(MockObjectUtil.AGREEMENT)));
 	
 		verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
@@ -211,9 +211,9 @@ public class ContractNegotiationAPIServiceTest {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_VERIFIED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED));
 		
-		service.finalizeNegotiation(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
+		service.finalizeNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE);
 		
 		verify(contractNegotiationRepository).save(any(ContractNegotiation.class));
 	}
@@ -221,7 +221,7 @@ public class ContractNegotiationAPIServiceTest {
 	@Test
 	@DisplayName("Finalize negotiation failed - negotiation not found")
 	public void finalizeNegotiation_failedNegotiationNotFound() {
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.finalizeNegotiation(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.finalizeNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
 		
 		verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
@@ -232,12 +232,12 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Finalize negotiation failed - wrong negotiation state")
 	public void finalizeNegotiation_wrongNegotiationState() {
 		
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 
 		assertThrows(ContractNegotiationAPIException.class, 
-				() -> service.finalizeNegotiation(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
+				() -> service.finalizeNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 		verify(agreementRepository, times(0)).save(any(Agreement.class));
 	}
@@ -246,10 +246,10 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Finalize negotiation error - already finalized")
 	public void finalizeNegotiation_error_finalized_state() {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString()))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_FINALIZED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_FINALIZED));
 		
 		assertThrows(ContractNegotiationAPIException.class,
-				() -> service.finalizeNegotiation(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
+				() -> service.finalizeNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
 		
 		verify(contractNegotiationRepository, times(0)).save(argumentCaptor.capture());
 	}
@@ -261,9 +261,9 @@ public class ContractNegotiationAPIServiceTest {
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(anyString(), anyString()))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_VERIFIED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED));
 		
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.finalizeNegotiation(ModelUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.finalizeNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_EVENT_MESSAGE));
 	
 		verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
@@ -274,8 +274,8 @@ public class ContractNegotiationAPIServiceTest {
 	public void findAll() {
 		when(contractNegotiationRepository.findAll())
 				.thenReturn(Arrays.asList(
-						ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED,
-						ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+						MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED,
+						MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		Collection<JsonNode> response = service.findContractNegotiations(null);
 		assertNotNull(response);
 		assertEquals(2, response.size());
@@ -285,7 +285,7 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Find contract negotiations by state")
 	public void findContractNegotiationByState() {
 		when(contractNegotiationRepository.findByState(ContractNegotiationState.ACCEPTED.name()))
-				.thenReturn(Arrays.asList(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+				.thenReturn(Arrays.asList(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		Collection<JsonNode> response = service.findContractNegotiations(ContractNegotiationState.ACCEPTED.name());
 		assertNotNull(response);
 		assertEquals(1, response.size());
@@ -296,7 +296,7 @@ public class ContractNegotiationAPIServiceTest {
 	public void handleContractNegotiationAccepted() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
 		when(contractNegotiationRepository.findById(contractNegotaitionId))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
@@ -311,7 +311,7 @@ public class ContractNegotiationAPIServiceTest {
 	public void handleContractNegotiationAccepted_invalid_state() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
 		when(contractNegotiationRepository.findById(contractNegotaitionId))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
 		assertThrows(ContractNegotiationAPIException.class, 
 				()-> service.handleContractNegotiationAccepted(contractNegotaitionId));
@@ -322,7 +322,7 @@ public class ContractNegotiationAPIServiceTest {
 	public void handleContractNegotiationAccepted_error_api() {
 		String contractNegotaitionId = UUID.randomUUID().toString();
 		when(contractNegotiationRepository.findById(contractNegotaitionId))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);
@@ -335,11 +335,11 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Provider accepts contract negotiation")
 	public void handleCNApproved() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
-		when(properties.getAssignee()).thenReturn(ModelUtil.ASSIGNEE);
-		when(offerRepository.findById(any(String.class))).thenReturn(Optional.of(ModelUtil.OFFER));
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
+		when(properties.getAssignee()).thenReturn(MockObjectUtil.ASSIGNEE);
+		when(offerRepository.findById(any(String.class))).thenReturn(Optional.of(MockObjectUtil.OFFER));
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
 		
@@ -353,7 +353,7 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Provider accepts contract negotiation - invalid initial state")
 	public void handleCNApproved_invalid_state() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_AGREED));
+		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 		
 		assertThrows(ContractNegotiationAPIException.class, 
 				() -> service.handleContractNegotiationAgreed(contractNegotaitionId));
@@ -363,7 +363,7 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Provider accepts contract negotiation - offer does not exists")
 	public void handleCNApproved_no_offer() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(offerRepository.findById(any(String.class))).thenReturn(Optional.empty());
 		
 		assertThrows(OfferNotFoundException.class, 
@@ -374,11 +374,11 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Provider accepts contract negotiation - error while contacting consumer")
 	public void handleCNApproved_error_consumer() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
-		when(properties.getAssignee()).thenReturn(ModelUtil.ASSIGNEE);
-		when(offerRepository.findById(any(String.class))).thenReturn(Optional.of(ModelUtil.OFFER));
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
+		when(properties.getAssignee()).thenReturn(MockObjectUtil.ASSIGNEE);
+		when(offerRepository.findById(any(String.class))).thenReturn(Optional.of(MockObjectUtil.OFFER));
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);
 		
@@ -393,8 +393,8 @@ public class ContractNegotiationAPIServiceTest {
 	@DisplayName("Validate agreement")
 	public void vaidateAgreement() {
 		when(agreementRepository.findById(any(String.class)))
-			.thenReturn(Optional.of(ModelUtil.AGREEMENT));
-		assertDoesNotThrow(()-> service.validateAgreement(ModelUtil.AGREEMENT.getId()));
+			.thenReturn(Optional.of(MockObjectUtil.AGREEMENT));
+		assertDoesNotThrow(()-> service.validateAgreement(MockObjectUtil.AGREEMENT.getId()));
 	}
 	
 	@Test
@@ -402,7 +402,7 @@ public class ContractNegotiationAPIServiceTest {
 	public void vaidateAgreement_notFound() {
 		when(agreementRepository.findById(any(String.class)))
 			.thenReturn(Optional.empty());
-		assertThrows(ContractNegotiationAPIException.class, ()-> service.validateAgreement(ModelUtil.AGREEMENT.getId()));
+		assertThrows(ContractNegotiationAPIException.class, ()-> service.validateAgreement(MockObjectUtil.AGREEMENT.getId()));
 	}
 
 }

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
@@ -28,7 +28,7 @@ import it.eng.negotiation.model.ContractAgreementVerificationMessage;
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationEventType;
 import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.model.Offer;
 import it.eng.negotiation.properties.ContractNegotiationProperties;
 import it.eng.negotiation.repository.AgreementRepository;
@@ -58,7 +58,7 @@ public class ContractNegotiationConsumerServiceTest {
 	@Test
 	@DisplayName("Process contract offer success")
 	public void processContractOffer_success() {
-		service.processContractOffer(ModelUtil.CONTRACT_OFFER_MESSAGE);
+		service.processContractOffer(MockObjectUtil.CONTRACT_OFFER_MESSAGE);
 		verify(offerRepository).save(any(Offer.class));
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 		assertEquals(ContractNegotiationState.OFFERED, argCaptorContractNegotiation.getValue().getState());
@@ -67,16 +67,16 @@ public class ContractNegotiationConsumerServiceTest {
 	@Test
 	@DisplayName("Process negotiation offer consumer success")
 	public void handleNegotiationOfferConsumer_success() {
-		service.handleNegotiationOfferConsumer(ModelUtil.CONSUMER_PID, ModelUtil.CONTRACT_OFFER_MESSAGE);
+		service.handleNegotiationOfferConsumer(MockObjectUtil.CONSUMER_PID, MockObjectUtil.CONTRACT_OFFER_MESSAGE);
 	}
 	
 	@Test
 	@DisplayName("Process agreement message - automatic negotiation - ON success")
 	public void handleAgreement_success() {
 		when(properties.isAutomaticNegotiation()).thenReturn(true);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
-		service.handleAgreement(ModelUtil.CONTRACT_AGREEMENT_MESSAGE);
+		service.handleAgreement(MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE);
 		
 		verify(publisher).publishEvent(any(ContractAgreementVerificationMessage.class));
 	}
@@ -85,11 +85,11 @@ public class ContractNegotiationConsumerServiceTest {
 	@DisplayName("Process agreement message - automatic negotiation OFF - success")
 	public void handleAgreement_off_success() {
 		when(properties.isAutomaticNegotiation()).thenReturn(false);
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		
-		service.handleAgreement( ModelUtil.CONTRACT_AGREEMENT_MESSAGE);
+		service.handleAgreement( MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE);
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 		verify(agreementRepository).save(any(Agreement.class));
 		//verify that status is updated to AGREED
@@ -100,11 +100,11 @@ public class ContractNegotiationConsumerServiceTest {
 	@Test
 	@DisplayName("Process agreement message - automatic negotiation OFF - negotiation not found")
 	public void handleAgreement_off_negotiationNotFound() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID)).thenReturn(Optional.ofNullable(null));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID)).thenReturn(Optional.ofNullable(null));
 
-		assertThrows(ContractNegotiationNotFoundException.class, () -> service.handleAgreement( ModelUtil.CONTRACT_AGREEMENT_MESSAGE));
+		assertThrows(ContractNegotiationNotFoundException.class, () -> service.handleAgreement( MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE));
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 		verify(agreementRepository, times(0)).save(any(Agreement.class));
 	}
@@ -113,11 +113,11 @@ public class ContractNegotiationConsumerServiceTest {
 	@DisplayName("Process agreement message - automatic negotiation OFF - wrong negotiation state")
 	public void handleAgreement_off_wrongNegotiationState() {
 		
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_OFFERED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_OFFERED));
 
-		assertThrows(ContractNegotiationInvalidStateException.class, () -> service.handleAgreement( ModelUtil.CONTRACT_AGREEMENT_MESSAGE));
+		assertThrows(ContractNegotiationInvalidStateException.class, () -> service.handleAgreement( MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE));
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 		verify(agreementRepository, times(0)).save(any(Agreement.class));
 	}
@@ -125,12 +125,12 @@ public class ContractNegotiationConsumerServiceTest {
 	@Test
 	@DisplayName("Process agreement message - automatic negotiation OFF - offer not found")
 	public void handleAgreement_off_offerNotFound() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED_NO_OFFER));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID))
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED_NO_OFFER));
 
-		assertThrows(OfferNotFoundException.class, () -> service.handleAgreement( ModelUtil.CONTRACT_AGREEMENT_MESSAGE));
+		assertThrows(OfferNotFoundException.class, () -> service.handleAgreement( MockObjectUtil.CONTRACT_AGREEMENT_MESSAGE));
 		
-		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(ModelUtil.PROVIDER_PID, ModelUtil.CONSUMER_PID);
+		verify(contractNegotiationRepository).findByProviderPidAndConsumerPid(MockObjectUtil.PROVIDER_PID, MockObjectUtil.CONSUMER_PID);
 		verify(contractNegotiationRepository, times(0)).save(any(ContractNegotiation.class));
 		verify(agreementRepository, times(0)).save(any(Agreement.class));
 	}
@@ -138,8 +138,8 @@ public class ContractNegotiationConsumerServiceTest {
 	@Test
 	@DisplayName("Process FINALIZED event message - response success")
 	public void handleFinalizeEvent_success() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_VERIFIED));
-		service.handleFinalizeEvent(ModelUtil.getEventMessage(ContractNegotiationEventType.FINALIZED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED));
+		service.handleFinalizeEvent(MockObjectUtil.getEventMessage(ContractNegotiationEventType.FINALIZED));
 	
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 
@@ -153,7 +153,7 @@ public class ContractNegotiationConsumerServiceTest {
 	public void handleFinalizeEvent_wrongEventType() {
 	
 		assertThrows(ContractNegotiationInvalidEventTypeException.class,
-				() -> service.handleFinalizeEvent(ModelUtil.getEventMessage(ContractNegotiationEventType.ACCEPTED)));
+				() -> service.handleFinalizeEvent(MockObjectUtil.getEventMessage(ContractNegotiationEventType.ACCEPTED)));
 	
 	}
 	
@@ -163,25 +163,25 @@ public class ContractNegotiationConsumerServiceTest {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.empty());
 		
 		assertThrows(ContractNegotiationNotFoundException.class,
-				() -> service.handleFinalizeEvent(ModelUtil.getEventMessage(ContractNegotiationEventType.FINALIZED)));
+				() -> service.handleFinalizeEvent(MockObjectUtil.getEventMessage(ContractNegotiationEventType.FINALIZED)));
 	}
 	
 	@Test
 	@DisplayName("Process FINALIZED event message - invalid state")
 	public void handleFinalizeEvent_invalidState() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_AGREED));
+		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 		
 		assertThrows(ContractNegotiationInvalidStateException.class,
-				() -> service.handleFinalizeEvent(ModelUtil.getEventMessage(ContractNegotiationEventType.FINALIZED)));
+				() -> service.handleFinalizeEvent(MockObjectUtil.getEventMessage(ContractNegotiationEventType.FINALIZED)));
 	}
 	
 	@Test
 	@DisplayName("Process termination message success")
 	public void handleTerminationResponse_success() {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 
-		service.handleTerminationResponse(ModelUtil.CONSUMER_PID, ModelUtil.TERMINATION_MESSAGE);
+		service.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE);
 		
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 		assertEquals(ContractNegotiationState.TERMINATED, argCaptorContractNegotiation.getValue().getState());
@@ -194,7 +194,7 @@ public class ContractNegotiationConsumerServiceTest {
 			.thenReturn(Optional.empty());
 
 		assertThrows(ContractNegotiationNotFoundException.class, 
-				() -> service.handleTerminationResponse(ModelUtil.CONSUMER_PID, ModelUtil.TERMINATION_MESSAGE));
+				() -> service.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE));
 	}
 	
 	

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationEventHandlerServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationEventHandlerServiceTest.java
@@ -26,7 +26,7 @@ import it.eng.negotiation.exception.ContractNegotiationNotFoundException;
 import it.eng.negotiation.model.Agreement;
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.properties.ContractNegotiationProperties;
 import it.eng.negotiation.repository.AgreementRepository;
 import it.eng.negotiation.repository.ContractNegotiationRepository;
@@ -63,15 +63,15 @@ public class ContractNegotiationEventHandlerServiceTest {
 	@Test
 	@DisplayName("Handle contract negotiation offer response success")
 	public void handleContractNegotiationOfferResponse_accepted_success() {
-		ContractNegotiationOfferResponseEvent offerResponse = new ContractNegotiationOfferResponseEvent(ModelUtil.CONSUMER_PID, 
-				ModelUtil.PROVIDER_PID, true, Serializer.serializePlainJsonNode(ModelUtil.OFFER));
-		when(properties.getAssignee()).thenReturn(ModelUtil.ASSIGNEE);
-		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		ContractNegotiationOfferResponseEvent offerResponse = new ContractNegotiationOfferResponseEvent(MockObjectUtil.CONSUMER_PID, 
+				MockObjectUtil.PROVIDER_PID, true, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER));
+		when(properties.getAssignee()).thenReturn(MockObjectUtil.ASSIGNEE);
+		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
 		// TODO temporary until figure out how to get assignee and assigner
-		when(properties.providerCallbackAddress()).thenReturn(ModelUtil.CALLBACK_ADDRESS);
+		when(properties.providerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
 		handlerService.handleContractNegotiationOfferResponse(offerResponse);
 		
@@ -81,10 +81,10 @@ public class ContractNegotiationEventHandlerServiceTest {
 	@Test
 	@DisplayName("Handle contract negotiation offer declined")
 	public void handleContractNegotiationOfferResponse_declined() {
-		ContractNegotiationOfferResponseEvent offerResponse = new ContractNegotiationOfferResponseEvent(ModelUtil.CONSUMER_PID, 
-				ModelUtil.PROVIDER_PID, false, Serializer.serializeProtocolJsonNode(ModelUtil.OFFER));
+		ContractNegotiationOfferResponseEvent offerResponse = new ContractNegotiationOfferResponseEvent(MockObjectUtil.CONSUMER_PID, 
+				MockObjectUtil.PROVIDER_PID, false, Serializer.serializeProtocolJsonNode(MockObjectUtil.OFFER));
 		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
 		handlerService.handleContractNegotiationOfferResponse(offerResponse);
 		
@@ -95,11 +95,11 @@ public class ContractNegotiationEventHandlerServiceTest {
 	@DisplayName("Handle agreement verification message success")
 	public void contractAgreementVerificationMessage_success() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
-		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_AGREED));
+		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
 
-		handlerService.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
+		handlerService.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
 		
 		verify(repository).save(any(ContractNegotiation.class));
 	}
@@ -109,33 +109,33 @@ public class ContractNegotiationEventHandlerServiceTest {
 	public void contractAgreementVerificationMessage_contractNegotiationNotFound() {
 		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.empty());
 
-		assertThrows(ContractNegotiationAPIException.class, () -> handlerService.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
+		assertThrows(ContractNegotiationAPIException.class, () -> handlerService.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
 	}
 	
 	@Test
 	@DisplayName("Handle agreement verification message - invalid state")
 	public void contractAgreementVerificationMessage_invalidState() {
-		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
-		assertThrows(ContractNegotiationAPIException.class, () -> handlerService.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
+		assertThrows(ContractNegotiationAPIException.class, () -> handlerService.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
 	}
 	
 	@Test
 	@DisplayName("Handle agreement verification message - bad request")
 	public void contractAgreementVerificationMessage_badRequest() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
-		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_AGREED));
+		when(repository.findByProviderPidAndConsumerPid(any(String.class), any(String.class))).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		
 		assertThrows(ContractNegotiationAPIException.class, 
-				() -> handlerService.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
+				() -> handlerService.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
 	}
 	
 	@Test
 	@DisplayName("Provider terminate contract negotiation")
 	public void terminateNegotiation() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(repository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(repository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
@@ -162,7 +162,7 @@ public class ContractNegotiationEventHandlerServiceTest {
 	@DisplayName("Provider terminate contract negotiation - consumer did not respond")
 	public void terminateNegotiation_consumer_error() {
 		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(repository.findById(contractNegotaitionId)).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_REQUESTED));
+		when(repository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationProviderServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationProviderServiceTest.java
@@ -32,7 +32,7 @@ import it.eng.negotiation.listener.ContractNegotiationPublisher;
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationState;
 import it.eng.negotiation.model.ContractRequestMessage;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.properties.ContractNegotiationProperties;
 import it.eng.negotiation.repository.ContractNegotiationRepository;
 import it.eng.negotiation.repository.OfferRepository;
@@ -72,14 +72,14 @@ public class ContractNegotiationProviderServiceTest {
         when(repository.findByProviderPidAndConsumerPid(eq(null), anyString())).thenReturn(Optional.ofNullable(null));
     	when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
     	when(apiResponse.isSuccess()).thenReturn(true);
-        ContractNegotiation result = service.startContractNegotiation(ModelUtil.CONTRACT_REQUEST_MESSAGE);
+        ContractNegotiation result = service.startContractNegotiation(MockObjectUtil.CONTRACT_REQUEST_MESSAGE);
         assertNotNull(result);
         assertEquals(result.getType(), "dspace:ContractNegotiation");
         verify(repository).save(argCaptorContractNegotiation.capture());
 		//verify that status is updated to REQUESTED
 		assertEquals(ContractNegotiationState.REQUESTED, argCaptorContractNegotiation.getValue().getState());
-		assertEquals(ModelUtil.CALLBACK_ADDRESS, argCaptorContractNegotiation.getValue().getCallbackAddress());
-		assertEquals(ModelUtil.CONSUMER_PID, argCaptorContractNegotiation.getValue().getConsumerPid());
+		assertEquals(MockObjectUtil.CALLBACK_ADDRESS, argCaptorContractNegotiation.getValue().getCallbackAddress());
+		assertEquals(MockObjectUtil.CONSUMER_PID, argCaptorContractNegotiation.getValue().getConsumerPid());
 		assertNotNull(argCaptorContractNegotiation.getValue().getProviderPid());
 		verify(publisher).publishEvent(any(ContractNegotationOfferRequestEvent.class));
     }
@@ -91,14 +91,14 @@ public class ContractNegotiationProviderServiceTest {
         when(credentialUtils.getAPICredentials()).thenReturn("credentials");
     	when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
     	when(apiResponse.isSuccess()).thenReturn(true);
-        ContractNegotiation result = service.startContractNegotiation(ModelUtil.CONTRACT_REQUEST_MESSAGE);
+        ContractNegotiation result = service.startContractNegotiation(MockObjectUtil.CONTRACT_REQUEST_MESSAGE);
         assertNotNull(result);
         assertEquals(result.getType(), "dspace:ContractNegotiation");
         verify(repository).save(argCaptorContractNegotiation.capture());
 		//verify that status is updated to REQUESTED
         assertEquals(ContractNegotiationState.REQUESTED, argCaptorContractNegotiation.getValue().getState());
-		assertEquals(ModelUtil.CALLBACK_ADDRESS, argCaptorContractNegotiation.getValue().getCallbackAddress());
-		assertEquals(ModelUtil.CONSUMER_PID, argCaptorContractNegotiation.getValue().getConsumerPid());
+		assertEquals(MockObjectUtil.CALLBACK_ADDRESS, argCaptorContractNegotiation.getValue().getCallbackAddress());
+		assertEquals(MockObjectUtil.CONSUMER_PID, argCaptorContractNegotiation.getValue().getConsumerPid());
 		assertNotNull(argCaptorContractNegotiation.getValue().getProviderPid());
 		verify(publisher, times(0)).publishEvent(any(ContractNegotationOfferRequestEvent.class));
     }
@@ -107,10 +107,10 @@ public class ContractNegotiationProviderServiceTest {
     @DisplayName("Start contract negotiation failed - provider pid not blank")
     public void startContractNegotiation_providerPidNotBlank() throws InterruptedException {
     	ContractRequestMessage contractRequestMessage = ContractRequestMessage.Builder.newInstance()
-    			.callbackAddress(ModelUtil.CALLBACK_ADDRESS)
-    			.consumerPid(ModelUtil.CONSUMER_PID)
-    			.providerPid(ModelUtil.PROVIDER_PID)
-    			.offer(ModelUtil.OFFER)
+    			.callbackAddress(MockObjectUtil.CALLBACK_ADDRESS)
+    			.consumerPid(MockObjectUtil.CONSUMER_PID)
+    			.providerPid(MockObjectUtil.PROVIDER_PID)
+    			.offer(MockObjectUtil.OFFER)
     			.build();
     	
         assertThrows(ProviderPidNotBlankException.class,()-> service.startContractNegotiation(contractRequestMessage));
@@ -120,9 +120,9 @@ public class ContractNegotiationProviderServiceTest {
     @Test
     @DisplayName("Start contract negotiation failed - contract negotiation exists")
     public void startContractNegotiation_contractNegotiationExists() throws InterruptedException {
-        when(repository.findByProviderPidAndConsumerPid(eq(null), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+        when(repository.findByProviderPidAndConsumerPid(eq(null), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
     	
-        assertThrows(ContractNegotiationExistsException.class,()-> service.startContractNegotiation(ModelUtil.CONTRACT_REQUEST_MESSAGE));
+        assertThrows(ContractNegotiationExistsException.class,()-> service.startContractNegotiation(MockObjectUtil.CONTRACT_REQUEST_MESSAGE));
         verify(repository, times(0)).save(any(ContractNegotiation.class));
     }
     
@@ -134,21 +134,21 @@ public class ContractNegotiationProviderServiceTest {
     	when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
     	when(apiResponse.isSuccess()).thenReturn(false);
     	
-        assertThrows(OfferNotValidException.class,()-> service.startContractNegotiation(ModelUtil.CONTRACT_REQUEST_MESSAGE));
+        assertThrows(OfferNotValidException.class,()-> service.startContractNegotiation(MockObjectUtil.CONTRACT_REQUEST_MESSAGE));
         verify(repository, times(0)).save(any(ContractNegotiation.class));
     }
 
     @Test
     @DisplayName("Get negotiation by provider pid - success")
     public void getNegotiationByProviderPid() {
-        when(repository.findByProviderPid(anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+        when(repository.findByProviderPid(anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
-        ContractNegotiation result = service.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID);
+        ContractNegotiation result = service.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID);
 
         assertNotNull(result);
 
-        assertEquals(result.getConsumerPid(), ModelUtil.CONSUMER_PID);
-        assertEquals(result.getProviderPid(), ModelUtil.PROVIDER_PID);
+        assertEquals(result.getConsumerPid(), MockObjectUtil.CONSUMER_PID);
+        assertEquals(result.getProviderPid(), MockObjectUtil.PROVIDER_PID);
         assertEquals(result.getState(), ContractNegotiationState.ACCEPTED);
     }
 
@@ -156,21 +156,21 @@ public class ContractNegotiationProviderServiceTest {
     @DisplayName("Get negotiation by provider pid - negotiation not found")
     public void getNegotiationByProviderPid_notFound() {
         when(repository.findByProviderPid(anyString())).thenReturn(Optional.ofNullable(null));
-        assertThrows(ContractNegotiationNotFoundException.class, () -> service.getNegotiationByProviderPid(ModelUtil.PROVIDER_PID),
+        assertThrows(ContractNegotiationNotFoundException.class, () -> service.getNegotiationByProviderPid(MockObjectUtil.PROVIDER_PID),
                 "Expected getNegotiationByProviderPid to throw, but it didn't");
     }
     
     @Test
     @DisplayName("Get negotiation by id - success")
     public void getNegotiationById() {
-        when(repository.findById(anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+        when(repository.findById(anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
-        ContractNegotiation result = service.getNegotiationById(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId());
+        ContractNegotiation result = service.getNegotiationById(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId());
 
         assertNotNull(result);
 
-        assertEquals(result.getConsumerPid(), ModelUtil.CONSUMER_PID);
-        assertEquals(result.getProviderPid(), ModelUtil.PROVIDER_PID);
+        assertEquals(result.getConsumerPid(), MockObjectUtil.CONSUMER_PID);
+        assertEquals(result.getProviderPid(), MockObjectUtil.PROVIDER_PID);
         assertEquals(result.getState(), ContractNegotiationState.ACCEPTED);
     }
 
@@ -178,16 +178,16 @@ public class ContractNegotiationProviderServiceTest {
     @DisplayName("Get negotiation by id - negotiation not found")
     public void getNegotiationById_notFound() {
         when(repository.findById(anyString())).thenReturn(Optional.empty());
-        assertThrows(ContractNegotiationNotFoundException.class, () -> service.getNegotiationById(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId()),
+        assertThrows(ContractNegotiationNotFoundException.class, () -> service.getNegotiationById(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId()),
                 "Expected getNegotiationByProviderPid to throw, but it didn't");
     }
     
     @Test
     @DisplayName("Verify negotiation - success")
     public void verifyNegotiation_success() {
-        when(repository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_AGREED));
+        when(repository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 
-    	service.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
+    	service.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE);
     	
 		verify(repository).save(argCaptorContractNegotiation.capture());
 		
@@ -200,15 +200,15 @@ public class ContractNegotiationProviderServiceTest {
     public void verifyNegotiation_negotiationNotFound() {
         when(repository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.empty());
 
-        assertThrows(ContractNegotiationNotFoundException.class, () -> service.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
+        assertThrows(ContractNegotiationNotFoundException.class, () -> service.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
     }
     
     @Test
     @DisplayName("Verify negotiation - invalid state")
     public void verifyNegotiation_invalidState() {
-        when(repository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(ModelUtil.CONTRACT_NEGOTIATION_ACCEPTED));
+        when(repository.findByProviderPidAndConsumerPid(anyString(), anyString())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED));
 
-        assertThrows(ContractNegotiationInvalidStateException.class, () -> service.verifyNegotiation(ModelUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
+        assertThrows(ContractNegotiationInvalidStateException.class, () -> service.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
     }
 
 }

--- a/negotiation/src/test/java/it/eng/negotiation/transformer/from/JsonFromContractNegotiationTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/transformer/from/JsonFromContractNegotiationTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import it.eng.negotiation.model.ContractNegotiation;
 import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.tools.model.DSpaceConstants;
 
 public class JsonFromContractNegotiationTest {
@@ -18,8 +18,8 @@ public class JsonFromContractNegotiationTest {
 	public void transformToJson() {
 		ContractNegotiation message = 
 				ContractNegotiation.Builder.newInstance()
-				.consumerPid(ModelUtil.CONSUMER_PID)
-				.providerPid(ModelUtil.PROVIDER_PID)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
 				.state(ContractNegotiationState.ACCEPTED)
 				.build();
 		

--- a/negotiation/src/test/java/it/eng/negotiation/transformer/from/JsonFromContractRequestMessageTransformerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/transformer/from/JsonFromContractRequestMessageTransformerTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
 
 import it.eng.negotiation.model.ContractRequestMessage;
-import it.eng.negotiation.model.ModelUtil;
+import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.tools.model.DSpaceConstants;
 
 public class JsonFromContractRequestMessageTransformerTest {
@@ -17,8 +17,8 @@ public class JsonFromContractRequestMessageTransformerTest {
 	public void transform() {
 		ContractRequestMessage contractRequestMessage = ContractRequestMessage.Builder.newInstance()
 				.callbackAddress("https://callback.address.test.mock")
-				.offer(ModelUtil.OFFER)
-				.consumerPid(ModelUtil.CONSUMER_PID)
+				.offer(MockObjectUtil.OFFER)
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
 				.build();
 		
 		var jsonNode = transformer.transform(contractRequestMessage);

--- a/tools/src/main/java/it/eng/tools/client/rest/OkHttpRestClient.java
+++ b/tools/src/main/java/it/eng/tools/client/rest/OkHttpRestClient.java
@@ -47,10 +47,15 @@ public class OkHttpRestClient {
 	 */
 	public GenericApiResponse<String> sendRequestProtocol(String targetAddress, JsonNode jsonNode, String authorization) {
 		// send response to targetAddress
-		RequestBody body = RequestBody.create(jsonNode.toPrettyString(), MediaType.parse("application/json"));
 		Request.Builder requestBuilder = new Request.Builder()
-			      .url(targetAddress)
-			      .post(body);
+				.url(targetAddress);
+		if(jsonNode != null) {
+			RequestBody body = RequestBody.create(jsonNode.toPrettyString(), MediaType.parse("application/json"));
+			requestBuilder.post(body);
+		} else {
+			RequestBody body = RequestBody.create("", MediaType.parse("application/json"));
+			requestBuilder.post(body);
+		}
 		if(StringUtils.isNotBlank(authorization)) {
 			requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, authorization);
 		}

--- a/tools/src/main/java/it/eng/tools/controller/ApiEndpoints.java
+++ b/tools/src/main/java/it/eng/tools/controller/ApiEndpoints.java
@@ -1,0 +1,8 @@
+package it.eng.tools.controller;
+
+public interface ApiEndpoints {
+
+	public static final String NEGOTIATION_AGREEMENTS_V1 ="/api/v1/agreements";
+	public static final String CATALOG_OFFERS_V1 = "/api/v1/offers";
+	public static final String TRANSFER_DATATRANSFER_V1 = "/api/v1/transfers";
+}

--- a/tools/src/main/java/it/eng/tools/model/DSpaceConstants.java
+++ b/tools/src/main/java/it/eng/tools/model/DSpaceConstants.java
@@ -6,6 +6,10 @@ public interface DSpaceConstants {
 		REQUESTED, OFFERED, ACCEPTED, AGREED, VERIFIED, FINALIZED, TERMINATED
 	}
 	
+	public static enum DataTransferStates {
+		REQUESTED, STARTED, COMPLETED, SUSPENDED, TERMINATED
+	}
+	
 	public static enum ContractNegotiationEvent {
 		ACCEPTED, FINALIZED;
 	}

--- a/tools/src/main/java/it/eng/tools/response/GenericApiResponse.java
+++ b/tools/src/main/java/it/eng/tools/response/GenericApiResponse.java
@@ -5,19 +5,26 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Data
 @Builder
 @AllArgsConstructor
-public class GenericApiResponse<T> {
-    private boolean success;
+@NoArgsConstructor
+public class GenericApiResponse<T> implements Serializable {
+	
+	private static final long serialVersionUID = -1433451249888939134L;
+	
+	private boolean success;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    //, pattern = "dd-MM-yyyy HH:mm:ss"
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalDateTime timestamp;
     private int httpStatus;
 


### PR DESCRIPTION
### Added

 - TransferStartMessage logic for provider and consumer callback (controller and service layer)
 - Negotiation module - API endpoint for agreement check (valid or not)
 
## Updated

 - code coverage (junit and integration)
 - TransferRequestMessage - call to negotiation for agreement validity check before proceeding
 - postman collection