### PR TITLE
Feature/wiremock as provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 25-11-2024
+## [0.1.1] - 27-11-2024
 
 ### Changed
 
  - Moved integration tests into packages
  - ContractNegotiationAPIException accepts ContractNegotiationErrorMessage as parameter
  - ContractNegotiationAPIService when error happens, create ContractNegotiationErrorMessage
+ - Dependency changed from de.flapdoodle.embed.mongo.spring30x to de.flapdoodle.embed.mongo.spring3x
+ - DataTransferAPIException accepts TransferError as parameter
+ - DataTransferApiService when error happens, create TransferError (requestTransfer)
+ - TransferProcess and ContractNegotiation sets correct id when deserialized from plain string
 
 ### Added
 
  - Wiremock to simulate provider in integration requests
+ - DataTransferApi tests
 
 ## [0.1.1] - 22-11-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 25-11-2024
+
+### Changed
+
+ - Moved integration tests into packages
+ - ContractNegotiationAPIException accepts ContractNegotiationErrorMessage as parameter
+ - ContractNegotiationAPIService when error happens, create ContractNegotiationErrorMessage
+
+### Added
+
+ - Wiremock to simulate provider in integration requests
+
 ## [0.1.1] - 22-11-2024
 
 ### Changed

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -103,6 +103,13 @@
 		</dependency>
 
 		<dependency>
+		    <groupId>org.wiremock.integrations</groupId>
+		    <artifactId>wiremock-spring-boot</artifactId>
+		    <version>3.2.0</version>
+		    <scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>it.eng.catalog</groupId>
 			<artifactId>catalog</artifactId>
 			<classifier>tests</classifier>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -97,8 +97,8 @@
 
 		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
-			<artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
-			<version>4.11.0</version>
+			<artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
+			<version>4.16.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
+import org.wiremock.spring.EnableWireMock;
 
 @SpringBootTest(
 		  webEnvironment = WebEnvironment.DEFINED_PORT,
@@ -12,9 +13,11 @@ import org.springframework.test.web.servlet.MockMvc;
 		    "server.port=8090"
 		  })
 @AutoConfigureMockMvc
+@EnableWireMock
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BaseIntegrationTest {
 	
-	   @Autowired
-	   protected MockMvc mockMvc;
-
+   @Autowired
+   protected MockMvc mockMvc;
+	   
 }

--- a/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
@@ -1,5 +1,7 @@
 package it.eng.connector.integration;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,5 +20,9 @@ public class BaseIntegrationTest {
 	
    @Autowired
    protected MockMvc mockMvc;
+   
+   protected String createNewId() {
+		return "urn:uuid:" + UUID.randomUUID().toString();
+	}
 	   
 }

--- a/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
@@ -14,7 +14,6 @@ import org.wiremock.spring.EnableWireMock;
 		  })
 @AutoConfigureMockMvc
 @EnableWireMock
-//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BaseIntegrationTest {
 	
    @Autowired

--- a/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseIntegrationTest.java
@@ -1,13 +1,24 @@
 package it.eng.connector.integration;
 
+import java.time.Instant;
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
 import org.wiremock.spring.EnableWireMock;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import it.eng.negotiation.serializer.InstantDeserializer;
