### PR TITLE
Feature/terminate contract negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 21-11-2024
+
+### Changed
+
+ - ContractNegotiation.callbackAddress on consumer side value set to provider address
+ - Terminate negotiation API request - based on role, it sends to provider protocol address or consumer callback address
+
+### Added
+
+ - Provider handleTermination request
+
 ## [0.1.1] - 19-11-2024
 
 ### Changed

--- a/True_connector_DSP.postman_collection.json
+++ b/True_connector_DSP.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "976b0794-c898-456b-b8e1-02f21a0bdc7f",
+		"_postman_id": "7d2a07b5-b19e-4566-b543-54ba2d7de487",
 		"name": "True_connector_DSP",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "36278855"
@@ -662,7 +662,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"Forward-To\": \"{{PROVIDER}}/negotiations/request\",\r\n    \"offer\": {\r\n        \"@id\": \"urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5\",\r\n        \"target\": \"urn:uuid:TARGET\",\r\n        \"assigner\": \"urn:uuid:ASSIGNER_PROVIDER\",\r\n        \"permission\": [\r\n            {\r\n                \"target\": \"urn:uuid:TARGET\",\r\n                \"action\": \"USE\",\r\n                \"constraint\": [\r\n                    {\r\n                        \"leftOperand\": \"COUNT\",\r\n                        \"operator\": \"EQ\",\r\n                        \"rightOperand\": \"5\"\r\n                    }\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+									"raw": "{\r\n    \"Forward-To\": \"{{PROVIDER}}\",\r\n    \"offer\": {\r\n        \"@id\": \"urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5\",\r\n        \"target\": \"urn:uuid:fdc45798-a222-4955-8baf-ab7fd66ac4d5\",\r\n        \"assigner\": \"urn:uuid:ASSIGNER_PROVIDER\",\r\n        \"permission\": [\r\n            {\r\n                \"action\": \"USE\",\r\n                \"constraint\": [\r\n                    {\r\n                        \"leftOperand\": \"COUNT\",\r\n                        \"operator\": \"LTEQ\",\r\n                        \"rightOperand\": \"5\"\r\n                    }\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/ci/docker/test-cases/negotiation-tests/negotiation-tests.json
+++ b/ci/docker/test-cases/negotiation-tests/negotiation-tests.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "04c08cce-8b0b-4708-b7c8-ee0c4e19c16d",
+		"_postman_id": "da605012-3910-469e-9a15-7f38358c649e",
 		"name": "Negotiation tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21815221",
-		"_collection_link": "https://true-connector.postman.co/workspace/6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/21815221-04c08cce-8b0b-4708-b7c8-ee0c4e19c16d?action=share&source=collection_link&creator=21815221"
+		"_exporter_id": "36278855"
 	},
 	"item": [
 		{
@@ -46,7 +45,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"Forward-To\": \"{{PROVIDER_PROTOCOL_ENDPOINT}}/request\",\r\n    \"offer\": {\r\n        \"@id\": \"urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5\",\r\n        \"target\": \"{{datasetId}}\",\r\n        \"assigner\": \"urn:uuid:ASSIGNER_PROVIDER\",\r\n        \"permission\": [\r\n            {\r\n                \"action\": \"USE\",\r\n                \"constraint\": [\r\n                    {\r\n                        \"leftOperand\": \"COUNT\",\r\n                        \"operator\": \"LTEQ\",\r\n                        \"rightOperand\": \"5\"\r\n                    }\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+							"raw": "{\r\n    \"Forward-To\": \"{{PROVIDER_PROTOCOL_ENDPOINT}}\",\r\n    \"offer\": {\r\n        \"@id\": \"urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5\",\r\n        \"target\": \"{{datasetId}}\",\r\n        \"assigner\": \"urn:uuid:ASSIGNER_PROVIDER\",\r\n        \"permission\": [\r\n            {\r\n                \"action\": \"USE\",\r\n                \"constraint\": [\r\n                    {\r\n                        \"leftOperand\": \"COUNT\",\r\n                        \"operator\": \"LTEQ\",\r\n                        \"rightOperand\": \"5\"\r\n                    }\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -780,7 +779,7 @@
 		},
 		{
 			"key": "PROVIDER_PROTOCOL_ENDPOINT",
-			"value": "http://172.17.0.1:8090/negotiations",
+			"value": "http://172.17.0.1:8090/",
 			"type": "string"
 		},
 		{

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
@@ -1,0 +1,179 @@
+package it.eng.connector.integration.negotiation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.ResultActions;
+
+import it.eng.connector.integration.BaseIntegrationTest;
+import it.eng.connector.util.TestUtil;
+import it.eng.negotiation.model.ContractNegotiation;
+import it.eng.negotiation.model.ContractNegotiationErrorMessage;
+import it.eng.negotiation.model.ContractNegotiationState;
+import it.eng.negotiation.model.ContractNegotiationTerminationMessage;
+import it.eng.negotiation.model.Reason;
+import it.eng.negotiation.repository.ContractNegotiationRepository;
+import it.eng.negotiation.serializer.Serializer;
+import it.eng.tools.model.IConstants;
+
+public class ContractNegotiationTerminateIntegrationTest extends BaseIntegrationTest {
+
+	private static final String CALLBACK_ADDRESS = "http://localhost:8080/consumer";
+
+	private static final String INVALID_PID = "INVALID_PID";
+	
+	@Autowired
+	private ContractNegotiationRepository contractNegotiationRepository;
+
+    @Test
+    @DisplayName("Provider endpoint terminate negotiation - success")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void providerTerminateNegotiation_success() throws Exception {
+    	ContractNegotiation cn = createContractNegotiation();
+    	
+    	ContractNegotiationTerminationMessage terminaionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
+    			.consumerPid(cn.getConsumerPid())
+    			.providerPid(cn.getProviderPid())
+    			.code("test")
+    			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
+    			.build();
+    	String body = Serializer.serializeProtocol(terminaionMessage);
+    	
+    	//negotiations/:id/termination resource
+    	final ResultActions result =
+    			mockMvc.perform(
+    					post("/negotiations/" + cn.getProviderPid() + "/termination")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	// result is 200 OK
+    	result.andExpect(status().isOk())
+    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	
+    	// cleanup
+    	contractNegotiationRepository.delete(cn);
+    }
+    
+    @Test
+    @DisplayName("Provider endpoint terminate negotiation - wrong Pid")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void providerTerminateNegotiation_error() throws Exception {
+    	ContractNegotiation cn = createContractNegotiation();
+    	
+    	ContractNegotiationTerminationMessage terminaionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
+    			.consumerPid(cn.getConsumerPid())
+    			.providerPid(cn.getProviderPid())
+    			.code("test")
+    			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
+    			.build();
+    	String body = Serializer.serializeProtocol(terminaionMessage);
+    	
+    	//negotiations/:id/termination resource
+    	final ResultActions result =
+    			mockMvc.perform(
+    					post("/negotiations/" + INVALID_PID + "/termination")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	// result is 400 error
+    	result.andExpect(status().is4xxClientError())
+    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	
+    	ContractNegotiationErrorMessage erroMessage = Serializer.deserializeProtocol(result.andReturn().getResponse().getContentAsString(), 
+    			ContractNegotiationErrorMessage.class);
+    	assertNotNull(erroMessage);
+    	assertEquals(cn.getConsumerPid(), erroMessage.getConsumerPid());
+    	assertEquals(INVALID_PID, erroMessage.getProviderPid());
+    	
+    	// cleanup
+    	contractNegotiationRepository.delete(cn);
+    }
+
+    @Test
+    @DisplayName("Consumer callback endpoint terminate negotiation - success")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void consumerTerminateNegotiation_success() throws Exception {
+    	ContractNegotiation cn = createContractNegotiation();
+    	
+    	ContractNegotiationTerminationMessage terminaionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
+    			.consumerPid(cn.getConsumerPid())
+    			.providerPid(cn.getProviderPid())
+    			.code("test")
+    			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
+    			.build();
+    	String body = Serializer.serializeProtocol(terminaionMessage);
+    	
+    	// /consumer/negotiations/{consumerPid}/termination
+    	final ResultActions result =
+    			mockMvc.perform(
+    					post("/consumer/negotiations/" + cn.getConsumerPid() + "/termination")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	// result is 200 OK
+    	result.andExpect(status().isOk())
+    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	
+    	// cleanup
+    	contractNegotiationRepository.delete(cn);
+    }
+    
+    @Test
+    @DisplayName("Consumer callback endpoint terminate negotiation - invalid Pid")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void consumerTerminateNegotiation_error() throws Exception {
+    	ContractNegotiation cn = createContractNegotiation();
+    	
+    	ContractNegotiationTerminationMessage terminaionMessage = ContractNegotiationTerminationMessage.Builder.newInstance()
+    			.consumerPid(cn.getConsumerPid())
+    			.providerPid(cn.getProviderPid())
+    			.code("test")
+    			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
+    			.build();
+    	String body = Serializer.serializeProtocol(terminaionMessage);
+    	
+    	// /consumer/negotiations/{consumerPid}/termination
+    	final ResultActions result =
+    			mockMvc.perform(
+    					post("/consumer/negotiations/" + INVALID_PID + "/termination")
+    					.content(body)
+    					.contentType(MediaType.APPLICATION_JSON));
+    	// result is 400 error
+    	result.andExpect(status().is4xxClientError())
+    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	ContractNegotiationErrorMessage erroMessage = Serializer.deserializeProtocol(result.andReturn().getResponse().getContentAsString(), 
+    			ContractNegotiationErrorMessage.class);
+    	assertNotNull(erroMessage);
+    	assertEquals(INVALID_PID, erroMessage.getConsumerPid());
+    	assertEquals(cn.getProviderPid(), erroMessage.getProviderPid());
+    	
+    	// cleanup
+    	contractNegotiationRepository.delete(cn);
+    }
+    
+    private String createNewId() {
+        return UUID.randomUUID().toString();
+    }
+    
+	private ContractNegotiation createContractNegotiation() {
+		ContractNegotiation cn = ContractNegotiation.Builder.newInstance()
+    			.consumerPid(createNewId())
+    			.providerPid(createNewId())
+    			.callbackAddress(CALLBACK_ADDRESS)
+    			.role(IConstants.ROLE_PROVIDER)
+    			.state(ContractNegotiationState.REQUESTED)
+    			.build();
+    	contractNegotiationRepository.save(cn);
+		return cn;
+	}
+	
+   
+}

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
@@ -57,8 +57,9 @@ public class ContractNegotiationTerminateIntegrationTest extends BaseIntegration
     					.content(body)
     					.contentType(MediaType.APPLICATION_JSON));
     	// result is 200 OK
-    	result.andExpect(status().isOk())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	result.andExpect(status().isOk());
+    	// Spring does not set content type when there is no body - if DSP requires it, uncomment
+//    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
     	
     	// cleanup
     	contractNegotiationRepository.delete(cn);
@@ -119,8 +120,8 @@ public class ContractNegotiationTerminateIntegrationTest extends BaseIntegration
     					.content(body)
     					.contentType(MediaType.APPLICATION_JSON));
     	// result is 200 OK
-    	result.andExpect(status().isOk())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    	result.andExpect(status().isOk());
+//    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
     	
     	// cleanup
     	contractNegotiationRepository.delete(cn);

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.negotiation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferState;

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
@@ -221,6 +221,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     					.content(Serializer.serializeProtocol(verificationMessage))
     					.contentType(MediaType.APPLICATION_JSON));
     	result.andExpect(status().isOk());
+//    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
     	
     	JsonNode contractNegotiation = getContractNegotiationOverAPI();
     	offerCheck(contractNegotiation);

--- a/negotiation/src/main/java/it/eng/negotiation/repository/ContractNegotiationRepository.java
+++ b/negotiation/src/main/java/it/eng/negotiation/repository/ContractNegotiationRepository.java
@@ -12,6 +12,8 @@ import it.eng.negotiation.model.ContractNegotiation;
 public interface ContractNegotiationRepository extends MongoRepository<ContractNegotiation, String> {
 
 	Optional<ContractNegotiation> findByProviderPid(String providerPid);
+	
+	Optional<ContractNegotiation> findByConsumerPid(String consumerPid);
 
 	Optional<ContractNegotiation> findByProviderPidAndConsumerPid(String providerPid, String consumerPid);
 

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackController.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -77,7 +76,6 @@ public class ConsumerContractNegotiationCallbackController {
 //        return ResponseEntity.of().contentType(MediaType.APPLICATION_JSON).build();
         ContractNegotiationErrorMessage error = methodNotYetImplemented();
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED)
-        		.contentType(MediaType.APPLICATION_JSON)
         		.body(Serializer.serializeProtocolJsonNode(error));
     }
 
@@ -94,7 +92,9 @@ public class ConsumerContractNegotiationCallbackController {
         contractNegotiationConsumerService.handleAgreement(contractAgreementMessage);
 
         log.info("CONSUMER - Sending response OK - agreementMessage received");
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+//        		.contentType(MediaType.APPLICATION_JSON)
+        		.build();
     }
 
     // https://consumer.com/:callback/negotiations/:consumerPid/events	POST	ContractNegotiationEventMessage
@@ -113,7 +113,7 @@ public class ConsumerContractNegotiationCallbackController {
         //If the CN's state is successfully transitioned, the Consumer must return HTTP code 200 (OK).
         // The response body is not specified and clients are not required to process it.
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+//        		.contentType(MediaType.APPLICATION_JSON)
                 .build();
     }
 
@@ -133,10 +133,9 @@ public class ConsumerContractNegotiationCallbackController {
         // If the CN's state is successfully transitioned, the Consumer must return HTTP code 200 (OK).
         // The response body is not specified and clients are not required to process it.
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
-                .build();
+//        		.contentType(MediaType.APPLICATION_JSON)
+        		.build();
     }
-    
 
 	private ContractNegotiationErrorMessage methodNotYetImplemented() {
 		ContractNegotiationErrorMessage cnem = ContractNegotiationErrorMessage.Builder.newInstance()

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackController.java
@@ -127,7 +127,7 @@ public class ConsumerContractNegotiationCallbackController {
         ContractNegotiationTerminationMessage contractNegotiationTerminationMessage =
                 Serializer.deserializeProtocol(contractNegotiationTerminationMessageJsonNode, ContractNegotiationTerminationMessage.class);
 
-        contractNegotiationConsumerService.handleTerminationResponse(consumerPid, contractNegotiationTerminationMessage);
+        contractNegotiationConsumerService.handleTerminationRequest(consumerPid, contractNegotiationTerminationMessage);
 
         // ACK or ERROR
         // If the CN's state is successfully transitioned, the Consumer must return HTTP code 200 (OK).

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ContractNegotiationCallback.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ContractNegotiationCallback.java
@@ -2,10 +2,12 @@ package it.eng.negotiation.rest.protocol;
 
 public class ContractNegotiationCallback {
 
+	private static final String NEGOTIATION_REQUEST = "/negotiations/request";
 	private static final String OFFERS = "/negotiations/offers";
 	private static final String CONSUMER_OFFERS = ":callback:/negotiations/:consumerPid:/offers";
 	private static final String CONSUMER_AGREEMENT = ":callback:/negotiations/:consumerPid:/agreement";
 	private static final String CONSUMER_EVENTS = ":callback:/negotiations/:consumerPid:/events";
+	private static final String PROVIDER_TERMINATION = "/negotiations/:providerPid:/termination";
 	private static final String CONSUMER_TERMINATION = ":callback:/negotiations/:consumerPid:/termination";
 	
 	/*
@@ -18,7 +20,10 @@ public class ContractNegotiationCallback {
 		return OFFERS;
 	}
 
-	public static String getConsumerOffersCallback(String callback, String consumerPid) {
+	public static String getNegotiationRequestURL(String protocolAddress) {
+		return getValidCallback(protocolAddress) + NEGOTIATION_REQUEST;
+	}
+ 	public static String getConsumerOffersCallback(String callback, String consumerPid) {
 		return CONSUMER_OFFERS.replace(":callback:", getValidCallback(callback)).replace(":consumerPid:", consumerPid);
 	}
 	
@@ -37,6 +42,10 @@ public class ContractNegotiationCallback {
 	/*
 	 * Provider
 	 */
+	public static String getContractTerminationProvider(String protocolAddress, String providerPid) {
+		return getValidCallback(protocolAddress) + PROVIDER_TERMINATION.replace(":providerPid:", providerPid);
+	}
+	
 	public static String getProviderAgreementVerificationCallback(String callback, String providerPid) {
 		return PROVIDER_AGREEMENT_VERIFICATION.replace(":callback:", getValidCallback(callback)).replace(":providerPid:", providerPid);
 	}

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationController.java
@@ -3,7 +3,6 @@ package it.eng.negotiation.rest.protocol;
 import java.net.URI;
 import java.util.Arrays;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,8 +44,11 @@ public class ProviderContractNegotiationController {
     @GetMapping(path = "/{providerPid}")
     public ResponseEntity<JsonNode>  getNegotiationByProviderPid(@PathVariable String providerPid) {
         log.info("Get negotiation by provider pid");
-		ContractNegotiation contractNegotiation = providerService.getNegotiationByProviderPid(providerPid);
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(Serializer.serializeProtocolJsonNode(contractNegotiation));
+		
+        ContractNegotiation contractNegotiation = providerService.getNegotiationByProviderPid(providerPid);
+        
+		return ResponseEntity.ok()
+        		.body(Serializer.serializeProtocolJsonNode(contractNegotiation));
     }
 
     // 2.2 The provider negotiations/request resource
@@ -62,7 +64,8 @@ public class ProviderContractNegotiationController {
                 .fromCurrentRequest().path("/{id}")
                 .buildAndExpand(cn.getProviderPid()).toUri();
 
-        return ResponseEntity.created(location).contentType(MediaType.APPLICATION_JSON).body(Serializer.serializeProtocolJsonNode(cn));
+        return ResponseEntity.created(location)
+        		.body(Serializer.serializeProtocolJsonNode(cn));
     }
 
     // 2.3 The provider negotiations/:providerPid/request resource
@@ -74,7 +77,9 @@ public class ProviderContractNegotiationController {
         ContractRequestMessage crm = Serializer.deserializeProtocol(contractRequestMessageJsonNode, ContractRequestMessage.class);
 
         ContractNegotiationErrorMessage error = methodNotYetImplemented();
-        return ResponseEntity.internalServerError().contentType(MediaType.APPLICATION_JSON).body(Serializer.serializeProtocolJsonNode(error));
+        
+        return ResponseEntity.internalServerError()
+        		.body(Serializer.serializeProtocolJsonNode(error));
     }
 
     // 2.4 The provider negotiations/:providerPid/events
@@ -88,9 +93,8 @@ public class ProviderContractNegotiationController {
          
          ContractNegotiation contractNegotiation = providerService.handleContractNegotationEventMessage(contractNegotiationEventMessage);
        
-         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+         return ResponseEntity.ok()
         		 .body(Serializer.serializeProtocolJsonNode(contractNegotiation));
-//        		 .build();
     }
 
     // 2.5 The provider negotiations/:providerPid/agreement/verification resource
@@ -102,8 +106,12 @@ public class ProviderContractNegotiationController {
         ContractAgreementVerificationMessage cavm = 
         		Serializer.deserializeProtocol(contractAgreementVerificationMessageJsonNode, ContractAgreementVerificationMessage.class);
         log.info("Verification message received");
+        
         providerService.verifyNegotiation(cavm);
-        return ResponseEntity.ok().build();
+        
+        return ResponseEntity.ok()
+//        		.contentType(MediaType.APPLICATION_JSON)
+        		.build();
     }
 
     // 2.6 The provider negotiations/:id/termination resource
@@ -118,8 +126,8 @@ public class ProviderContractNegotiationController {
         providerService.handleTerminationRequest(providerPid, contractNegotiationTerminationMessage);
         
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
-                .build();
+//        		.contentType(MediaType.APPLICATION_JSON)
+        		.build();
     }
 
 	private ContractNegotiationErrorMessage methodNotYetImplemented() {

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationController.java
@@ -3,6 +3,7 @@ package it.eng.negotiation.rest.protocol;
 import java.net.URI;
 import java.util.Arrays;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -111,11 +112,14 @@ public class ProviderContractNegotiationController {
     @PostMapping(path = "/{providerPid}/termination")
     public ResponseEntity<JsonNode> handleTerminationMessage(@PathVariable String providerPid, 
     		@RequestBody JsonNode contractNegotiationTerminationMessageJsonNode) {
-        ContractNegotiationTerminationMessage cntm = 
+        ContractNegotiationTerminationMessage contractNegotiationTerminationMessage = 
         		Serializer.deserializeProtocol(contractNegotiationTerminationMessageJsonNode, ContractNegotiationTerminationMessage.class);
 
-        ContractNegotiationErrorMessage error = methodNotYetImplemented();
-        return ResponseEntity.internalServerError().contentType(MediaType.APPLICATION_JSON).body(Serializer.serializeProtocolJsonNode(error));
+        providerService.handleTerminationRequest(providerPid, contractNegotiationTerminationMessage);
+        
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                .build();
     }
 
 	private ContractNegotiationErrorMessage methodNotYetImplemented() {

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
@@ -175,8 +175,7 @@ public class ContractNegotiationConsumerService extends BaseProtocolService {
      * @param contractNegotiationTerminationMessage
      * @return
      */
-
-    public void handleTerminationResponse(String consumerPid, ContractNegotiationTerminationMessage contractNegotiationTerminationMessage) {
+    public void handleTerminationRequest(String consumerPid, ContractNegotiationTerminationMessage contractNegotiationTerminationMessage) {
     	ContractNegotiation contractNegotiation = findContractNegotiationByPids(contractNegotiationTerminationMessage.getConsumerPid(), contractNegotiationTerminationMessage.getProviderPid());
 
     	stateTransitionCheck(ContractNegotiationState.TERMINATED, contractNegotiation);
@@ -184,24 +183,8 @@ public class ContractNegotiationConsumerService extends BaseProtocolService {
     	ContractNegotiation contractNegotiationTerminated = contractNegotiation.withNewContractNegotiationState(ContractNegotiationState.TERMINATED);
     	contractNegotiationRepository.save(contractNegotiationTerminated);
     	log.info("Contract Negotiation with id {} set to TERMINATED state", contractNegotiation.getId());
-    }
-    
-//    private Offer validateAgreementAgainstOffer(ContractAgreementMessage contractAgreementMessage) {
-//    	return 
-//    	repository.findByProviderPidAndConsumerPid(contractAgreementMessage.getProviderPid(), contractAgreementMessage.getConsumerPid())
-//    		.map(cn -> cn.getOffer())
-//    	.orElseThrow(() -> new OfferNotFoundException(
-//				"Offer with following values from Agreement not found: providerPid " + contractAgreementMessage.getProviderPid() + 
-//				" and consumerPid " + contractAgreementMessage.getConsumerPid() + "and target " + contractAgreementMessage.getAgreement().getTarget()));
-
     	
-//		return offerRepository
-//				.findByConsumerPidAndProviderPidAndTarget(contractAgreementMessage.getConsumerPid(),
-//						contractAgreementMessage.getProviderPid(),
-//						contractAgreementMessage.getAgreement().getTarget())
-//				.orElseThrow(() -> new OfferNotFoundException(
-//						"Offer with following values from Agreement not found: providerPid " + contractAgreementMessage.getProviderPid() + 
-//						" and consumerPid " + contractAgreementMessage.getConsumerPid() + "and target " + contractAgreementMessage.getAgreement().getTarget()));
-//	}
+    	publisher.publishEvent(contractNegotiationTerminationMessage);
+    }
 
 }

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import it.eng.negotiation.exception.ContractNegotiationInvalidEventTypeException;
+import it.eng.negotiation.exception.ContractNegotiationNotFoundException;
 import it.eng.negotiation.exception.OfferNotFoundException;
 import it.eng.negotiation.listener.ContractNegotiationPublisher;
 import it.eng.negotiation.model.ContractAgreementMessage;
@@ -176,8 +177,11 @@ public class ContractNegotiationConsumerService extends BaseProtocolService {
      * @return
      */
     public void handleTerminationRequest(String consumerPid, ContractNegotiationTerminationMessage contractNegotiationTerminationMessage) {
-    	ContractNegotiation contractNegotiation = findContractNegotiationByPids(contractNegotiationTerminationMessage.getConsumerPid(), contractNegotiationTerminationMessage.getProviderPid());
-
+    	ContractNegotiation contractNegotiation = contractNegotiationRepository.findByConsumerPid(consumerPid)
+				.orElseThrow(() -> new ContractNegotiationNotFoundException(
+						"Contract negotiation with providerPid " + contractNegotiationTerminationMessage.getProviderPid() + 
+						" and consumerPid " + consumerPid + " not found", consumerPid, contractNegotiationTerminationMessage.getProviderPid()));
+    	
     	stateTransitionCheck(ContractNegotiationState.TERMINATED, contractNegotiation);
 
     	ContractNegotiation contractNegotiationTerminated = contractNegotiation.withNewContractNegotiationState(ContractNegotiationState.TERMINATED);

--- a/negotiation/src/test/java/it/eng/negotiation/model/MockObjectUtil.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/MockObjectUtil.java
@@ -171,6 +171,16 @@ public class MockObjectUtil {
 			.role(IConstants.ROLE_CONSUMER)
 			.build();
 	
+	public static final ContractNegotiation CONTRACT_NEGOTIATION_REQUESTED_PROIVDER = ContractNegotiation.Builder.newInstance()
+			.consumerPid(MockObjectUtil.CONSUMER_PID)
+			.providerPid(MockObjectUtil.PROVIDER_PID)
+			.callbackAddress(CALLBACK_ADDRESS)
+			.state(ContractNegotiationState.REQUESTED)
+			.offer(OFFER)
+			.assigner(ASSIGNER)
+			.role(IConstants.ROLE_PROVIDER)
+			.build();
+	
 	public static final ContractNegotiation CONTRACT_NEGOTIATION_AGREED = ContractNegotiation.Builder.newInstance()
 			.consumerPid(MockObjectUtil.CONSUMER_PID)
 			.providerPid(MockObjectUtil.PROVIDER_PID)

--- a/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ConsumerContractNegotiationCallbackControllerTest.java
@@ -130,7 +130,7 @@ public class ConsumerContractNegotiationCallbackControllerTest {
     public void handleTerminationResponse_error_service() {
     	JsonNode jsonNode = Serializer.serializeProtocolJsonNode(MockObjectUtil.TERMINATION_MESSAGE);
     	doThrow(ContractNegotiationNotFoundException.class).when(contractNegotiationConsumerService)
-    		.handleTerminationResponse(any(String.class), any(ContractNegotiationTerminationMessage.class));
+    		.handleTerminationRequest(any(String.class), any(ContractNegotiationTerminationMessage.class));
     	assertThrows(ContractNegotiationNotFoundException.class, 
     			() ->controller.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, jsonNode));
     }

--- a/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/protocol/ProviderContractNegotiationControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -149,7 +150,20 @@ public class ProviderContractNegotiationControllerTest {
 				.build();
 		ResponseEntity<JsonNode> response = controller.handleTerminationMessage(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cntm));
 		assertNotNull(response, "Response is not null");
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
 	
+	@Test
+	public void handleTerminationMessage_error() {
+		ContractNegotiationTerminationMessage cntm = ContractNegotiationTerminationMessage.Builder.newInstance()
+				.consumerPid(MockObjectUtil.CONSUMER_PID)
+				.providerPid(MockObjectUtil.PROVIDER_PID)
+				.code("1")
+				.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("test").build()))
+				.build();
+		doThrow(ContractNegotiationNotFoundException.class)
+			.when(contractNegotiationService).handleTerminationRequest(anyString(), any(ContractNegotiationTerminationMessage.class));
+		assertThrows(ContractNegotiationNotFoundException.class, 
+				() -> controller.handleTerminationMessage(MockObjectUtil.PROVIDER_PID, Serializer.serializeProtocolJsonNode(cntm)));
+	}
 }

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
@@ -498,15 +498,30 @@ public class ContractNegotiationAPIServiceTest {
 	}
 	
 	@Test
-	@DisplayName("Provider terminate contract negotiation")
-	public void terminateNegotiation() {
-		String contractNegotaitionId = UUID.randomUUID().toString(); 
-		when(contractNegotiationRepository.findById(contractNegotaitionId)).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
+	@DisplayName("Handle termination - provider")
+	public void handleTerminationCN_provider() {
+		when(contractNegotiationRepository.findById(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED_PROIVDER.getId()))
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED_PROIVDER));
+		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
+		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
+		when(apiResponse.isSuccess()).thenReturn(true);
+
+		service.handleContractNegotiationTerminated(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED_PROIVDER.getId());
+		
+		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
+		assertEquals(ContractNegotiationState.TERMINATED, argCaptorContractNegotiation.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("Handle termination - consumer")
+	public void handleTerminationCN_consumer() {
+		when(contractNegotiationRepository.findById(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED.getId()))
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(true);
 		
-		service.handleContractNegotiationTerminated(contractNegotaitionId);
+		service.handleContractNegotiationTerminated(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED.getId());
 		
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 		assertEquals(ContractNegotiationState.TERMINATED, argCaptorContractNegotiation.getValue().getState());

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
@@ -185,11 +185,11 @@ when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUti
 	
 	@Test
 	@DisplayName("Process termination message success")
-	public void handleTerminationResponse_success() {
+	public void handleTerminationRequest_success() {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
 			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 
-		service.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE);
+		service.handleTerminationRequest(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE);
 		
 		verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
 		assertEquals(ContractNegotiationState.TERMINATED, argCaptorContractNegotiation.getValue().getState());
@@ -197,23 +197,21 @@ when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUti
 	
 	@Test
 	@DisplayName("Process termination message failed - negotiation not found")
-	public void handleTerminationResponse_fail() {
+	public void handleTerminationRequest_fail() {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
 			.thenReturn(Optional.empty());
 
 		assertThrows(ContractNegotiationNotFoundException.class, 
-				() -> service.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE));
+				() -> service.handleTerminationRequest(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE));
 	}
 	
 	@Test
 	@DisplayName("Process termination message failed - already terminated")
-	public void handleTerminationResponse_fail_alreadyTerminated() {
+	public void handleTerminationRequest_fail_alreadyTerminated() {
 		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
 			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_TERMINATED));
 
 		assertThrows(ContractNegotiationInvalidStateException.class, 
-				() -> service.handleTerminationResponse(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE));
+				() -> service.handleTerminationRequest(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE));
 	}
-	
-	
 }

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationConsumerServiceTest.java
@@ -186,7 +186,7 @@ when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUti
 	@Test
 	@DisplayName("Process termination message success")
 	public void handleTerminationRequest_success() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
+		when(contractNegotiationRepository.findByConsumerPid(any(String.class)))
 			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED));
 
 		service.handleTerminationRequest(MockObjectUtil.CONSUMER_PID, MockObjectUtil.TERMINATION_MESSAGE);
@@ -198,7 +198,7 @@ when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUti
 	@Test
 	@DisplayName("Process termination message failed - negotiation not found")
 	public void handleTerminationRequest_fail() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
+		when(contractNegotiationRepository.findByConsumerPid(any(String.class)))
 			.thenReturn(Optional.empty());
 
 		assertThrows(ContractNegotiationNotFoundException.class, 
@@ -208,7 +208,7 @@ when(contractNegotiationRepository.findByProviderPidAndConsumerPid(MockObjectUti
 	@Test
 	@DisplayName("Process termination message failed - already terminated")
 	public void handleTerminationRequest_fail_alreadyTerminated() {
-		when(contractNegotiationRepository.findByProviderPidAndConsumerPid(any(String.class), any(String.class)))
+		when(contractNegotiationRepository.findByConsumerPid(any(String.class)))
 			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_TERMINATED));
 
 		assertThrows(ContractNegotiationInvalidStateException.class, 

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationProviderServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationProviderServiceTest.java
@@ -227,4 +227,35 @@ public class ContractNegotiationProviderServiceTest {
         assertThrows(ContractNegotiationInvalidStateException.class, () -> service.verifyNegotiation(MockObjectUtil.CONTRACT_AGREEMENT_VERIFICATION_MESSAGE));
     }
 
+    @Test
+	@DisplayName("Process termination message success")
+	public void handleTerminationRequest_success() {
+		when(repository.findByProviderPid(any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_REQUESTED_PROIVDER));
+
+		service.handleTerminationRequest(MockObjectUtil.PROVIDER_PID, MockObjectUtil.TERMINATION_MESSAGE);
+		
+		verify(repository).save(argCaptorContractNegotiation.capture());
+		assertEquals(ContractNegotiationState.TERMINATED, argCaptorContractNegotiation.getValue().getState());
+	}
+	
+	@Test
+	@DisplayName("Process termination message failed - negotiation not found")
+	public void handleTerminationRequest_fail() {
+		when(repository.findByProviderPid(any(String.class)))
+			.thenReturn(Optional.empty());
+
+		assertThrows(ContractNegotiationNotFoundException.class, 
+				() -> service.handleTerminationRequest(MockObjectUtil.PROVIDER_PID, MockObjectUtil.TERMINATION_MESSAGE));
+	}
+	
+	@Test
+	@DisplayName("Process termination message failed - already terminated")
+	public void handleTerminationRequest_fail_alreadyTerminated() {
+		when(repository.findByProviderPid(any(String.class)))
+			.thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_TERMINATED));
+
+		assertThrows(ContractNegotiationInvalidStateException.class, 
+				() -> service.handleTerminationRequest(MockObjectUtil.PROVIDER_PID, MockObjectUtil.TERMINATION_MESSAGE));
+	}
 }


### PR DESCRIPTION
### Changed

 - ContractNegotiation.callbackAddress on consumer side value set to provider address (protocol address)
 - Terminate negotiation API request - based on role, it sends to provider protocol address or consumer callback address

### Added

 - Provider handleTermination request
 - New integration test to cover contract negotiation termination logic (without change of initial_data.json)