+import it.eng.negotiation.serializer.InstantSerializer;
 
 @SpringBootTest(
 		  webEnvironment = WebEnvironment.DEFINED_PORT,
@@ -20,9 +31,23 @@ public class BaseIntegrationTest {
 	
    @Autowired
    protected MockMvc mockMvc;
+   protected JsonMapper jsonMapper;
    
    protected String createNewId() {
 		return "urn:uuid:" + UUID.randomUUID().toString();
 	}
-	   
+   
+	@BeforeEach
+	public void setup() {
+		SimpleModule instantConverterModule = new SimpleModule();
+		instantConverterModule.addSerializer(Instant.class, new InstantSerializer());
+		instantConverterModule.addDeserializer(Instant.class, new InstantDeserializer());
+		jsonMapper = JsonMapper.builder()
+       		.addModule(new JavaTimeModule())
+       		.configure(MapperFeature.USE_ANNOTATIONS, false)
+       		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+       		.addModule(instantConverterModule)
+               .build();
+	}
+
 }

--- a/connector/src/test/java/it/eng/connector/integration/applicationproperties/ApplicationPropertyIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/applicationproperties/ApplicationPropertyIntegrationTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.applicationproperties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.tools.model.ApplicationProperty;
 import it.eng.tools.model.IConstants;

--- a/connector/src/test/java/it/eng/connector/integration/catalog/CatalogIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/catalog/CatalogIntegrationTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.catalog;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import it.eng.catalog.model.CatalogError;
 import it.eng.catalog.serializer.Serializer;
 import it.eng.catalog.util.MockObjectUtil;
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.tools.model.DSpaceConstants;
 

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferApiTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferApiTest.java
@@ -10,12 +10,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,18 +23,11 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.wiremock.spring.InjectWireMock;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-import it.eng.catalog.serializer.InstantDeserializer;
-import it.eng.catalog.serializer.InstantSerializer;
 import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.model.DataTransferFormat;
@@ -55,26 +46,11 @@ import it.eng.tools.response.GenericApiResponse;
  */
 public class DataTransferApiTest extends BaseIntegrationTest {
 	
-	private JsonMapper jsonMapper;
-
 	@Autowired
 	private TransferProcessRepository transferProcessRepository;
 	
 	@InjectWireMock 
 	private WireMockServer wiremock;
-	
-	@BeforeEach
-	public void setup() {
-		SimpleModule instantConverterModule = new SimpleModule();
-		instantConverterModule.addSerializer(Instant.class, new InstantSerializer());
-		instantConverterModule.addDeserializer(Instant.class, new InstantDeserializer());
-		jsonMapper = JsonMapper.builder()
-				.addModule(new JavaTimeModule())
-				.configure(MapperFeature.USE_ANNOTATIONS, false)
-				.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-				.addModule(instantConverterModule)
-				.build();
-	}
 	
 	@Test
 	@DisplayName("TransferProcess API - get")

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferApiTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferApiTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.datatransfer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import it.eng.catalog.serializer.InstantDeserializer;
 import it.eng.catalog.serializer.InstantSerializer;
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.model.DataTransferFormat;
 import it.eng.datatransfer.model.TransferProcess;

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferConsumerCallbackTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferConsumerCallbackTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.datatransfer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferState;

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferTest.java
@@ -1,4 +1,4 @@
-package it.eng.connector.integration;
+package it.eng.connector.integration.datatransfer;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
 import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
 import it.eng.datatransfer.model.DataTransferFormat;

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
@@ -1,0 +1,344 @@
+package it.eng.connector.integration.negotiation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.ResultActions;
+import org.wiremock.spring.InjectWireMock;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import it.eng.connector.integration.BaseIntegrationTest;
+import it.eng.connector.util.TestUtil;
+import it.eng.negotiation.model.ContractNegotiation;
+import it.eng.negotiation.model.ContractNegotiationErrorMessage;
+import it.eng.negotiation.model.ContractNegotiationState;
+import it.eng.negotiation.model.MockObjectUtil;
+import it.eng.negotiation.model.Reason;
+import it.eng.negotiation.repository.ContractNegotiationRepository;
+import it.eng.negotiation.serializer.InstantDeserializer;
+import it.eng.negotiation.serializer.InstantSerializer;
+import it.eng.negotiation.serializer.Serializer;
+import it.eng.tools.controller.ApiEndpoints;
+import it.eng.tools.model.IConstants;
+import it.eng.tools.response.GenericApiResponse;
+
+public class ConsumerAPIContractNegotiationIntegrationTest extends BaseIntegrationTest {
+
+	private JsonMapper jsonMapper;
+	
+	@BeforeEach
+	public void setup() {
+		SimpleModule instantConverterModule = new SimpleModule();
+		instantConverterModule.addSerializer(Instant.class, new InstantSerializer());
+		instantConverterModule.addDeserializer(Instant.class, new InstantDeserializer());
+		jsonMapper = JsonMapper.builder()
+        		.addModule(new JavaTimeModule())
+        		.configure(MapperFeature.USE_ANNOTATIONS, false)
+        		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        		.addModule(instantConverterModule)
+                .build();
+	}
+
+	@InjectWireMock 
+	private WireMockServer wiremock;
+	
+	@Autowired
+	private ContractNegotiationRepository contractNegotiationRepository;
+
+	// start negotiation
+	@Test
+	@DisplayName("Consumer initiates contract negotiation - success")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerInitiatesContractNegotiation() throws Exception {
+		// insert data into consumer DB
+		ContractNegotiation contractNegotiationResponse = ContractNegotiation.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.state(ContractNegotiationState.REQUESTED)
+				.build();
+		
+		// prepare provider/wiremock response
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/request")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractRequestMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")
+	                .withBody(Serializer.serializeProtocol(contractNegotiationResponse))));
+		 
+		// send API request
+		Map<String, Object> apiContractNegotiationRequest = new HashMap<>();
+		apiContractNegotiationRequest.put("Forward-To", wiremock.baseUrl());
+		apiContractNegotiationRequest.put("offer", MockObjectUtil.OFFER);
+		final ResultActions result = mockMvc.perform(post(ApiEndpoints.NEGOTIATION_V1)
+				.content(Serializer.serializePlain(apiContractNegotiationRequest))
+				.contentType(MediaType.APPLICATION_JSON));
+		
+		// verify expected behavior
+		result.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+		
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiation.class);
+		GenericApiResponse<ContractNegotiation> genericApiResponse = jsonMapper.readValue(json, javaType);
+		assertNotNull(genericApiResponse);
+		assertTrue(genericApiResponse.isSuccess());
+		assertNotNull(genericApiResponse.getData());
+		assertEquals(ContractNegotiation.class, genericApiResponse.getData().getClass());
+	}
+	
+	@Test
+	@DisplayName("Consumer initiates contract negotiation - provider error")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerInitiatesContractNegotiation_providerError() throws Exception {
+		// prepare provider/wiremock response
+		ContractNegotiationErrorMessage contractNegotiationError = ContractNegotiationErrorMessage.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.code("TEST_ERROR")
+				.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("Test error").build()))
+				.build();
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/request")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractRequestMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")
+	                .withStatus(400)
+	                .withBody(Serializer.serializeProtocol(contractNegotiationError))));
+		
+		// send API request
+		Map<String, Object> apiContractNegotiationRequest = new HashMap<>();
+		apiContractNegotiationRequest.put("Forward-To", wiremock.baseUrl());
+		apiContractNegotiationRequest.put("offer", MockObjectUtil.OFFER);
+		final ResultActions result = mockMvc.perform(post(ApiEndpoints.NEGOTIATION_V1)
+				.content(Serializer.serializePlain(apiContractNegotiationRequest))
+				.contentType(MediaType.APPLICATION_JSON));
+		
+		// verify expected behavior
+		result.andExpect(status().is4xxClientError())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiationErrorMessage.class);
+		GenericApiResponse<ContractNegotiationErrorMessage> genericApiResponse = jsonMapper.readValue(json, javaType);
+		assertNotNull(genericApiResponse);
+		assertFalse(genericApiResponse.isSuccess());
+		assertNotNull(genericApiResponse.getData());
+		assertEquals(ContractNegotiationErrorMessage.class, genericApiResponse.getData().getClass());
+	}
+
+	// verify negotiation
+	@Test
+	@DisplayName("Consumer verify contract negotiation")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerVerifyContractNegotiation() throws Exception {
+		// insert data into consumer DB
+		ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.state(ContractNegotiationState.AGREED)
+				// wiremock acts as provider
+				.callbackAddress(wiremock.baseUrl())
+				.build();
+		contractNegotiationRepository.save(contractNegotiation);
+		
+		// prepare provider/wiremock response
+//		":callback:/negotiations/:providerPid:/agreement/verification"
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/" + contractNegotiation.getProviderPid() + "/agreement/verification")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractAgreementVerificationMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")));
+		
+		// send API request
+		//{contractNegotiationId}/verify
+		final ResultActions result = mockMvc.perform(put(ApiEndpoints.NEGOTIATION_V1 + "/" + contractNegotiation.getId() + "/verify")
+				.contentType(MediaType.APPLICATION_JSON));
+		
+		// verify expected behavior
+		// state changed to VERIFIED
+		assertEquals(ContractNegotiationState.VERIFIED, contractNegotiationRepository.findById(contractNegotiation.getId()).get().getState());
+
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiation.class);
+		GenericApiResponse<ContractNegotiation> genericApiResponse = jsonMapper.readValue(json, javaType);
+		assertNotNull(genericApiResponse);
+		assertTrue(genericApiResponse.isSuccess());
+		
+		contractNegotiationRepository.delete(contractNegotiation);
+	}
+	
+	@Test
+	@DisplayName("Consumer verify contract negotiation - provider error")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerVerifyContractNegotiation_providerError() throws Exception {
+		// insert data into consumer DB
+		ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.state(ContractNegotiationState.AGREED)
+				// wiremock acts as provider
+				.callbackAddress(wiremock.baseUrl())
+				.build();
+		contractNegotiationRepository.save(contractNegotiation);
+		
+		// prepare provider/wiremock response
+		ContractNegotiationErrorMessage contractNegotiationError = ContractNegotiationErrorMessage.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.code("TEST_ERROR")
+				.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("Test error").build()))
+				.build();
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/" + contractNegotiation.getProviderPid() + "/agreement/verification")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractAgreementVerificationMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")
+	                .withStatus(400)
+	                .withBody(Serializer.serializeProtocol(contractNegotiationError))));
+		
+		// send API request
+		//{contractNegotiationId}/verify
+		final ResultActions result = mockMvc.perform(put(ApiEndpoints.NEGOTIATION_V1 + "/" + contractNegotiation.getId() + "/verify")
+				.contentType(MediaType.APPLICATION_JSON));
+		
+		// verify expected behavior
+		result.andExpect(status().is4xxClientError())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiationErrorMessage.class);
+		GenericApiResponse<ContractNegotiationErrorMessage> genericApiResponse = jsonMapper.readValue(json, javaType);
+		
+		assertNotNull(genericApiResponse);
+		assertFalse(genericApiResponse.isSuccess());
+		assertNotNull(genericApiResponse.getData());
+		assertEquals(ContractNegotiationErrorMessage.class, genericApiResponse.getData().getClass());
+			
+		// state NOT changed
+		assertEquals(ContractNegotiationState.AGREED, contractNegotiationRepository.findById(contractNegotiation.getId()).get().getState());
+		contractNegotiationRepository.delete(contractNegotiation);
+	}
+	
+	// terminate contract negotiation
+	@Test
+	@DisplayName("Consumer terminates contract negotiation")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerTerminatesContractNegotiation() throws Exception {
+		// insert data into consumer DB
+		ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.state(ContractNegotiationState.AGREED)
+				.role(IConstants.ROLE_CONSUMER)
+				// wiremock acts as provider
+				.callbackAddress(wiremock.baseUrl())
+				.build();
+		contractNegotiationRepository.save(contractNegotiation);
+		
+		// prepare provider/wiremock response
+		// /{providerPid}/termination
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/" + contractNegotiation.getProviderPid() + "/termination")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractNegotiationTerminationMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")));
+		
+		// send API request
+		//{contractNegotiationId}/terminate
+		final ResultActions result = mockMvc.perform(put(ApiEndpoints.NEGOTIATION_V1 + "/" + contractNegotiation.getId() + "/terminate")
+				.contentType(MediaType.APPLICATION_JSON));
+
+		// verify expected behavior
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiation.class);
+		GenericApiResponse<ContractNegotiation> genericApiResponse = jsonMapper.readValue(json, javaType);
+		assertNotNull(genericApiResponse);
+		assertTrue(genericApiResponse.isSuccess());
+		
+		// state TERMIANTED
+		assertEquals(ContractNegotiationState.TERMINATED, contractNegotiationRepository.findById(contractNegotiation.getId()).get().getState());
+		contractNegotiationRepository.delete(contractNegotiation);
+	}
+	
+	// terminate contract negotiation
+	@Test
+	@DisplayName("Consumer terminates contract negotiation - provider error")
+	@WithUserDetails(TestUtil.ADMIN_USER)
+	public void consumerTerminatesContractNegotiation_providerError() throws Exception {
+		// insert data into consumer DB
+		ContractNegotiation contractNegotiation = ContractNegotiation.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.state(ContractNegotiationState.AGREED)
+				// wiremock acts as provider
+				.callbackAddress(wiremock.baseUrl())
+				.role(IConstants.ROLE_CONSUMER)
+				.build();
+		contractNegotiationRepository.save(contractNegotiation);
+		
+		// prepare provider/wiremock response
+		ContractNegotiationErrorMessage contractNegotiationError = ContractNegotiationErrorMessage.Builder.newInstance()
+				.consumerPid(createNewId())
+				.providerPid(createNewId())
+				.code("TEST_ERROR")
+				.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("Test error").build()))
+				.build();
+		WireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/negotiations/" + contractNegotiation.getProviderPid() + "/termination")
+				.withBasicAuth("connector@mail.com", "password")
+				.withRequestBody(WireMock.containing("dspace:ContractNegotiationTerminationMessage"))
+				.willReturn(
+	                aResponse().withHeader("Content-Type", "application/json")
+	                .withStatus(400)
+	                .withBody(Serializer.serializeProtocol(contractNegotiationError))));
+
+		// send API request
+		//{contractNegotiationId}/terminate
+		final ResultActions result = mockMvc.perform(put(ApiEndpoints.NEGOTIATION_V1 + "/" + contractNegotiation.getId() + "/terminate")
+				.contentType(MediaType.APPLICATION_JSON));
+
+		// verify expected behavior
+		result.andExpect(status().is4xxClientError())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+		String json = result.andReturn().getResponse().getContentAsString();
+		JavaType javaType = jsonMapper.getTypeFactory().constructParametricType(GenericApiResponse.class, ContractNegotiationErrorMessage.class);
+		GenericApiResponse<ContractNegotiationErrorMessage> genericApiResponse = jsonMapper.readValue(json, javaType);
+		
+		assertNotNull(genericApiResponse);
+		assertFalse(genericApiResponse.isSuccess());
+		assertNotNull(genericApiResponse.getData());
+		assertEquals(ContractNegotiationErrorMessage.class, genericApiResponse.getData().getClass());
+			
+		// state NOT changed
+		assertEquals(ContractNegotiationState.AGREED, contractNegotiationRepository.findById(contractNegotiation.getId()).get().getState());
+		contractNegotiationRepository.delete(contractNegotiation);
+	}
+	
+	private String createNewId() {
+		return "urn:uuid:" + UUID.randomUUID().toString();
+	}
+}

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -336,9 +335,5 @@ public class ConsumerAPIContractNegotiationIntegrationTest extends BaseIntegrati
 		// state NOT changed
 		assertEquals(ContractNegotiationState.AGREED, contractNegotiationRepository.findById(contractNegotiation.getId()).get().getState());
 		contractNegotiationRepository.delete(contractNegotiation);
-	}
-	
-	private String createNewId() {
-		return "urn:uuid:" + UUID.randomUUID().toString();
 	}
 }

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ConsumerAPIContractNegotiationIntegrationTest.java
@@ -10,12 +10,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,12 +22,7 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 import org.wiremock.spring.InjectWireMock;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
@@ -41,29 +34,12 @@ import it.eng.negotiation.model.ContractNegotiationState;
 import it.eng.negotiation.model.MockObjectUtil;
 import it.eng.negotiation.model.Reason;
 import it.eng.negotiation.repository.ContractNegotiationRepository;
-import it.eng.negotiation.serializer.InstantDeserializer;
-import it.eng.negotiation.serializer.InstantSerializer;
 import it.eng.negotiation.serializer.Serializer;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.response.GenericApiResponse;
 
 public class ConsumerAPIContractNegotiationIntegrationTest extends BaseIntegrationTest {
-
-	private JsonMapper jsonMapper;
-	
-	@BeforeEach
-	public void setup() {
-		SimpleModule instantConverterModule = new SimpleModule();
-		instantConverterModule.addSerializer(Instant.class, new InstantSerializer());
-		instantConverterModule.addDeserializer(Instant.class, new InstantDeserializer());
-		jsonMapper = JsonMapper.builder()
-        		.addModule(new JavaTimeModule())
-        		.configure(MapperFeature.USE_ANNOTATIONS, false)
-        		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        		.addModule(instantConverterModule)
-                .build();
-	}
 
 	@InjectWireMock 
 	private WireMockServer wiremock;

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationTerminateIntegrationTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Arrays;
-import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -158,10 +157,6 @@ public class ContractNegotiationTerminateIntegrationTest extends BaseIntegration
     	
     	// cleanup
     	contractNegotiationRepository.delete(cn);
-    }
-    
-    private String createNewId() {
-        return UUID.randomUUID().toString();
     }
     
 	private ContractNegotiation createContractNegotiation() {

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/NegotiationIntegrationTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
@@ -48,7 +47,6 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
 	
 	private static String providerPid;
 	private static String offerID = "urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5";
-	private final ObjectMapper mapper = new ObjectMapper();
 	
 	@Order(1)
     @ParameterizedTest
@@ -96,7 +94,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     	
-    	JsonNode jsonNode = mapper.readTree(result.andReturn().getResponse().getContentAsString());
+    	JsonNode jsonNode = jsonMapper.readTree(result.andReturn().getResponse().getContentAsString());
     	providerPid = jsonNode.get(DSpaceConstants.DSPACE_PROVIDER_PID).asText();
 
     	//TODO add protocol call using providerPid
@@ -154,7 +152,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
     	.andExpect(jsonPath("['"+DSpaceConstants.TYPE+"']", is(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getType())))
     	.andExpect(jsonPath("['"+DSpaceConstants.CONTEXT+"']", is(DSpaceConstants.DATASPACE_CONTEXT_0_8_VALUE)));
     	
-    	JsonNode jsonNode = mapper.readTree(result.andReturn().getResponse().getContentAsString());
+    	JsonNode jsonNode = jsonMapper.readTree(result.andReturn().getResponse().getContentAsString());
     	providerPid = jsonNode.get(DSpaceConstants.DSPACE_PROVIDER_PID).asText();
     	
 		mockMvc.perform(
@@ -260,7 +258,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
 		tp.andExpect(status().isOk())
 		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
 		
-		JsonNode jsonNode = mapper.readTree(tp.andReturn().getResponse().getContentAsString());
+		JsonNode jsonNode = jsonMapper.readTree(tp.andReturn().getResponse().getContentAsString());
 		TransferProcess transferProcess = it.eng.datatransfer.serializer.Serializer.deserializePlain(jsonNode.findValues("data").get(0).get(jsonNode.findValues("data").get(0).size()-1).toString(), TransferProcess.class);
 		
 		assertEquals(TransferState.INITIALIZED, transferProcess.getState());
@@ -295,7 +293,7 @@ public class NegotiationIntegrationTest extends BaseIntegrationTest {
 		result.andExpect(status().isOk())
 		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
 		
-		JsonNode jsonNode = mapper.readTree(result.andReturn().getResponse().getContentAsString());
+		JsonNode jsonNode = jsonMapper.readTree(result.andReturn().getResponse().getContentAsString());
 		return jsonNode.findValues("data").get(0).get(jsonNode.findValues("data").get(0).size()-1);
 	}
 	

--- a/connector/src/test/resources/application.properties
+++ b/connector/src/test/resources/application.properties
@@ -21,7 +21,7 @@ application.cors.allowed.headers=
 application.cors.allowed.credentials=
 
 # MongoDB connection settings
-de.flapdoodle.mongodb.embedded.version=6.0.5
+de.flapdoodle.mongodb.embedded.version=5.0.5
 
 ###### USAGE CONTROL
 application.usagecontrol.enabled=true

--- a/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferAPIException.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferAPIException.java
@@ -1,5 +1,6 @@
 package it.eng.datatransfer.exceptions;
 
+import it.eng.datatransfer.model.TransferError;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +9,12 @@ import lombok.Setter;
 public class DataTransferAPIException extends RuntimeException {
 
 	private static final long serialVersionUID = 4215112143496569972L;
+	private TransferError transferError;
+	
+	public DataTransferAPIException(TransferError transferError, String message) {
+		super(message);
+		this.transferError = transferError;
+	}
 	
 	public DataTransferAPIException(String message) {
         super(message);

--- a/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferAPIExceptionAdvice.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/exceptions/DataTransferAPIExceptionAdvice.java
@@ -15,7 +15,7 @@ public class DataTransferAPIExceptionAdvice extends ResponseEntityExceptionHandl
 	
 	@ExceptionHandler(value = {DataTransferAPIException.class})
     protected ResponseEntity<Object> handleDataTransferAPIException(DataTransferAPIException ex, WebRequest request) {
-    	return new ResponseEntity<>(GenericApiResponse.error(ex.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
+    	return new ResponseEntity<>(GenericApiResponse.error(ex.getTransferError(), ex.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/model/TransferProcess.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/model/TransferProcess.java
@@ -99,6 +99,7 @@ public class TransferProcess extends AbstractTransferMessage {
 			return new Builder();
 		}
 		
+		@JsonProperty(DSpaceConstants.ID)
 		public Builder id(String id) {
         	message.id = id;
         	return this;

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import it.eng.datatransfer.model.DataTransferRequest;
 import it.eng.datatransfer.service.DataTransferAPIService;
 import it.eng.tools.controller.ApiEndpoints;
-import it.eng.tools.model.DSpaceConstants;
 import it.eng.tools.response.GenericApiResponse;
 import lombok.extern.slf4j.Slf4j;
 

--- a/data-transfer/src/main/java/it/eng/datatransfer/serializer/Serializer.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/serializer/Serializer.java
@@ -59,7 +59,8 @@ public class Serializer {
 			// used when converting from Java to String; must exclude JsonIgnore for ContractNegotiation.id
 			protected <A extends Annotation> A _findAnnotation(Annotated ann, Class<A> annoClass) {
 				//  annoClass == JsonValue.class - enum returned without prefix for plain
-				if ((annoClass == JsonProperty.class && !ann.getName().equals("id")) || annoClass == JsonIgnore.class || annoClass == JsonValue.class) {
+				if ((annoClass == JsonProperty.class && !ann.getName().equals("id")) || annoClass == JsonIgnore.class 
+						|| annoClass == JsonValue.class) {
 					return null;
 				}
 				return super._findAnnotation(ann, annoClass);
@@ -205,4 +206,17 @@ public class Serializer {
 			throw new ValidationException("Missing mandatory protocol fields @context and/or @type or value not correct");
 		}
 	}
+	
+	public static <T> T deserializePlain(JsonNode jsonNode, Class<T> clazz) {
+		T obj = jsonMapperPlain.convertValue(jsonNode, clazz);
+		Set<ConstraintViolation<T>> violations = validator.validate(obj);
+		if(violations.isEmpty()) {
+			return obj;
+		}
+		throw new ValidationException(
+				violations
+					.stream()
+					.map(v -> v.getPropertyPath() + " " + v.getMessage())
+					.collect(Collectors.joining(",")));
+		}
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import it.eng.datatransfer.serializer.Serializer;
+import it.eng.datatransfer.util.MockObjectUtil;
 import it.eng.tools.model.DSpaceConstants;
 import jakarta.validation.ValidationException;
 
@@ -103,6 +104,14 @@ public class TransferProcessTest {
 		assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.TERMINATED));
 		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.REQUESTED));
 		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.COMPLETED));
+	}
+	
+	@Test
+	@DisplayName("Check if id is the same after serialization")
+	public void checkId() {
+		String sss = Serializer.serializePlain(MockObjectUtil.TRANSFER_PROCESS_REQUESTED);
+		TransferProcess tp = Serializer.deserializePlain(sss, TransferProcess.class);
+		assertEquals(MockObjectUtil.TRANSFER_PROCESS_REQUESTED.getId(), tp.getId());
 	}
 
 	private void validateJavaObject(TransferProcess javaObj) {

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferAPIServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferAPIServiceTest.java
@@ -128,6 +128,7 @@ class DataTransferAPIServiceTest {
 		when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(MockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.TRANSFER_ERROR));
 		when(properties.consumerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
 		assertThrows(DataTransferAPIException.class, ()->

--- a/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/util/MockObjectUtil.java
@@ -1,12 +1,15 @@
 package it.eng.datatransfer.util;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 
 import it.eng.datatransfer.model.DataAddress;
 import it.eng.datatransfer.model.DataTransferFormat;
 import it.eng.datatransfer.model.EndpointProperty;
+import it.eng.datatransfer.model.Reason;
 import it.eng.datatransfer.model.TransferCompletionMessage;
+import it.eng.datatransfer.model.TransferError;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferRequestMessage;
 import it.eng.datatransfer.model.TransferStartMessage;
@@ -46,6 +49,13 @@ public class MockObjectUtil {
 			.endpoint(ENDPOINT_URL)
 			.endpointType(ENDPOINT_TYPE)
 			.endpointProperties(List.of(ENDPOINT_PROPERTY))
+			.build();
+	
+	public static final TransferError TRANSFER_ERROR = TransferError.Builder.newInstance()
+			.consumerPid(CONSUMER_PID)
+			.providerPid(PROVIDER_PID)
+			.code("TEST")
+			.reason(Arrays.asList(Reason.Builder.newInstance().language("en").value("TEST").build()))
 			.build();
 	
 	public static final TransferProcess TRANSFER_PROCESS_INITIALIZED = TransferProcess.Builder.newInstance()

--- a/negotiation/src/main/java/it/eng/negotiation/exception/ContractNegotiationAPIException.java
+++ b/negotiation/src/main/java/it/eng/negotiation/exception/ContractNegotiationAPIException.java
@@ -1,5 +1,6 @@
 package it.eng.negotiation.exception;
 
+import it.eng.negotiation.model.ContractNegotiationErrorMessage;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,7 +9,13 @@ import lombok.Setter;
 public class ContractNegotiationAPIException extends RuntimeException {
 
 	private static final long serialVersionUID = -5195939797427111519L;
+	private ContractNegotiationErrorMessage errorMessage;
 
+	public ContractNegotiationAPIException(ContractNegotiationErrorMessage errorMessage, String message) {
+		super(message);
+		this.errorMessage = errorMessage;
+	}
+	
     public ContractNegotiationAPIException(String message) {
         super(message);
     }

--- a/negotiation/src/main/java/it/eng/negotiation/exception/ContractNegotiationAPIExceptionAdvice.java
+++ b/negotiation/src/main/java/it/eng/negotiation/exception/ContractNegotiationAPIExceptionAdvice.java
@@ -15,7 +15,7 @@ public class ContractNegotiationAPIExceptionAdvice extends ResponseEntityExcepti
 
     @ExceptionHandler(value = {ContractNegotiationAPIException.class, PolicyEnforcementException.class})
     protected ResponseEntity<Object> handleContractNegotiationAPIException(ContractNegotiationAPIException ex, WebRequest request) {
-    	return new ResponseEntity<>(GenericApiResponse.error(ex.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
+    	return new ResponseEntity<>(GenericApiResponse.error(ex.getErrorMessage(), ex.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
     }
     
 }

--- a/negotiation/src/main/java/it/eng/negotiation/model/ContractNegotiation.java
+++ b/negotiation/src/main/java/it/eng/negotiation/model/ContractNegotiation.java
@@ -86,6 +86,7 @@ public class ContractNegotiation extends AbstractNegotiationObject {
             return new ContractNegotiation.Builder();
         }
         
+        @JsonProperty(DSpaceConstants.ID)
         public Builder id(String id) {
         	message.id = id;
         	return this;

--- a/negotiation/src/main/java/it/eng/negotiation/serializer/Serializer.java
+++ b/negotiation/src/main/java/it/eng/negotiation/serializer/Serializer.java
@@ -65,7 +65,6 @@ public class Serializer {
 				}
 				return super._findAnnotation(ann, annoClass);
 			}
-			
         };
         
 		jsonMapperPlain = JsonMapper.builder()

--- a/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/ContractNegotiationTest.java
@@ -146,6 +146,7 @@ public class ContractNegotiationTest {
 		ContractNegotiation obj = Serializer.deserializePlain(ss, ContractNegotiation.class);
 		// must exclude id since it is not according to protocol but internally
 		assertThat(contractNegotiation).usingRecursiveComparison().ignoringFieldsMatchingRegexes("id").isEqualTo(obj);
+		assertEquals(contractNegotiation.getId(), obj.getId());
 	}
 	
 	@Test
@@ -155,6 +156,8 @@ public class ContractNegotiationTest {
 		ContractNegotiation obj = Serializer.deserializeProtocol(ss, ContractNegotiation.class);
 		// must exclude id since it is not according to protocol but internally
 		assertThat(contractNegotiation).usingRecursiveComparison().ignoringFieldsMatchingRegexes("id").isEqualTo(obj);
+		// protocol does not have id field
+		//		assertEquals(contractNegotiation.getId(), obj.getId());
 	}
 	
 	private void validateJavaObj(ContractNegotiation javaObj) {

--- a/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/ContractNegotiationAPIServiceTest.java
@@ -100,6 +100,7 @@ public class ContractNegotiationAPIServiceTest {
 	public void startNegotiation_failed() {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE));
 		when(properties.consumerCallbackAddress()).thenReturn(MockObjectUtil.CALLBACK_ADDRESS);
 		
 		assertThrows(ContractNegotiationAPIException.class, ()-> service.startNegotiation(MockObjectUtil.FORWARD_TO, Serializer.serializePlainJsonNode(MockObjectUtil.OFFER)));
@@ -492,7 +493,7 @@ public class ContractNegotiationAPIServiceTest {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(contractNegotiationRepository.findById(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId())).thenReturn(Optional.of(MockObjectUtil.CONTRACT_NEGOTIATION_AGREED));
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-		
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE));
 		assertThrows(ContractNegotiationAPIException.class, 
 				() -> service.verifyNegotiation(MockObjectUtil.CONTRACT_NEGOTIATION_ACCEPTED.getId()));
 	}
@@ -547,6 +548,7 @@ public class ContractNegotiationAPIServiceTest {
 		when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
 		when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
 		when(apiResponse.isSuccess()).thenReturn(false);
+		when(apiResponse.getData()).thenReturn(Serializer.serializeProtocol(MockObjectUtil.CONTRACT_NEGOTIATION_ERROR_MESSAGE));
 
 		assertThrows(ContractNegotiationAPIException.class,
 				() -> service.handleContractNegotiationTerminated(contractNegotaitionId));

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,10 @@
 				<plugin>
 		          <groupId>org.apache.maven.plugins</groupId>
 		          <artifactId>maven-surefire-plugin</artifactId>
-		          <version>3.2.2</version>
+		          <version>3.5.2</version>
+		          <configuration>
+			      	<shutdown>kill</shutdown>
+		          </configuration>
 		        </plugin>
 				 <plugin>
 		          <groupId>org.apache.maven.plugins</groupId>

--- a/tools/src/main/java/it/eng/tools/client/rest/OkHttpRestClient.java
+++ b/tools/src/main/java/it/eng/tools/client/rest/OkHttpRestClient.java
@@ -28,7 +28,8 @@ public class OkHttpRestClient {
 	private OkHttpClient okHttpClient;
 	private CredentialUtils credentialUtils;
 	
-	public OkHttpRestClient(@Qualifier("okHttpClient") OkHttpClient okHttpClient, CredentialUtils credentialUtils, 
+//	@Qualifier("okHttpClient") 
+	public OkHttpRestClient(OkHttpClient okHttpClient, CredentialUtils credentialUtils, 
 			@Value("${server.port}")String serverPort) {
 		this.okHttpClient = okHttpClient;
 		this.credentialUtils = credentialUtils;
@@ -77,7 +78,7 @@ public class OkHttpRestClient {
 			if(response.isSuccessful()) { // code in 200..299
 				return GenericApiResponse.success(resp, "Response received from " + targetAddress);
 			} else {
-				return GenericApiResponse.error(resp);
+				return GenericApiResponse.error(resp, "Error while making request");
 			}
         } catch (IOException e) {
 			log.error(e.getLocalizedMessage());

--- a/tools/src/main/java/it/eng/tools/response/GenericApiResponse.java
+++ b/tools/src/main/java/it/eng/tools/response/GenericApiResponse.java
@@ -48,4 +48,13 @@ public class GenericApiResponse<T> implements Serializable {
                 .timestamp(ZonedDateTime.now())
                 .build();
     }
+    
+    public static <T> GenericApiResponse<T> error(T data, String message) {
+        return GenericApiResponse.<T>builder()
+                .message(message)
+                .data(data)
+                .success(false)
+                .timestamp(ZonedDateTime.now())
+                .build();
+    }
 }


### PR DESCRIPTION
### Changed

 - Moved integration tests into packages
 - ContractNegotiationAPIException accepts ContractNegotiationErrorMessage as parameter
 - ContractNegotiationAPIService when error happens, create ContractNegotiationErrorMessage
 - Dependency changed from de.flapdoodle.embed.mongo.spring30x to de.flapdoodle.embed.mongo.spring3x

### Added

 - Wiremock to simulate provider in integration requests