### PR TITLE
Feature/async transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.5-SNAPSHOT] - 03.07.2025.
+## [0.4.5-SNAPSHOT] - 04.07.2025.
+
+### Added
+
+- New event and logic for logging DataTransfer events
 
 ### Changed
 
@@ -10,6 +14,7 @@ All notable changes to this project will be documented in this file.
   background
 - Refactored DataTransferStrategy and implementing classes to return CompletableFuture<Void> for transfer method
 - GeneratePresignURL uses BucketCredentials
+- Renamed DataTranferMockObjectUtil to DataTransferMockObjectUtil
 - Updated tests and Postman collection
 
 ## [0.4.4-SNAPSHOT] - 03.07.2025.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.5-SNAPSHOT] - 03.07.2025.
+
+### Changed
+
+- DataTransferAPIController.downloadData is now async - response with code 202 is returned and download is done in
+  background
+- Refactored DataTransferStrategy and implementing classes to return CompletableFuture<Void> for transfer method
+- GeneratePresignURL uses BucketCredentials
+- Updated tests and Postman collection
+
 ## [0.4.4-SNAPSHOT] - 03.07.2025.
 
 ### Added

--- a/catalog/src/main/java/it/eng/catalog/service/ArtifactService.java
+++ b/catalog/src/main/java/it/eng/catalog/service/ArtifactService.java
@@ -7,7 +7,6 @@ import it.eng.tools.model.ArtifactType;
 import it.eng.tools.repository.ArtifactRepository;
 import it.eng.tools.s3.properties.S3Properties;
 import it.eng.tools.s3.service.S3ClientService;
-import it.eng.tools.util.ToolsUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ContentDisposition;
@@ -21,94 +20,95 @@ import java.util.Optional;
 @Slf4j
 public class ArtifactService {
 
-	private final ArtifactRepository artifactRepository;
-	private final S3ClientService s3ClientService;
-	private final S3Properties s3Properties;
+    private final ArtifactRepository artifactRepository;
+    private final S3ClientService s3ClientService;
+    private final S3Properties s3Properties;
 
-	public ArtifactService(ArtifactRepository artifactRepository, S3ClientService s3ClientService, S3Properties s3Properties) {
-		super();
-		this.artifactRepository = artifactRepository;
+    public ArtifactService(ArtifactRepository artifactRepository, S3ClientService s3ClientService, S3Properties s3Properties) {
+        super();
+        this.artifactRepository = artifactRepository;
         this.s3ClientService = s3ClientService;
         this.s3Properties = s3Properties;
     }
 
-	public List<Artifact> getArtifacts(String artifactId) {
-		if(StringUtils.isNotBlank(artifactId)) {
-			Optional<Artifact> artifact = artifactRepository.findById(artifactId);
-			if (artifact.isPresent()) {
-				return List.of(artifact.get());
-			} else {
-				throw new ResourceNotFoundAPIException("Artifact with id " + artifactId + " not found");
-			}
-		}
-		return artifactRepository.findAll();
-	}
+    public List<Artifact> getArtifacts(String artifactId) {
+        if (StringUtils.isNotBlank(artifactId)) {
+            Optional<Artifact> artifact = artifactRepository.findById(artifactId);
+            if (artifact.isPresent()) {
+                return List.of(artifact.get());
+            } else {
+                throw new ResourceNotFoundAPIException("Artifact with id " + artifactId + " not found");
+            }
+        }
+        return artifactRepository.findAll();
+    }
 
-	public Artifact uploadArtifact(String fileId, MultipartFile file, String externalURL, String authorization) {
-		Artifact artifact = null;
-		if (file != null) {
-			storeFile(fileId, file);
-			artifact = Artifact.Builder.newInstance()
-					.artifactType(ArtifactType.FILE)
-					.value(fileId)
-					.contentType(file.getContentType())
-					.filename(file.getOriginalFilename())
-					.build();
-		} else if (externalURL != null) {
-			artifact = Artifact.Builder.newInstance()
-					.artifactType(ArtifactType.EXTERNAL)
-					.authorization(authorization)
-					.value(externalURL)
-					.build();
-		} else {
-			log.warn("Artifact and file not found");
-			throw new CatalogErrorAPIException("Artifact and file not found");
-		}
-		artifact = artifactRepository.save(artifact);
-		log.info("Inserted Artifact {}", artifact.getFilename() != null ? artifact.getFilename() : artifact.getValue());
-		return artifact;
-	}
-	
-	public void deleteOldArtifact(Artifact artifact) {
-		log.info("Deleting artifact {}", artifact.getId());
-		switch (artifact.getArtifactType()) {
-		case EXTERNAL: {
-			break;
-		}
-		case FILE: {
-			try {
-				s3ClientService.deleteFile(s3Properties.getBucketName(), artifact.getValue());
-			} catch (Exception e) {
-				log.warn("Error while deleting file from S3: {}", e.getMessage());
-			}
-			break;
-		}
-		default:
-			break;
-		}
-		artifactRepository.delete(artifact);
-	}
+    public Artifact uploadArtifact(String fileId, MultipartFile file, String externalURL, String authorization) {
+        Artifact artifact = null;
+        if (file != null) {
+            storeFile(fileId, file);
+            artifact = Artifact.Builder.newInstance()
+                    .artifactType(ArtifactType.FILE)
+                    .value(fileId)
+                    .contentType(file.getContentType())
+                    .filename(file.getOriginalFilename())
+                    .build();
+        } else if (externalURL != null) {
+            artifact = Artifact.Builder.newInstance()
+                    .artifactType(ArtifactType.EXTERNAL)
+                    .authorization(authorization)
+                    .value(externalURL)
+                    .build();
+        } else {
+            log.warn("Artifact and file not found");
+            throw new CatalogErrorAPIException("Artifact and file not found");
+        }
+        artifact = artifactRepository.save(artifact);
+        log.info("Inserted Artifact {}", artifact.getFilename() != null ? artifact.getFilename() : artifact.getValue());
+        return artifact;
+    }
 
-	private String storeFile(String fileId, MultipartFile file) {
-		ContentDisposition contentDisposition = ContentDisposition.attachment()
-				.filename(file.getOriginalFilename())
-				.build();
+    public void deleteOldArtifact(Artifact artifact) {
+        log.info("Deleting artifact {}", artifact.getId());
+        switch (artifact.getArtifactType()) {
+            case EXTERNAL: {
+                break;
+            }
+            case FILE: {
+                try {
+                    s3ClientService.deleteFile(s3Properties.getBucketName(), artifact.getValue());
+                } catch (Exception e) {
+                    log.warn("Error while deleting file from S3: {}", e.getMessage());
+                }
+                break;
+            }
+            default:
+                break;
+        }
+        artifactRepository.delete(artifact);
+    }
 
-		// Upload file to S3
-		try {
-			s3ClientService.uploadFile(
-					file.getInputStream(),
-					s3Properties.getBucketName(),
-					fileId,
-					file.getContentType(),
-					contentDisposition.toString()
-			);
-		} catch (Exception e) {
-			log.error("File storing aborted", e);
-			throw new CatalogErrorAPIException("File storing aborted, " + e.getLocalizedMessage());
-		}
-		log.info("Stored file {} under id {}", file.getOriginalFilename() ,fileId);
+    private String storeFile(String fileId, MultipartFile file) {
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(file.getOriginalFilename())
+                .build();
 
-		return fileId;
-	}
+        // Upload file to S3
+        try {
+            s3ClientService.uploadFile(
+                    file.getInputStream(),
+                    s3Properties.getBucketName(),
+                    fileId,
+                    file.getContentType(),
+                    contentDisposition.toString()
+            ).get();
+            //TODO make also uploading async
+        } catch (Exception e) {
+            log.error("File storing aborted", e);
+            throw new CatalogErrorAPIException("File storing aborted, " + e.getLocalizedMessage());
+        }
+        log.info("Stored file {} under id {}", file.getOriginalFilename(), fileId);
+
+        return fileId;
+    }
 }

--- a/ci/docker/test-cases/datatransfer-api-tests/datatransfer-api-tests.json
+++ b/ci/docker/test-cases/datatransfer-api-tests/datatransfer-api-tests.json
@@ -1,954 +1,963 @@
 {
-	"info": {
-		"_postman_id": "aeb056ff-5a87-4458-ae9a-dbe902fe3833",
-		"name": "Data Transfer API test",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21815221",
-		"_collection_link": "https://true-connector.postman.co/workspace/My-Workspace~6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/21815221-aeb056ff-5a87-4458-ae9a-dbe902fe3833?action=share&source=collection_link&creator=21815221"
-	},
-	"item": [
-		{
-			"name": "[P] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
-					"host": [
-						"{{PROVIDER}}"
-					],
-					"path": [
-						"artifacts",
-						"{{transactionId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Request transfer",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Retrieve consumer transfer process id\", function () {\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.collectionVariables.set(\"consumer_transferProcessId\", jsonData[\"data\"][\"@id\"])\r",
-							"});\r",
-							"\r",
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});\r",
-							"\r",
-							"pm.test(\"TransactionId\", ()=> {\r",
-							"    var jsonData = pm.response.json();\r",
-							"    let trId = jsonData[\"data\"][\"consumerPid\"] + \"|\" + jsonData[\"data\"][\"providerPid\"];\r",
-							"    pm.collectionVariables.set(\"transactionId\", btoa(trId));\r",
-							"    console.log(pm.collectionVariables.get(\"transactionId\"));\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"transferProcessId\": \"{{consumer_transferProcessId}}\",\r\n    \"format\": \"HttpData-PULL\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"download"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] View data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"view"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[P] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
-					"host": [
-						"{{PROVIDER}}"
-					],
-					"path": [
-						"artifacts",
-						"{{transactionId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[P] Find Transfer Process",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});\r",
-							"\r",
-							"pm.test(\"Retrieve provider transfer process id\", function () {\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.collectionVariables.set(\"provider_transferProcessId\", jsonData[\"data\"][jsonData.data.length-1][\"@id\"])\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{PROVIDER_API_TRANSFERS}}?state=REQUESTED&role=provider",
-					"host": [
-						"{{PROVIDER_API_TRANSFERS}}"
-					],
-					"query": [
-						{
-							"key": "state",
-							"value": "REQUESTED"
-						},
-						{
-							"key": "role",
-							"value": "provider"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[P] Start transfer",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.collectionVariables.set(\"presignedURL\", jsonData[\"data\"][\"dataAddress\"][\"endpoint\"])\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{PROVIDER_API_TRANSFERS}}/{{provider_transferProcessId}}/start",
-					"host": [
-						"{{PROVIDER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{provider_transferProcessId}}",
-						"start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Download data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"download"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] View data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", () => {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var response = pm.response.text();\r",
-							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"view"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Use presignedURL to download actual data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{presignedURL}}",
-					"host": [
-						"{{presignedURL}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Suspend transfer",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/suspend",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"suspend"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"download"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] View data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var response = pm.response.text();\r",
-							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"view"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Use presignedURL to download actual data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{presignedURL}}",
-					"host": [
-						"{{presignedURL}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Start transfer",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/start",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"download"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] View data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var response = pm.response.text();\r",
-							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"view"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Use presignedURL to download actual data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{presignedURL}}",
-					"host": [
-						"{{presignedURL}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Complete transfer",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check if status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/complete",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"complete"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Download data fail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is client error or server error\", () => {\r",
-							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"download"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] View data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var response = pm.response.text();\r",
-							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-					"host": [
-						"{{CONSUMER_API_TRANSFERS}}"
-					],
-					"path": [
-						"{{consumer_transferProcessId}}",
-						"view"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "[C] Use presignedURL to download actual data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Check expected response\", ()=> {\r",
-							"    pm.response.to.have.status(200);\r",
-							"    var jsonData = pm.response.json();\r",
-							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-							"});"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{presignedURL}}",
-					"host": [
-						"{{presignedURL}}"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"auth": {
-		"type": "basic",
-		"basic": [
-			{
-				"key": "password",
-				"value": "password",
-				"type": "string"
-			},
-			{
-				"key": "username",
-				"value": "admin@mail.com",
-				"type": "string"
-			}
-		]
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "PROVIDER",
-			"value": "http://172.17.0.1:8090",
-			"type": "string"
-		},
-		{
-			"key": "CONSUMER_API_TRANSFERS",
-			"value": "http://localhost:8080/api/v1/transfers",
-			"type": "default"
-		},
-		{
-			"key": "PROVIDER_API_TRANSFERS",
-			"value": "http://localhost:8090/api/v1/transfers",
-			"type": "default"
-		},
-		{
-			"key": "consumer_transferProcessId",
-			"value": "urn:uuid:abc45798-1434-4932-8baf-ab7fd66ql4d5",
-			"type": "string"
-		}
-	]
+  "info": {
+    "_postman_id": "aeb056ff-5a87-4458-ae9a-dbe902fe3833",
+    "name": "Data Transfer API test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "21815221",
+    "_collection_link": "https://true-connector.postman.co/workspace/My-Workspace~6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/21815221-aeb056ff-5a87-4458-ae9a-dbe902fe3833?action=share&source=collection_link&creator=21815221"
+  },
+  "item": [
+    {
+      "name": "[P] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
+          "host": [
+            "{{PROVIDER}}"
+          ],
+          "path": [
+            "artifacts",
+            "{{transactionId}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Request transfer",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Retrieve consumer transfer process id\", function () {\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.collectionVariables.set(\"consumer_transferProcessId\", jsonData[\"data\"][\"@id\"])\r",
+              "});\r",
+              "\r",
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});\r",
+              "\r",
+              "pm.test(\"TransactionId\", ()=> {\r",
+              "    var jsonData = pm.response.json();\r",
+              "    let trId = jsonData[\"data\"][\"consumerPid\"] + \"|\" + jsonData[\"data\"][\"providerPid\"];\r",
+              "    pm.collectionVariables.set(\"transactionId\", btoa(trId));\r",
+              "    console.log(pm.collectionVariables.get(\"transactionId\"));\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"transferProcessId\": \"{{consumer_transferProcessId}}\",\r\n    \"format\": \"HttpData-PULL\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "download"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] View data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "view"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[P] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
+          "host": [
+            "{{PROVIDER}}"
+          ],
+          "path": [
+            "artifacts",
+            "{{transactionId}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[P] Find Transfer Process",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});\r",
+              "\r",
+              "pm.test(\"Retrieve provider transfer process id\", function () {\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.collectionVariables.set(\"provider_transferProcessId\", jsonData[\"data\"][jsonData.data.length-1][\"@id\"])\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{PROVIDER_API_TRANSFERS}}?state=REQUESTED&role=provider",
+          "host": [
+            "{{PROVIDER_API_TRANSFERS}}"
+          ],
+          "query": [
+            {
+              "key": "state",
+              "value": "REQUESTED"
+            },
+            {
+              "key": "role",
+              "value": "provider"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[P] Start transfer",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.collectionVariables.set(\"presignedURL\", jsonData[\"data\"][\"dataAddress\"][\"endpoint\"])\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{PROVIDER_API_TRANSFERS}}/{{provider_transferProcessId}}/start",
+          "host": [
+            "{{PROVIDER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{provider_transferProcessId}}",
+            "start"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Download data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "download"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] View data",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "setTimeout(() => {}, 5000);"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", () => {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var response = pm.response.text();\r",
+              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "view"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Use presignedURL to download actual data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{presignedURL}}",
+          "host": [
+            "{{presignedURL}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Suspend transfer",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/suspend",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "suspend"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "download"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] View data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var response = pm.response.text();\r",
+              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "view"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Use presignedURL to download actual data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{presignedURL}}",
+          "host": [
+            "{{presignedURL}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Start transfer",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/start",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "start"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "download"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] View data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var response = pm.response.text();\r",
+              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "view"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Use presignedURL to download actual data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{presignedURL}}",
+          "host": [
+            "{{presignedURL}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Complete transfer",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check if status code is 200\", function () {\r",
+              "    pm.response.to.have.status(200);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/complete",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "complete"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Download data fail",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is client error or server error\", () => {\r",
+              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "download"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] View data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var response = pm.response.text();\r",
+              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
+          "host": [
+            "{{CONSUMER_API_TRANSFERS}}"
+          ],
+          "path": [
+            "{{consumer_transferProcessId}}",
+            "view"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "[C] Use presignedURL to download actual data",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Check expected response\", ()=> {\r",
+              "    pm.response.to.have.status(200);\r",
+              "    var jsonData = pm.response.json();\r",
+              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+              "});"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{presignedURL}}",
+          "host": [
+            "{{presignedURL}}"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "basic",
+    "basic": [
+      {
+        "key": "password",
+        "value": "password",
+        "type": "string"
+      },
+      {
+        "key": "username",
+        "value": "admin@mail.com",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "PROVIDER",
+      "value": "http://172.17.0.1:8090",
+      "type": "string"
+    },
+    {
+      "key": "CONSUMER_API_TRANSFERS",
+      "value": "http://localhost:8080/api/v1/transfers",
+      "type": "default"
+    },
+    {
+      "key": "PROVIDER_API_TRANSFERS",
+      "value": "http://localhost:8090/api/v1/transfers",
+      "type": "default"
+    },
+    {
+      "key": "consumer_transferProcessId",
+      "value": "urn:uuid:abc45798-1434-4932-8baf-ab7fd66ql4d5",
+      "type": "string"
+    }
+  ]
 }

--- a/ci/docker/test-cases/datatransfer-api-tests/datatransfer-api-tests.json
+++ b/ci/docker/test-cases/datatransfer-api-tests/datatransfer-api-tests.json
@@ -1,963 +1,664 @@
 {
-  "info": {
-    "_postman_id": "aeb056ff-5a87-4458-ae9a-dbe902fe3833",
-    "name": "Data Transfer API test",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "21815221",
-    "_collection_link": "https://true-connector.postman.co/workspace/My-Workspace~6be747d4-8cb4-4754-802a-4e3fb2f11910/collection/21815221-aeb056ff-5a87-4458-ae9a-dbe902fe3833?action=share&source=collection_link&creator=21815221"
-  },
-  "item": [
-    {
-      "name": "[P] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
-          "host": [
-            "{{PROVIDER}}"
-          ],
-          "path": [
-            "artifacts",
-            "{{transactionId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Request transfer",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Retrieve consumer transfer process id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"consumer_transferProcessId\", jsonData[\"data\"][\"@id\"])\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"TransactionId\", ()=> {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    let trId = jsonData[\"data\"][\"consumerPid\"] + \"|\" + jsonData[\"data\"][\"providerPid\"];\r",
-              "    pm.collectionVariables.set(\"transactionId\", btoa(trId));\r",
-              "    console.log(pm.collectionVariables.get(\"transactionId\"));\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [],
-        "body": {
-          "mode": "raw",
-          "raw": "{\r\n    \"transferProcessId\": \"{{consumer_transferProcessId}}\",\r\n    \"format\": \"HttpData-PULL\"\r\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "download"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] View data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "view"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[P] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "{{PROVIDER}}/artifacts/{{transactionId}}",
-          "host": [
-            "{{PROVIDER}}"
-          ],
-          "path": [
-            "artifacts",
-            "{{transactionId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[P] Find Transfer Process",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Retrieve provider transfer process id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"provider_transferProcessId\", jsonData[\"data\"][jsonData.data.length-1][\"@id\"])\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{PROVIDER_API_TRANSFERS}}?state=REQUESTED&role=provider",
-          "host": [
-            "{{PROVIDER_API_TRANSFERS}}"
-          ],
-          "query": [
-            {
-              "key": "state",
-              "value": "REQUESTED"
-            },
-            {
-              "key": "role",
-              "value": "provider"
-            }
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[P] Start transfer",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"presignedURL\", jsonData[\"data\"][\"dataAddress\"][\"endpoint\"])\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "PUT",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{PROVIDER_API_TRANSFERS}}/{{provider_transferProcessId}}/start",
-          "host": [
-            "{{PROVIDER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{provider_transferProcessId}}",
-            "start"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Download data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "download"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] View data",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "setTimeout(() => {}, 5000);"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", () => {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var response = pm.response.text();\r",
-              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "view"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Use presignedURL to download actual data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{presignedURL}}",
-          "host": [
-            "{{presignedURL}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Suspend transfer",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "PUT",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/suspend",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "suspend"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "download"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] View data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var response = pm.response.text();\r",
-              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "view"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Use presignedURL to download actual data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{presignedURL}}",
-          "host": [
-            "{{presignedURL}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Start transfer",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "PUT",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/start",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "start"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "download"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] View data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var response = pm.response.text();\r",
-              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "view"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Use presignedURL to download actual data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{presignedURL}}",
-          "host": [
-            "{{presignedURL}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Complete transfer",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "PUT",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/complete",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "complete"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Download data fail",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Status code is client error or server error\", () => {\r",
-              "    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "download"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] View data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var response = pm.response.text();\r",
-              "    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view",
-          "host": [
-            "{{CONSUMER_API_TRANSFERS}}"
-          ],
-          "path": [
-            "{{consumer_transferProcessId}}",
-            "view"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "[C] Use presignedURL to download actual data",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check expected response\", ()=> {\r",
-              "    pm.response.to.have.status(200);\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{presignedURL}}",
-          "host": [
-            "{{presignedURL}}"
-          ]
-        }
-      },
-      "response": []
-    }
-  ],
-  "auth": {
-    "type": "basic",
-    "basic": [
-      {
-        "key": "password",
-        "value": "password",
-        "type": "string"
-      },
-      {
-        "key": "username",
-        "value": "admin@mail.com",
-        "type": "string"
-      }
-    ]
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [
-          ""
-        ]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [
-          ""
-        ]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "key": "PROVIDER",
-      "value": "http://172.17.0.1:8090",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_API_TRANSFERS",
-      "value": "http://localhost:8080/api/v1/transfers",
-      "type": "default"
-    },
-    {
-      "key": "PROVIDER_API_TRANSFERS",
-      "value": "http://localhost:8090/api/v1/transfers",
-      "type": "default"
-    },
-    {
-      "key": "consumer_transferProcessId",
-      "value": "urn:uuid:abc45798-1434-4932-8baf-ab7fd66ql4d5",
-      "type": "string"
-    }
-  ]
+	"info": {
+		"_postman_id": "6fa1f6f6-b027-4eb1-9fa1-e7c121eb0cb8",
+		"name": "Data Transfer API test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		"_exporter_id": "36278855"
+	},
+	"item": [
+		{
+			"name": "[P] Download data fail",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is client error or server error\", () => {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": "{{PROVIDER}}/artifacts/{{transactionId}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Request transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Retrieve consumer transfer process id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"consumer_transferProcessId\", jsonData[\"data\"][\"@id\"])\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"TransactionId\", ()=> {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    let trId = jsonData[\"data\"][\"consumerPid\"] + \"|\" + jsonData[\"data\"][\"providerPid\"];\r",
+							"    pm.collectionVariables.set(\"transactionId\", btoa(trId));\r",
+							"    console.log(pm.collectionVariables.get(\"transactionId\"));\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"transferProcessId\": \"{{consumer_transferProcessId}}\",\r\n    \"format\": \"HttpData-PULL\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "{{CONSUMER_API_TRANSFERS}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[P] Download data fail",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is client error or server error\", () => {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([400, 401, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 422, 423, 424, 425, 426, 428, 429, 431, 451, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511]);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": "{{PROVIDER}}/artifacts/{{transactionId}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[P] Find Transfer Process",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Retrieve provider transfer process id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"provider_transferProcessId\", jsonData[\"data\"][jsonData.data.length-1][\"@id\"])\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{PROVIDER_API_TRANSFERS}}?state=REQUESTED&role=provider",
+					"host": [
+						"{{PROVIDER_API_TRANSFERS}}"
+					],
+					"query": [
+						{
+							"key": "state",
+							"value": "REQUESTED"
+						},
+						{
+							"key": "role",
+							"value": "provider"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "[P] Start transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"presignedURL\", jsonData[\"data\"][\"dataAddress\"][\"endpoint\"])\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "{{PROVIDER_API_TRANSFERS}}/{{provider_transferProcessId}}/start"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Download data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 202\", function () {\r",
+							"    pm.response.to.have.status(202);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/download"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] View data",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"setTimeout(() => {}, 5000);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", () => {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var response = pm.response.text();\r",
+							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Use presignedURL to download actual data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{presignedURL}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Suspend transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/suspend"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] View data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var response = pm.response.text();\r",
+							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Use presignedURL to download actual data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{presignedURL}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Start transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/start"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] View data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var response = pm.response.text();\r",
+							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Introduce a delay of 2 seconds before sending the request\r",
+							"setTimeout(() => {}, 2000);\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Use presignedURL to download actual data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{presignedURL}}"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Complete transfer",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/complete"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] View data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var response = pm.response.text();\r",
+							"    pm.expect(response).to.include(\"http://172.17.0.1:9000/dsp-true-connector-a\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{CONSUMER_API_TRANSFERS}}/{{consumer_transferProcessId}}/view"
+			},
+			"response": []
+		},
+		{
+			"name": "[C] Use presignedURL to download actual data",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check expected response\", ()=> {\r",
+							"    pm.response.to.have.status(200);\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData[0]['employee']['name']).to.eq('John Doe');\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": "{{presignedURL}}"
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "basic",
+		"basic": {
+			"password": "password",
+			"username": "admin@mail.com"
+		}
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "PROVIDER",
+			"value": "http://172.17.0.1:8090",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_API_TRANSFERS",
+			"value": "http://localhost:8080/api/v1/transfers",
+			"type": "default"
+		},
+		{
+			"key": "PROVIDER_API_TRANSFERS",
+			"value": "http://localhost:8090/api/v1/transfers",
+			"type": "default"
+		},
+		{
+			"key": "consumer_transferProcessId",
+			"value": "urn:uuid:abc45798-1434-4932-8baf-ab7fd66ql4d5",
+			"type": "string"
+		},
+		{
+			"key": "transactionId",
+			"value": ""
+		},
+		{
+			"key": "provider_transferProcessId",
+			"value": ""
+		},
+		{
+			"key": "presignedURL",
+			"value": ""
+		}
+	]
 }

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferAPIDownloadDataIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferAPIDownloadDataIntegrationTest.java
@@ -25,16 +25,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 import org.wiremock.spring.InjectWireMock;
-import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -43,6 +38,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -52,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationTest {
 
     private static final String FILE_NAME = "hello.txt";
-    private String fileContent = "Hello, World!";
+    private final String fileContent = "Hello, World!";
 
     @InjectWireMock
     private WireMockServer wiremock;
@@ -84,6 +80,8 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
     @Autowired
     private S3Properties s3Properties;
 
+    private Dataset mockDataset;
+
     @BeforeEach
     public void cleanup() {
         transferProcessRepository.deleteAll();
@@ -99,6 +97,7 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                 }
             }
         }
+        mockDataset = getMockDataset();
     }
 
     @Test
@@ -106,9 +105,6 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
     @WithUserDetails(TestUtil.API_USER)
     public void downloadData_success() throws Exception {
         int startingTransferProcessCollectionSize = transferProcessRepository.findAll().size();
-        int startingBucketFileCount = s3ClientService.listFiles(s3Properties.getBucketName()).size();
-
-        Dataset mockDataset = getMockDataset();
 
         Agreement agreement = Agreement.Builder.newInstance()
                 .id(createNewId())
@@ -116,9 +112,9 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                 .assigner(NegotiationMockObjectUtil.ASSIGNER)
                 .target(NegotiationMockObjectUtil.TARGET)
                 .timestamp(Instant.now().toString())
-                .permission(Arrays.asList(Permission.Builder.newInstance()
+                .permission(Collections.singletonList(Permission.Builder.newInstance()
                         .action(Action.USE)
-                        .constraint(Arrays.asList(Constraint.Builder.newInstance()
+                        .constraint(Collections.singletonList(Constraint.Builder.newInstance()
                                 .leftOperand(LeftOperand.COUNT)
                                 .operator(Operator.LTEQ)
                                 .rightOperand("5")
@@ -168,7 +164,7 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                         get(ApiEndpoints.TRANSFER_DATATRANSFER_V1 + "/" + transferProcessStarted.getId() + "/download")
                                 .contentType(MediaType.APPLICATION_JSON));
 
-        result.andExpect(status().isOk())
+        result.andExpect(status().isAccepted())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
         TypeReference<GenericApiResponse<String>> typeRef = new TypeReference<GenericApiResponse<String>>() {
@@ -179,14 +175,14 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
 
         assertNotNull(apiResp);
         assertTrue(apiResp.isSuccess());
-        assertNull(apiResp.getData());
-
+        assertNotNull(apiResp.getData());
+        assertEquals("Download started for transfer process " + transferProcessStarted.getId(), apiResp.getData());
 
         // check if the TransferProcess is inserted in the database
         TransferProcess transferProcessFromDb = transferProcessRepository.findById(transferProcessStarted.getId()).get();
 
-        assertTrue(transferProcessFromDb.isDownloaded());
-        assertNotNull(transferProcessFromDb.getDataId());
+        // this one should be skipped since we cannot guarantee that download will be done - transferProcessFromDb.isDownloaded() equal true
+//        assertNotNull(transferProcessFromDb.getDataId());
         assertEquals(transferProcessStarted.getConsumerPid(), transferProcessFromDb.getConsumerPid());
         assertEquals(transferProcessStarted.getProviderPid(), transferProcessFromDb.getProviderPid());
         assertEquals(transferProcessStarted.getAgreementId(), transferProcessFromDb.getAgreementId());
@@ -196,22 +192,22 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
         assertEquals(startingTransferProcessCollectionSize + 1, transferProcessRepository.findAll().size());
 
 
-        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
-        s3ClientService.downloadFile(s3Properties.getBucketName(), transferProcessStarted.getId(), mockResponse);
-
-        ResponseBytes<GetObjectResponse> fileFromStorage = ResponseBytes.fromByteArray(GetObjectResponse.builder()
-                        .contentType(mockResponse.getContentType())
-                        .contentDisposition(mockResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION))
-                        .build(),
-                mockResponse.getContentAsByteArray());
-
-        ContentDisposition contentDisposition = ContentDisposition.parse(fileFromStorage.response().contentDisposition());
-
-        assertEquals(MediaType.TEXT_PLAIN_VALUE, fileFromStorage.response().contentType());
-        assertEquals(FILE_NAME, contentDisposition.getFilename());
-        assertEquals(fileContent, fileFromStorage.asUtf8String());
-        // +2 from test; inserted Dataset with file and downloaded TransferProcess
-        checkIfEndBucketFileCountIsAsExpected(startingBucketFileCount + 2);
+//        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+//        s3ClientService.downloadFile(s3Properties.getBucketName(), transferProcessStarted.getId(), mockResponse);
+//
+//        ResponseBytes<GetObjectResponse> fileFromStorage = ResponseBytes.fromByteArray(GetObjectResponse.builder()
+//                        .contentType(mockResponse.getContentType())
+//                        .contentDisposition(mockResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION))
+//                        .build(),
+//                mockResponse.getContentAsByteArray());
+//
+//        ContentDisposition contentDisposition = ContentDisposition.parse(fileFromStorage.response().contentDisposition());
+//
+//        assertEquals(MediaType.TEXT_PLAIN_VALUE, fileFromStorage.response().contentType());
+//        assertEquals(FILE_NAME, contentDisposition.getFilename());
+//        assertEquals(fileContent, fileFromStorage.asUtf8String());
+//        // +2 from test; inserted Dataset with file and downloaded TransferProcess
+//        checkIfEndBucketFileCountIsAsExpected(startingBucketFileCount + 2);
     }
 
     @Test
@@ -219,9 +215,6 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
     @WithUserDetails(TestUtil.API_USER)
     public void downloadData_fail() throws Exception {
         int startingTransferProcessCollectionSize = transferProcessRepository.findAll().size();
-        int startingBucketFileCount = s3ClientService.listFiles(s3Properties.getBucketName()).size();
-
-        Dataset mockDataset = getMockDataset();
 
         Agreement agreement = Agreement.Builder.newInstance()
                 .id(createNewId())
@@ -229,9 +222,9 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                 .assigner(NegotiationMockObjectUtil.ASSIGNER)
                 .target(NegotiationMockObjectUtil.TARGET)
                 .timestamp(Instant.now().toString())
-                .permission(Arrays.asList(Permission.Builder.newInstance()
+                .permission(Collections.singletonList(Permission.Builder.newInstance()
                         .action(Action.USE)
-                        .constraint(Arrays.asList(Constraint.Builder.newInstance()
+                        .constraint(Collections.singletonList(Constraint.Builder.newInstance()
                                 .leftOperand(LeftOperand.COUNT)
                                 .operator(Operator.LTEQ)
                                 .rightOperand("5")
@@ -308,11 +301,6 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
         assertEquals(transferProcessStarted.getState(), transferProcessFromDb.getState());
         // +1 from test
         assertEquals(startingTransferProcessCollectionSize + 1, transferProcessRepository.findAll().size());
-
-        // check if the file is inserted in the database
-        // 1 from initial data + 1 from test; dataset is added but not downloaded
-        checkIfEndBucketFileCountIsAsExpected(startingBucketFileCount + 1);
-
     }
 
     @Test
@@ -320,9 +308,6 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
     @WithUserDetails(TestUtil.API_USER)
     public void downloadData_PurposePolicy_allowed() throws Exception {
         int startingTransferProcessCollectionSize = transferProcessRepository.findAll().size();
-        int startingBucketFileCount = s3ClientService.listFiles(s3Properties.getBucketName()).size();
-
-        Dataset mockDataset = getMockDataset();
 
         Constraint constraintPurpose = Constraint.Builder.newInstance()
                 .leftOperand(LeftOperand.PURPOSE)
@@ -368,7 +353,7 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                         get(ApiEndpoints.TRANSFER_DATATRANSFER_V1 + "/" + transferProcessStarted.getId() + "/download")
                                 .contentType(MediaType.APPLICATION_JSON));
 
-        result.andExpect(status().isOk())
+        result.andExpect(status().isAccepted())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
         TypeReference<GenericApiResponse<String>> typeRef = new TypeReference<GenericApiResponse<String>>() {
@@ -379,11 +364,11 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
 
         assertNotNull(apiResp);
         assertTrue(apiResp.isSuccess());
-        assertNull(apiResp.getData());
+        assertNotNull(apiResp.getData());
+        assertEquals("Download started for transfer process " + transferProcessStarted.getId(), apiResp.getData());
+
         // + 1 from test
         assertEquals(startingTransferProcessCollectionSize + 1, transferProcessRepository.findAll().size());
-        // +2 from test; inserted Dataset with file and downloaded TransferProcess
-        checkIfEndBucketFileCountIsAsExpected(startingBucketFileCount + 2);
     }
 
     @Test
@@ -391,9 +376,6 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
     @WithUserDetails(TestUtil.API_USER)
     public void downloadData_LocationPolicy_allowed() throws Exception {
         int startingTransferProcessCollectionSize = transferProcessRepository.findAll().size();
-        int startingBucketFileCount = s3ClientService.listFiles(s3Properties.getBucketName()).size();
-
-        Dataset mockDataset = getMockDataset();
 
         Constraint constraintPurpose = Constraint.Builder.newInstance()
                 .leftOperand(LeftOperand.SPATIAL)
@@ -439,7 +421,7 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                         get(ApiEndpoints.TRANSFER_DATATRANSFER_V1 + "/" + transferProcessStarted.getId() + "/download")
                                 .contentType(MediaType.APPLICATION_JSON));
 
-        result.andExpect(status().isOk())
+        result.andExpect(status().isAccepted())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
         TypeReference<GenericApiResponse<String>> typeRef = new TypeReference<GenericApiResponse<String>>() {
@@ -450,11 +432,8 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
 
         assertNotNull(apiResp);
         assertTrue(apiResp.isSuccess());
-        assertNull(apiResp.getData());
         // + 1 from test
         assertEquals(startingTransferProcessCollectionSize + 1, transferProcessRepository.findAll().size());
-        // +2 from test; inserted Dataset with file and downloaded TransferProcess
-        checkIfEndBucketFileCountIsAsExpected(startingBucketFileCount + 2);
     }
 
     private Agreement insertAgreement(Constraint constraint) {
@@ -464,9 +443,9 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                 .assigner(NegotiationMockObjectUtil.ASSIGNER)
                 .target(NegotiationMockObjectUtil.TARGET)
                 .timestamp(Instant.now().toString())
-                .permission(Arrays.asList(Permission.Builder.newInstance()
+                .permission(Collections.singletonList(Permission.Builder.newInstance()
                         .action(Action.USE)
-                        .constraint(Arrays.asList(constraint))
+                        .constraint(Collections.singletonList(constraint))
                         .build()))
                 .build();
 
@@ -479,21 +458,21 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
                 .id(CatalogMockObjectUtil.DATASET_ID)
                 .conformsTo(CatalogMockObjectUtil.CONFORMSTO)
                 .creator(CatalogMockObjectUtil.CREATOR)
-                .distribution(Arrays.asList(CatalogMockObjectUtil.DISTRIBUTION).stream().collect(Collectors.toCollection(HashSet::new)))
-                .description(Arrays.asList(CatalogMockObjectUtil.MULTILANGUAGE).stream().collect(Collectors.toCollection(HashSet::new)))
+                .distribution(Stream.of(CatalogMockObjectUtil.DISTRIBUTION).collect(Collectors.toCollection(HashSet::new)))
+                .description(new HashSet<>(Collections.singletonList(CatalogMockObjectUtil.MULTILANGUAGE)))
                 .issued(CatalogMockObjectUtil.ISSUED)
-                .keyword(Arrays.asList("keyword1", "keyword2").stream().collect(Collectors.toCollection(HashSet::new)))
+                .keyword(new HashSet<>(Arrays.asList("keyword1", "keyword2")))
                 .identifier(CatalogMockObjectUtil.IDENTIFIER)
                 .modified(CatalogMockObjectUtil.MODIFIED)
-                .theme(Arrays.asList("white", "blue", "aqua").stream().collect(Collectors.toCollection(HashSet::new)))
+                .theme(new HashSet<>(Arrays.asList("white", "blue", "aqua")))
                 .title(CatalogMockObjectUtil.TITLE)
-                .hasPolicy(Arrays.asList(CatalogMockObjectUtil.OFFER).stream().collect(Collectors.toCollection(HashSet::new)))
+                .hasPolicy(new HashSet<>(Collections.singletonList(CatalogMockObjectUtil.OFFER)))
                 .build();
 
         Catalog mockCatalog = Catalog.Builder.newInstance()
                 .id(createNewId())
                 .title(CatalogMockObjectUtil.TITLE)
-                .description(Arrays.asList(CatalogMockObjectUtil.MULTILANGUAGE).stream().collect(Collectors.toCollection(HashSet::new)))
+                .description(new HashSet<>(Collections.singletonList(CatalogMockObjectUtil.MULTILANGUAGE)))
                 .dataset(Collections.emptySet())
                 .build();
         catalogRepository.save(mockCatalog);
@@ -501,19 +480,5 @@ public class DataTransferAPIDownloadDataIntegrationTest extends BaseIntegrationT
         MockMultipartFile mockFile = new MockMultipartFile(FILE_NAME, FILE_NAME, MediaType.TEXT_PLAIN_VALUE, fileContent.getBytes());
         datasetService.saveDataset(mockDataset, mockFile, null, null);
         return mockDataset;
-    }
-
-    private void checkIfEndBucketFileCountIsAsExpected(int expectedEndBucketFileCount) throws InterruptedException {
-        // Wait for S3 to reflect the deletion (max 5 seconds)
-        int maxRetries = 10;
-        int delayMs = 500;
-        // this is to ensure that the test functions correctly since the count will never -10000
-        int endBucketFileCount = -10000;
-        for (int i = 0; i < maxRetries; i++) {
-            endBucketFileCount = s3ClientService.listFiles(s3Properties.getBucketName()).size();
-            if (endBucketFileCount == expectedEndBucketFileCount) break;
-            Thread.sleep(delayMs);
-        }
-        assertEquals(endBucketFileCount, expectedEndBucketFileCount);
     }
 }

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessCompletedIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessCompletedIntegrationTest.java
@@ -1,11 +1,12 @@
 package it.eng.connector.integration.datatransfer;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import it.eng.connector.integration.BaseIntegrationTest;
+import it.eng.connector.util.TestUtil;
+import it.eng.datatransfer.model.*;
+import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.datatransfer.serializer.TransferSerializer;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.tools.model.IConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,246 +15,238 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
-import it.eng.connector.integration.BaseIntegrationTest;
-import it.eng.connector.util.TestUtil;
-import it.eng.datatransfer.model.DataTransferFormat;
-import it.eng.datatransfer.model.TransferCompletionMessage;
-import it.eng.datatransfer.model.TransferError;
-import it.eng.datatransfer.model.TransferProcess;
-import it.eng.datatransfer.model.TransferRequestMessage;
-import it.eng.datatransfer.model.TransferStartMessage;
-import it.eng.datatransfer.model.TransferState;
-import it.eng.datatransfer.repository.TransferProcessRepository;
-import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.tools.model.IConstants;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class DataTransferProcessCompletedIntegrationTest extends BaseIntegrationTest {
 // STARTED -> COMPLETED
-	
-	@Autowired
-	private TransferProcessRepository transferProcessRepository;
-	
-	@AfterEach
-	public void cleanup() {
-		transferProcessRepository.deleteAll();
-	}
 
-	// Provider
-	@Test
-	@DisplayName("Complete transfer process - from started")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_provider() throws Exception {
-		
-		TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.state(TransferState.STARTED)
-    			.role(IConstants.ROLE_PROVIDER)
-    			.build();
-    	transferProcessRepository.save(transferProcessStarted);
-	      
-    	TransferCompletionMessage transferCompletionMessage = TransferCompletionMessage.Builder.newInstance()
-				.consumerPid(transferProcessStarted.getConsumerPid())
-				.providerPid(transferProcessStarted.getProviderPid())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/" + transferCompletionMessage.getProviderPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferCompletionMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isOk());
+    @Autowired
+    private TransferProcessRepository transferProcessRepository;
+
+    @AfterEach
+    public void cleanup() {
+        transferProcessRepository.deleteAll();
+    }
+
+    // Provider
+    @Test
+    @DisplayName("Complete transfer process - from started")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_provider() throws Exception {
+
+        TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .state(TransferState.STARTED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        transferProcessRepository.save(transferProcessStarted);
+
+        TransferCompletionMessage transferCompletionMessage = TransferCompletionMessage.Builder.newInstance()
+                .consumerPid(transferProcessStarted.getConsumerPid())
+                .providerPid(transferProcessStarted.getProviderPid())
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/" + transferCompletionMessage.getProviderPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferCompletionMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isOk());
 //    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-    	ResultActions transferProcessStartedAction = mockMvc.perform(
-    			get("/transfers/" + transferProcessStarted.getProviderPid())
-    			.contentType(MediaType.APPLICATION_JSON));
-    	// check if status is STARTED
-    	transferProcessStartedAction.andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-    	String response = transferProcessStartedAction.andReturn().getResponse().getContentAsString();
-    	TransferProcess transferProcessStarted2 = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
-    	assertNotNull(transferProcessStarted2);
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - not_found")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_transfer_not_found() throws Exception {
-    	TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
-				.providerPid(createNewId())
-				.consumerPid(createNewId())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/" + transferProcessStarted.getProviderPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferProcessStarted))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
 
-    	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-    	assertNotNull(transferError);
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - provider - invalid message type")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_provider_transfer_invalid_msg() throws Exception {
-		TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(createNewId())
-	    		.agreementId("agreement_id")
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/" + transferRequestMessage.getConsumerPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - invalid state")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_invalid_state() throws Exception {
-		TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.state(TransferState.REQUESTED)
-    			.role(IConstants.ROLE_PROVIDER)
-    			.build();
-    	transferProcessRepository.save(transferProcessRequested);
-	      
-    	TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
-				.providerPid(createNewId())
-				.consumerPid(createNewId())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/" + transferProcessStarted.getProviderPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferProcessStarted))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
+        ResultActions transferProcessStartedAction = mockMvc.perform(
+                get("/transfers/" + transferProcessStarted.getProviderPid())
+                        .contentType(MediaType.APPLICATION_JSON));
+        // check if status is STARTED
+        transferProcessStartedAction.andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
-    	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-    	assertNotNull(transferError);
-	}
-	
-	// Consumer
-	@Test
-	@DisplayName("Complete transfer process - from requested - consumer")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void startTransferProcess_consumer() throws Exception {
-		TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.state(TransferState.STARTED)
-    			.role(IConstants.ROLE_PROVIDER)
-    			.build();
-    	transferProcessRepository.save(transferProcessStarted);
-    	
-    	TransferCompletionMessage transferCompletionMessage = TransferCompletionMessage.Builder.newInstance()
-				.consumerPid(transferProcessStarted.getConsumerPid())
-				.providerPid(transferProcessStarted.getProviderPid())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/consumer/transfers/" + transferCompletionMessage.getConsumerPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferCompletionMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isOk());
-    	
-    	//?? not sure if this is correct endpoint or it should be consumer/transfers/{consumerPid}
-    	// but such endpoint does not exists in protocol specification
-    	ResultActions transferProcessStartedAction = mockMvc.perform(
-    			get("/transfers/" + transferProcessStarted.getProviderPid())
-    			.contentType(MediaType.APPLICATION_JSON));
-    	// check if status is STARTED
-    	transferProcessStartedAction.andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-    	String response = transferProcessStartedAction.andReturn().getResponse().getContentAsString();
-    	TransferProcess transferProcessStarted2 = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
-    	assertNotNull(transferProcessStarted2);
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - consumer - not_found")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_consumer_transfer_not_found() throws Exception {
-    	TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
-				.providerPid(createNewId())
-				.consumerPid(createNewId())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/consumer/transfers/" + transferProcessStarted.getConsumerPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferProcessStarted))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
+        String response = transferProcessStartedAction.andReturn().getResponse().getContentAsString();
+        TransferProcess transferProcessStarted2 = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
+        assertNotNull(transferProcessStarted2);
+    }
 
-    	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-    	assertNotNull(transferError);
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - consumer - invalid msg")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_consumer_transfer_invalid_msg() throws Exception {
-		TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(createNewId())
-	    		.agreementId("agreement_id")
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/consumer/transfers/" + transferRequestMessage.getConsumerPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
-	}
-	
-	@Test
-	@DisplayName("Complete transfer process - consumer - invalid state")
-	@WithUserDetails(TestUtil.CONNECTOR_USER)
-	public void completeTransferProcess_consumer_invalid_state() throws Exception {
-		TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.state(TransferState.REQUESTED)
-    			.role(IConstants.ROLE_PROVIDER)
-    			.build();
-    	transferProcessRepository.save(transferProcessRequested);
-	      
-    	TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
-				.providerPid(createNewId())
-				.consumerPid(createNewId())
-				.build();
-    	
-		final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/" + transferProcessStarted.getConsumerPid() +"/completion")
-    					.content(TransferSerializer.serializeProtocol(transferProcessStarted))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest());
+    @Test
+    @DisplayName("Complete transfer process - not_found")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_transfer_not_found() throws Exception {
+        TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
+                .providerPid(createNewId())
+                .consumerPid(createNewId())
+                .build();
 
-    	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-    	assertNotNull(transferError);
-	}
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/" + transferProcessStarted.getProviderPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferProcessStarted))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+    }
+
+    @Test
+    @DisplayName("Complete transfer process - provider - invalid message type")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_provider_transfer_invalid_msg() throws Exception {
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId("agreement_id")
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/" + transferRequestMessage.getConsumerPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Complete transfer process - invalid state")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_invalid_state() throws Exception {
+        TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .state(TransferState.REQUESTED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        transferProcessRepository.save(transferProcessRequested);
+
+        TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
+                .providerPid(createNewId())
+                .consumerPid(createNewId())
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/" + transferProcessStarted.getProviderPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferProcessStarted))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+    }
+
+    // Consumer
+    @Test
+    @DisplayName("Complete transfer process - from requested - consumer")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void startTransferProcess_consumer() throws Exception {
+        TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .state(TransferState.STARTED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        transferProcessRepository.save(transferProcessStarted);
+
+        TransferCompletionMessage transferCompletionMessage = TransferCompletionMessage.Builder.newInstance()
+                .consumerPid(transferProcessStarted.getConsumerPid())
+                .providerPid(transferProcessStarted.getProviderPid())
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/consumer/transfers/" + transferCompletionMessage.getConsumerPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferCompletionMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isOk());
+
+        //?? not sure if this is correct endpoint or it should be consumer/transfers/{consumerPid}
+        // but such endpoint does not exists in protocol specification
+        ResultActions transferProcessStartedAction = mockMvc.perform(
+                get("/transfers/" + transferProcessStarted.getProviderPid())
+                        .contentType(MediaType.APPLICATION_JSON));
+        // check if status is STARTED
+        transferProcessStartedAction.andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        String response = transferProcessStartedAction.andReturn().getResponse().getContentAsString();
+        TransferProcess transferProcessStarted2 = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
+        assertNotNull(transferProcessStarted2);
+    }
+
+    @Test
+    @DisplayName("Complete transfer process - consumer - not_found")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_consumer_transfer_not_found() throws Exception {
+        TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
+                .providerPid(createNewId())
+                .consumerPid(createNewId())
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/consumer/transfers/" + transferProcessStarted.getConsumerPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferProcessStarted))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+    }
+
+    @Test
+    @DisplayName("Complete transfer process - consumer - invalid msg")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_consumer_transfer_invalid_msg() throws Exception {
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId("agreement_id")
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/consumer/transfers/" + transferRequestMessage.getConsumerPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Complete transfer process - consumer - invalid state")
+    @WithUserDetails(TestUtil.CONNECTOR_USER)
+    public void completeTransferProcess_consumer_invalid_state() throws Exception {
+        TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .state(TransferState.REQUESTED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        transferProcessRepository.save(transferProcessRequested);
+
+        TransferStartMessage transferProcessStarted = TransferStartMessage.Builder.newInstance()
+                .providerPid(createNewId())
+                .consumerPid(createNewId())
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/" + transferProcessStarted.getConsumerPid() + "/completion")
+                                .content(TransferSerializer.serializeProtocol(transferProcessStarted))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest());
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+    }
 }

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessRequestedIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessRequestedIntegrationTest.java
@@ -1,24 +1,5 @@
 package it.eng.connector.integration.datatransfer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithUserDetails;
-import org.springframework.test.web.servlet.ResultActions;
-
 import it.eng.catalog.model.Catalog;
 import it.eng.catalog.model.Dataset;
 import it.eng.catalog.model.Distribution;
@@ -29,318 +10,323 @@ import it.eng.catalog.repository.DistributionRepository;
 import it.eng.catalog.util.CatalogMockObjectUtil;
 import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.connector.util.TestUtil;
-import it.eng.datatransfer.model.DataTransferFormat;
-import it.eng.datatransfer.model.TransferError;
-import it.eng.datatransfer.model.TransferProcess;
-import it.eng.datatransfer.model.TransferRequestMessage;
-import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.model.*;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.negotiation.model.Action;
-import it.eng.negotiation.model.Agreement;
-import it.eng.negotiation.model.Constraint;
-import it.eng.negotiation.model.ContractNegotiation;
-import it.eng.negotiation.model.ContractNegotiationState;
-import it.eng.negotiation.model.LeftOperand;
-import it.eng.negotiation.model.Operator;
-import it.eng.negotiation.model.Permission;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.negotiation.model.*;
 import it.eng.negotiation.repository.AgreementRepository;
 import it.eng.negotiation.repository.ContractNegotiationRepository;
 import it.eng.tools.model.IConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class DataTransferProcessRequestedIntegrationTest extends BaseIntegrationTest {
 // Consumer -> REQUESTED
-	
-	@Autowired
-	private AgreementRepository agreementRepository;
-	@Autowired
-	private ContractNegotiationRepository contractNegotiationRepository;
-	@Autowired
-	private TransferProcessRepository transferProcessRepository;
-	
-	@Autowired
-	private CatalogRepository catalogRepository;
-	@Autowired
-	private DatasetRepository datasetRepository;
-	@Autowired
-	private DistributionRepository distributionRepository;
-	
-	private Catalog catalog;
-	private Dataset dataset;
-	private Distribution distribution;
-	
-	@BeforeEach
-	public void populateCatalog() {
-		distribution = Distribution.Builder.newInstance()
-				.format(Reference.Builder.newInstance().id(DataTransferFormat.HTTP_PULL.format()).build())
-				.accessService(Collections.singleton(CatalogMockObjectUtil.DATA_SERVICE))
-				.build();
-		dataset = Dataset.Builder.newInstance()
-				.hasPolicy(Collections.singleton(CatalogMockObjectUtil.OFFER))
-				.distribution(Collections.singleton(distribution))
-				.build();
-		catalog = Catalog.Builder.newInstance()
-				.dataset(Collections.singleton(dataset))
-				.build();
-		
-		distributionRepository.save(distribution);
-		datasetRepository.save(dataset);
-		catalogRepository.save(catalog);
-	}
-	
-	@AfterEach
-	public void cleanup() {
-		distributionRepository.deleteAll();
-		datasetRepository.deleteAll();
-		catalogRepository.deleteAll();
-		
-		agreementRepository.deleteAll();
-		contractNegotiationRepository.deleteAll();
-		transferProcessRepository.deleteAll();
-	}
-	
-	@Test
+
+    @Autowired
+    private AgreementRepository agreementRepository;
+    @Autowired
+    private ContractNegotiationRepository contractNegotiationRepository;
+    @Autowired
+    private TransferProcessRepository transferProcessRepository;
+
+    @Autowired
+    private CatalogRepository catalogRepository;
+    @Autowired
+    private DatasetRepository datasetRepository;
+    @Autowired
+    private DistributionRepository distributionRepository;
+
+    private Catalog catalog;
+    private Dataset dataset;
+    private Distribution distribution;
+
+    @BeforeEach
+    public void populateCatalog() {
+        distribution = Distribution.Builder.newInstance()
+                .format(Reference.Builder.newInstance().id(DataTransferFormat.HTTP_PULL.format()).build())
+                .accessService(Collections.singleton(CatalogMockObjectUtil.DATA_SERVICE))
+                .build();
+        dataset = Dataset.Builder.newInstance()
+                .hasPolicy(Collections.singleton(CatalogMockObjectUtil.OFFER))
+                .distribution(Collections.singleton(distribution))
+                .build();
+        catalog = Catalog.Builder.newInstance()
+                .dataset(Collections.singleton(dataset))
+                .build();
+
+        distributionRepository.save(distribution);
+        datasetRepository.save(dataset);
+        catalogRepository.save(catalog);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        distributionRepository.deleteAll();
+        datasetRepository.deleteAll();
+        catalogRepository.deleteAll();
+
+        agreementRepository.deleteAll();
+        contractNegotiationRepository.deleteAll();
+        transferProcessRepository.deleteAll();
+    }
+
+    @Test
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void initiateDataTransfer() throws Exception {
-		// finalized contract negotiation
-		Permission permission = Permission.Builder.newInstance()
-    			.action(Action.USE)
-    			.constraint(Arrays.asList(Constraint.Builder.newInstance()
-    					.leftOperand(LeftOperand.COUNT)
-    					.operator(Operator.LTEQ)
-    					.rightOperand("5")
-    					.build()))
-    			.build();
-		Agreement agreement = Agreement.Builder.newInstance()
-    			.assignee("assignee")
-    			.assigner("assigner")
-    			.target("test_dataset")
-    			.permission(Arrays.asList(permission))
-    			.build();
-    	agreementRepository.save(agreement);
-    	
-    	// finalized contract negotiation
-    	ContractNegotiation contractNegotiationFinalized = ContractNegotiation.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.callbackAddress("callbackAddress.test")
-    			.agreement(agreement)
-    			.state(ContractNegotiationState.FINALIZED)
-    			.role(IConstants.ROLE_PROVIDER)
-    			.build();
-    	contractNegotiationRepository.save(contractNegotiationFinalized);
-    	
-    	TransferProcess transferProcessInitialized = TransferProcess.Builder.newInstance()
-    			.consumerPid(IConstants.TEMPORARY_CONSUMER_PID)
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.agreementId(agreement.getId())
-    			.state(TransferState.INITIALIZED)
-    			.datasetId(dataset.getId())
-    			.build();
-    	transferProcessRepository.save(transferProcessInitialized);
-    	
-		TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(createNewId())
-	    		.agreementId(agreement.getId())
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-		
-    	final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/request")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isCreated())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-       	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferProcess transferProcessRequested = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
-    	assertNotNull(transferProcessRequested);
-    	assertEquals(TransferState.REQUESTED, transferProcessRequested.getState());
-    	
-    	// check if the Transfer Process is properly inserted and that consumerPid and providerPid are correct
-    	TransferProcess transferProcessFromDb = transferProcessRepository.findById(transferProcessInitialized.getId()).get();
-    	
-    	assertEquals(transferProcessInitialized.getProviderPid(), transferProcessFromDb.getProviderPid());
-    	assertEquals(transferRequestMessage.getConsumerPid(), transferProcessFromDb.getConsumerPid());
-    	assertEquals(TransferState.REQUESTED, transferProcessFromDb.getState());
-    	
-    	// cleanup
-    	agreementRepository.delete(agreement);
-    	contractNegotiationRepository.delete(contractNegotiationFinalized);
-    	transferProcessRepository.deleteById(transferProcessInitialized.getId());
+        // finalized contract negotiation
+        Permission permission = Permission.Builder.newInstance()
+                .action(Action.USE)
+                .constraint(Arrays.asList(Constraint.Builder.newInstance()
+                        .leftOperand(LeftOperand.COUNT)
+                        .operator(Operator.LTEQ)
+                        .rightOperand("5")
+                        .build()))
+                .build();
+        Agreement agreement = Agreement.Builder.newInstance()
+                .assignee("assignee")
+                .assigner("assigner")
+                .target("test_dataset")
+                .permission(Arrays.asList(permission))
+                .build();
+        agreementRepository.save(agreement);
+
+        // finalized contract negotiation
+        ContractNegotiation contractNegotiationFinalized = ContractNegotiation.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .callbackAddress("callbackAddress.test")
+                .agreement(agreement)
+                .state(ContractNegotiationState.FINALIZED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        contractNegotiationRepository.save(contractNegotiationFinalized);
+
+        TransferProcess transferProcessInitialized = TransferProcess.Builder.newInstance()
+                .consumerPid(IConstants.TEMPORARY_CONSUMER_PID)
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .agreementId(agreement.getId())
+                .state(TransferState.INITIALIZED)
+                .datasetId(dataset.getId())
+                .build();
+        transferProcessRepository.save(transferProcessInitialized);
+
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId(agreement.getId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/request")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferProcess transferProcessRequested = TransferSerializer.deserializeProtocol(response, TransferProcess.class);
+        assertNotNull(transferProcessRequested);
+        assertEquals(TransferState.REQUESTED, transferProcessRequested.getState());
+
+        // check if the Transfer Process is properly inserted and that consumerPid and providerPid are correct
+        TransferProcess transferProcessFromDb = transferProcessRepository.findById(transferProcessInitialized.getId()).get();
+
+        assertEquals(transferProcessInitialized.getProviderPid(), transferProcessFromDb.getProviderPid());
+        assertEquals(transferRequestMessage.getConsumerPid(), transferProcessFromDb.getConsumerPid());
+        assertEquals(TransferState.REQUESTED, transferProcessFromDb.getState());
+
+        // cleanup
+        agreementRepository.delete(agreement);
+        contractNegotiationRepository.delete(contractNegotiationFinalized);
+        transferProcessRepository.deleteById(transferProcessInitialized.getId());
     }
-	
-	@Test
+
+    @Test
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void initiateDataTransfer_already_requested() throws Exception {
-		TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.agreementId(createNewId())
-    			.state(TransferState.REQUESTED)
-    			.datasetId(dataset.getId())
-    			.build();
-    	transferProcessRepository.save(transferProcessRequested);
-    	
-    	TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(createNewId())
-	    		.agreementId(transferProcessRequested.getAgreementId())
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-    	
-    	final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/request")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-       	String response = result.andReturn().getResponse().getContentAsString();
-      	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-      	assertNotNull(transferError);
-      	
-      	// cleanup
-    	transferProcessRepository.deleteById(transferProcessRequested.getId());
-	}
-	
-	@Test
+        TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .agreementId(createNewId())
+                .state(TransferState.REQUESTED)
+                .datasetId(dataset.getId())
+                .build();
+        transferProcessRepository.save(transferProcessRequested);
+
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId(transferProcessRequested.getAgreementId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/request")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+
+        // cleanup
+        transferProcessRepository.deleteById(transferProcessRequested.getId());
+    }
+
+    @Test
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void initiateDataTransfer_wrongDatasetFormat() throws Exception {
-		// finalized contract negotiation
-				Permission permission = Permission.Builder.newInstance()
-		    			.action(Action.USE)
-		    			.constraint(Arrays.asList(Constraint.Builder.newInstance()
-		    					.leftOperand(LeftOperand.COUNT)
-		    					.operator(Operator.LTEQ)
-		    					.rightOperand("5")
-		    					.build()))
-		    			.build();
-				Agreement agreement = Agreement.Builder.newInstance()
-		    			.assignee("assignee")
-		    			.assigner("assigner")
-		    			.target("test_dataset")
-		    			.permission(Arrays.asList(permission))
-		    			.build();
-		    	agreementRepository.save(agreement);
-		    	
-		    	// finalized contract negotiation
-		    	ContractNegotiation contractNegotiationFinalized = ContractNegotiation.Builder.newInstance()
-		    			.consumerPid(createNewId())
-		    			.providerPid(createNewId())
-		    			.callbackAddress("callbackAddress.test")
-		    			.agreement(agreement)
-		    			.state(ContractNegotiationState.FINALIZED)
-		    			.role(IConstants.ROLE_PROVIDER)
-		    			.build();
-		    	contractNegotiationRepository.save(contractNegotiationFinalized);
-				
-		    	TransferProcess transferProcessInitialized = TransferProcess.Builder.newInstance()
-		    			.consumerPid(IConstants.TEMPORARY_CONSUMER_PID)
-		    			.providerPid(createNewId())
-		    			.format(DataTransferFormat.HTTP_PULL.format())
-		    			.agreementId(agreement.getId())
-		    			.state(TransferState.INITIALIZED)
-		    			.datasetId(dataset.getId())
-		    			.build();
-		    	transferProcessRepository.save(transferProcessInitialized);
-		    	
-				TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-			    		.consumerPid(createNewId())
-			    		.agreementId(agreement.getId())
-			    		.format("some_format")
-			    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-			    		.build();
-    	
-    	final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/request")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-       	String response = result.andReturn().getResponse().getContentAsString();
-      	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-      	assertNotNull(transferError);
-      	
-      	// check if the Transfer Process is unchanged and that consumerPid and providerPid are correct
-    	TransferProcess transferProcessFromDb = transferProcessRepository.findById(transferProcessInitialized.getId()).get();
-    	
-    	assertEquals(transferProcessInitialized.getProviderPid(), transferProcessFromDb.getProviderPid());
-    	assertNotEquals(transferRequestMessage.getConsumerPid(), transferProcessFromDb.getConsumerPid());
-    	assertEquals(transferProcessInitialized.getConsumerPid(), transferProcessFromDb.getConsumerPid());
-    	assertEquals(TransferState.INITIALIZED, transferProcessFromDb.getState());
-      	
-      	// cleanup
-    	agreementRepository.delete(agreement);
-    	contractNegotiationRepository.delete(contractNegotiationFinalized);
-    	transferProcessRepository.deleteById(transferProcessInitialized.getId());
-	}
-	
-	@Test
+        // finalized contract negotiation
+        Permission permission = Permission.Builder.newInstance()
+                .action(Action.USE)
+                .constraint(Arrays.asList(Constraint.Builder.newInstance()
+                        .leftOperand(LeftOperand.COUNT)
+                        .operator(Operator.LTEQ)
+                        .rightOperand("5")
+                        .build()))
+                .build();
+        Agreement agreement = Agreement.Builder.newInstance()
+                .assignee("assignee")
+                .assigner("assigner")
+                .target("test_dataset")
+                .permission(Arrays.asList(permission))
+                .build();
+        agreementRepository.save(agreement);
+
+        // finalized contract negotiation
+        ContractNegotiation contractNegotiationFinalized = ContractNegotiation.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .callbackAddress("callbackAddress.test")
+                .agreement(agreement)
+                .state(ContractNegotiationState.FINALIZED)
+                .role(IConstants.ROLE_PROVIDER)
+                .build();
+        contractNegotiationRepository.save(contractNegotiationFinalized);
+
+        TransferProcess transferProcessInitialized = TransferProcess.Builder.newInstance()
+                .consumerPid(IConstants.TEMPORARY_CONSUMER_PID)
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .agreementId(agreement.getId())
+                .state(TransferState.INITIALIZED)
+                .datasetId(dataset.getId())
+                .build();
+        transferProcessRepository.save(transferProcessInitialized);
+
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId(agreement.getId())
+                .format("some_format")
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/request")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+
+        // check if the Transfer Process is unchanged and that consumerPid and providerPid are correct
+        TransferProcess transferProcessFromDb = transferProcessRepository.findById(transferProcessInitialized.getId()).get();
+
+        assertEquals(transferProcessInitialized.getProviderPid(), transferProcessFromDb.getProviderPid());
+        assertNotEquals(transferRequestMessage.getConsumerPid(), transferProcessFromDb.getConsumerPid());
+        assertEquals(transferProcessInitialized.getConsumerPid(), transferProcessFromDb.getConsumerPid());
+        assertEquals(TransferState.INITIALIZED, transferProcessFromDb.getState());
+
+        // cleanup
+        agreementRepository.delete(agreement);
+        contractNegotiationRepository.delete(contractNegotiationFinalized);
+        transferProcessRepository.deleteById(transferProcessInitialized.getId());
+    }
+
+    @Test
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void initiateDataTransfer_no_agreement() throws Exception {
-		TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
-    			.consumerPid(createNewId())
-    			.providerPid(createNewId())
-    			.format(DataTransferFormat.HTTP_PULL.format())
-    			.agreementId(createNewId())
-    			.state(TransferState.INITIALIZED)
-    			.datasetId(dataset.getId())
-    			.build();
-    	transferProcessRepository.save(transferProcessRequested);
-    	
-    	TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(createNewId())
-	    		.agreementId("different_agreement_id")
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-    	
-    	final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/request")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON));
-    	result.andExpect(status().isBadRequest())
-    		.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	
-       	String response = result.andReturn().getResponse().getContentAsString();
-      	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-      	assertNotNull(transferError);
-      	
-      	// cleanup
-    	transferProcessRepository.deleteById(transferProcessRequested.getId());
-	}
-	
-	@Test
+        TransferProcess transferProcessRequested = TransferProcess.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .agreementId(createNewId())
+                .state(TransferState.INITIALIZED)
+                .datasetId(dataset.getId())
+                .build();
+        transferProcessRepository.save(transferProcessRequested);
+
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(createNewId())
+                .agreementId("different_agreement_id")
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/request")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON));
+        result.andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
+
+        // cleanup
+        transferProcessRepository.deleteById(transferProcessRequested.getId());
+    }
+
+    @Test
     @DisplayName("Start transfer - unauthorized")
     public void getCatalog_UnauthorizedTest() throws Exception {
-    	
-		TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
-	    		.consumerPid(DataTranferMockObjectUtil.CONSUMER_PID)
-	    		.agreementId(createNewId()) 
-	    		.format(DataTransferFormat.HTTP_PULL.format())
-	    		.callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
-	    		.build();
-		
-    	final ResultActions result =
-    			mockMvc.perform(
-    					post("/transfers/request")
-    					.content(TransferSerializer.serializeProtocol(transferRequestMessage))
-    					.contentType(MediaType.APPLICATION_JSON)
-    					.header("Authorization", "Basic YXNkckBtYWlsLmNvbTpwYXNzd29yZA=="));
-    	result.andExpect(status().isUnauthorized())
-    	.andExpect(content().contentType(MediaType.APPLICATION_JSON));
-    	String response = result.andReturn().getResponse().getContentAsString();
-    	TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
-      	assertNotNull(transferError);
+
+        TransferRequestMessage transferRequestMessage = TransferRequestMessage.Builder.newInstance()
+                .consumerPid(DataTransferMockObjectUtil.CONSUMER_PID)
+                .agreementId(createNewId())
+                .format(DataTransferFormat.HTTP_PULL.format())
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
+                .build();
+
+        final ResultActions result =
+                mockMvc.perform(
+                        post("/transfers/request")
+                                .content(TransferSerializer.serializeProtocol(transferRequestMessage))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Basic YXNkckBtYWlsLmNvbTpwYXNzd29yZA=="));
+        result.andExpect(status().isUnauthorized())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        String response = result.andReturn().getResponse().getContentAsString();
+        TransferError transferError = TransferSerializer.deserializeProtocol(response, TransferError.class);
+        assertNotNull(transferError);
     }
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/event/DataTransferEventListener.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/event/DataTransferEventListener.java
@@ -87,7 +87,12 @@ public class DataTransferEventListener {
 
     @EventListener
     public void handleTransferTerminationMessage(TransferTerminationMessage transferTerminationMessage) {
-        log.info("Completeing transfer with consumerPid {} and providerPid {}", transferTerminationMessage.getConsumerPid(), transferTerminationMessage.getProviderPid());
+        log.info("Terminating transfer with consumerPid {} and providerPid {}", transferTerminationMessage.getConsumerPid(), transferTerminationMessage.getProviderPid());
     }
 
+    @EventListener
+    public void handleTransferArtifactEvent(TransferArtifactEvent transferArtifactEvent) {
+        log.info("Handling transfer artifact event for process {}: isDownload={}, message={}",
+                transferArtifactEvent.getTransferProcessId(), transferArtifactEvent.isDownload(), transferArtifactEvent.getMessage());
+    }
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/event/TransferArtifactEvent.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/event/TransferArtifactEvent.java
@@ -1,0 +1,48 @@
+package it.eng.datatransfer.event;
+
+import it.eng.datatransfer.model.TransferProcess;
+import lombok.Getter;
+
+@Getter
+public class TransferArtifactEvent {
+    private TransferProcess transferProcess;
+    private String transferProcessId;
+    private boolean isDownload;
+    private String message;
+
+    public static class Builder {
+        private TransferArtifactEvent event;
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            event = new TransferArtifactEvent();
+        }
+
+        public Builder transferProcess(TransferProcess transferProcess) {
+            event.transferProcess = transferProcess;
+            return this;
+        }
+
+        public Builder transferProcessId(String transferProcessId) {
+            event.transferProcessId = transferProcessId;
+            return this;
+        }
+
+        public Builder isDownload(boolean isDownload) {
+            event.isDownload = isDownload;
+            return this;
+        }
+
+        public Builder message(String message) {
+            event.message = message;
+            return this;
+        }
+
+        public TransferArtifactEvent build() {
+            return event;
+        }
+    }
+}

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
@@ -17,127 +17,146 @@ import java.util.Collection;
 @Slf4j
 public class DataTransferAPIController {
 
-	private final DataTransferAPIService apiService;
+    private final DataTransferAPIService apiService;
 
-	public DataTransferAPIController(DataTransferAPIService apiService) {
-		this.apiService = apiService;
-	}
+    public DataTransferAPIController(DataTransferAPIService apiService) {
+        this.apiService = apiService;
+    }
 
-	/********* CONSUMER ***********/
-	
-	/**
-	 * Consumer requests (initiates) data transfer.
-	 * @param dataTransferRequest specifying transfer process id and other parameters.
-	 * @return GenericApiResponse response with transfer process details.
-	 */
-	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<GenericApiResponse<JsonNode>> requestTransfer(@RequestBody DataTransferRequest dataTransferRequest) {
-		log.info("Consumer sends transfer request {}", dataTransferRequest.getTransferProcessId());
-		JsonNode response = apiService.requestTransfer(dataTransferRequest);
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-				.body(GenericApiResponse.success(response, "Data transfer requested"));
-	}
-	
-	/**
-	 * Consumer download artifact.
-	 * @param transferProcessId transfer process id to download data for.
-	 * @return GenericApiResponse response with success message.
-	 */
-	@GetMapping(path = { "/{transferProcessId}/download" })
-	public ResponseEntity<GenericApiResponse<Void>> downloadData(
-			@PathVariable String transferProcessId) {
-		log.info("Downloading transfer process id - {} data", transferProcessId);
-		apiService.downloadData(transferProcessId);
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-				.body(GenericApiResponse.success(null, "Data successfully downloaded"));
-	}
-	
-	/**
-	 * Consumer view downloaded artifact.<br>
-	 * Before "viewing" artifact, policy will be enforced to check if agreement is still valid.
-	 *
-	 * @param transferProcessId transfer process id to view data for.
-	 * @return GenericApiResponse response with artifact URL
-	 */
-	@GetMapping(path = { "/{transferProcessId}/view" })
-	public ResponseEntity<String> viewData (
-			@PathVariable String transferProcessId) {
-		log.info("Accessing transfer process id - {} data", transferProcessId);
-		String artifactURL = apiService.viewData(transferProcessId);
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-				.body(artifactURL);
-	}
-	
-	/********* CONSUMER & PROVIDER ***********/
-	
-	/**
-	 * Find by id if present, next by state and get all.
-	 * @param transferProcessId transfer process id to filter by, if present.
-	 * @param state optional state to filter transfer processes by.
-	 * @param role optional role to filter transfer processes by (e.g., CONSUMER or PROVIDER).
-	 * @return GenericApiResponse
-	 */
-	@GetMapping(path = { "", "/{transferProcessId}" })
-	public ResponseEntity<GenericApiResponse<Collection<JsonNode>>> getTransfersProcess(
-			@PathVariable(required = false) String transferProcessId,
-			@RequestParam(required = false) String state,
-			@RequestParam(required = false) String role) {
-		log.info("Fetching transfer process id - {}, state {}", transferProcessId, state);
-		Collection<JsonNode> response = apiService.findDataTransfers(transferProcessId, state, role);
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-				.body(GenericApiResponse.success(response, "Fetched transfer process"));
-	}
-	
-	/**
-	 * Start transfer process.
-	 * @param transferProcessId transfer process id to start.
-	 * @return GenericApiResponse response with success message.
-	 */
-	@PutMapping(path = "/{transferProcessId}/start")
+    /********* CONSUMER ***********/
+
+    /**
+     * Consumer requests (initiates) data transfer.
+     *
+     * @param dataTransferRequest specifying transfer process id and other parameters.
+     * @return GenericApiResponse response with transfer process details.
+     */
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GenericApiResponse<JsonNode>> requestTransfer(@RequestBody DataTransferRequest dataTransferRequest) {
+        log.info("Consumer sends transfer request {}", dataTransferRequest.getTransferProcessId());
+        JsonNode response = apiService.requestTransfer(dataTransferRequest);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Data transfer requested"));
+    }
+
+    /**
+     * Consumer download artifact.
+     *
+     * @param transferProcessId transfer process id to download data for.
+     * @return GenericApiResponse response with success message.
+     */
+    @GetMapping(path = {"/{transferProcessId}/download"})
+    public ResponseEntity<GenericApiResponse<String>> downloadData(
+            @PathVariable String transferProcessId) {
+        log.info("Downloading transfer process id - {} data", transferProcessId);
+        apiService.downloadData(transferProcessId)
+                .whenComplete((result, throwable) -> {
+                    if (throwable != null) {
+                        log.error("Download failed for process {}: {}",
+                                transferProcessId, throwable.getMessage(), throwable);
+                    } else {
+                        log.info("Download completed successfully for process {}", transferProcessId);
+                    }
+                });
+
+        return ResponseEntity.accepted()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(
+                        "Download started for transfer process " + transferProcessId,
+                        "Request accepted"));
+    }
+
+    /**
+     * Consumer view downloaded artifact.<br>
+     * Before "viewing" artifact, policy will be enforced to check if agreement is still valid.
+     *
+     * @param transferProcessId transfer process id to view data for.
+     * @return GenericApiResponse response with artifact URL
+     */
+    @GetMapping(path = {"/{transferProcessId}/view"})
+    public ResponseEntity<String> viewData(
+            @PathVariable String transferProcessId) {
+        log.info("Accessing transfer process id - {} data", transferProcessId);
+        String artifactURL = apiService.viewData(transferProcessId);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(artifactURL);
+    }
+
+    /********* CONSUMER & PROVIDER ***********/
+
+    /**
+     * Find by id if present, next by state and get all.
+     *
+     * @param transferProcessId transfer process id to filter by, if present.
+     * @param state             optional state to filter transfer processes by.
+     * @param role              optional role to filter transfer processes by (e.g., CONSUMER or PROVIDER).
+     * @return GenericApiResponse
+     */
+    @GetMapping(path = {"", "/{transferProcessId}"})
+    public ResponseEntity<GenericApiResponse<Collection<JsonNode>>> getTransfersProcess(
+            @PathVariable(required = false) String transferProcessId,
+            @RequestParam(required = false) String state,
+            @RequestParam(required = false) String role) {
+        log.info("Fetching transfer process id - {}, state {}", transferProcessId, state);
+        Collection<JsonNode> response = apiService.findDataTransfers(transferProcessId, state, role);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Fetched transfer process"));
+    }
+
+    /**
+     * Start transfer process.
+     *
+     * @param transferProcessId transfer process id to start.
+     * @return GenericApiResponse response with success message.
+     */
+    @PutMapping(path = "/{transferProcessId}/start")
     public ResponseEntity<GenericApiResponse<JsonNode>> startTransfer(@PathVariable String transferProcessId) {
-		log.info("Starting data transfer {}", transferProcessId);
-    	JsonNode response = apiService.startTransfer(transferProcessId);
-    	return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-    			.body(GenericApiResponse.success(response, "Data transfer started"));
+        log.info("Starting data transfer {}", transferProcessId);
+        JsonNode response = apiService.startTransfer(transferProcessId);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Data transfer started"));
     }
-	
-	/**
-	 * Complete transfer process.
-	 * @param transferProcessId transfer process id to complete.
-	 * @return GenericApiResponse response with success message.
-	 */
-	@PutMapping(path = "/{transferProcessId}/complete")
+
+    /**
+     * Complete transfer process.
+     *
+     * @param transferProcessId transfer process id to complete.
+     * @return GenericApiResponse response with success message.
+     */
+    @PutMapping(path = "/{transferProcessId}/complete")
     public ResponseEntity<GenericApiResponse<JsonNode>> completeTransfer(@PathVariable String transferProcessId) {
-		log.info("Completing data transfer {}", transferProcessId);
-    	JsonNode response = apiService.completeTransfer(transferProcessId);
-    	return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-    			.body(GenericApiResponse.success(response, "Data transfer completed"));
+        log.info("Completing data transfer {}", transferProcessId);
+        JsonNode response = apiService.completeTransfer(transferProcessId);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Data transfer completed"));
     }
-	
-	/**
-	 * Suspend transfer process.
-	 * @param transferProcessId transfer process id to suspend.
-	 * @return GenericApiResponse response with success message.
-	 */
-	@PutMapping(path = "/{transferProcessId}/suspend")
+
+    /**
+     * Suspend transfer process.
+     *
+     * @param transferProcessId transfer process id to suspend.
+     * @return GenericApiResponse response with success message.
+     */
+    @PutMapping(path = "/{transferProcessId}/suspend")
     public ResponseEntity<GenericApiResponse<JsonNode>> suspendTransfer(@PathVariable String transferProcessId) {
-		log.info("Suspending data transfer {}", transferProcessId);
-    	JsonNode response = apiService.suspendTransfer(transferProcessId);
-    	return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-    			.body(GenericApiResponse.success(response, "Data transfer suspended"));
+        log.info("Suspending data transfer {}", transferProcessId);
+        JsonNode response = apiService.suspendTransfer(transferProcessId);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Data transfer suspended"));
     }
-	
-	/**
-	 * Terminate transfer process.
-	 * @param transferProcessId transfer process id to terminate.
-	 * @return GenericApiResponse response with success message.
-	 */
-	@PutMapping(path = "/{transferProcessId}/terminate")
+
+    /**
+     * Terminate transfer process.
+     *
+     * @param transferProcessId transfer process id to terminate.
+     * @return GenericApiResponse response with success message.
+     */
+    @PutMapping(path = "/{transferProcessId}/terminate")
     public ResponseEntity<GenericApiResponse<JsonNode>> terminateTransfer(@PathVariable String transferProcessId) {
-		log.info("Terminating data transfer {}", transferProcessId);
-    	JsonNode response = apiService.terminateTransfer(transferProcessId);
-    	return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
-    			.body(GenericApiResponse.success(response, "Data transfer terminated"));
+        log.info("Terminating data transfer {}", transferProcessId);
+        JsonNode response = apiService.terminateTransfer(transferProcessId);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(response, "Data transfer terminated"));
     }
 
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferStrategy.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferStrategy.java
@@ -2,6 +2,8 @@ package it.eng.datatransfer.service.api;
 
 import it.eng.datatransfer.model.TransferProcess;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface DataTransferStrategy {
-    void transfer(TransferProcess transferProcess);
+    CompletableFuture<Void> transfer(TransferProcess transferProcess);
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategy.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategy.java
@@ -32,23 +32,18 @@ public class HttpPullTransferStrategy implements DataTransferStrategy {
     }
 
     @Override
-    public void transfer(TransferProcess transferProcess) {
+    public CompletableFuture<Void> transfer(TransferProcess transferProcess) {
         log.info("Executing HTTP PULL transfer for process {}", transferProcess.getId());
 
         // get authorization information from Data Address if present
         String authorization = extractAuthorization(transferProcess);
 
-        try {
-            String key = downloadAndUploadToS3(
-                    transferProcess.getDataAddress().getEndpoint(),
-                    authorization,
-                    transferProcess.getId()
-            ).get();
-            log.info("Stored transfer process id - {} data!", key);
-        } catch (Exception e) {
-            log.error("Download failed, {}", e.getLocalizedMessage());
-            throw new DataTransferAPIException("Download failed, " + e.getLocalizedMessage());
-        }
+        return downloadAndUploadToS3(
+                transferProcess.getDataAddress().getEndpoint(),
+                authorization,
+                transferProcess.getId()
+        ).thenAccept(key ->
+                log.info("Stored transfer process id - {} data!", key));
     }
 
     private CompletableFuture<String> downloadAndUploadToS3(String presignedUrl,

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/HttpPushTransferStrategy.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/HttpPushTransferStrategy.java
@@ -5,13 +5,16 @@ import it.eng.datatransfer.service.api.DataTransferStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
+
 @Service
 @Slf4j
 public class HttpPushTransferStrategy implements DataTransferStrategy {
 
     @Override
-    public void transfer(TransferProcess transferProcess) {
+    public CompletableFuture<Void> transfer(TransferProcess transferProcess) {
         log.info("Executing HTTP PUSH transfer for process {}", transferProcess.getId());
         // Implementation will go here
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("S3 transfer not implemented"));
     }
 }

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/S3TransferStrategy.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/strategy/S3TransferStrategy.java
@@ -6,6 +6,8 @@ import it.eng.tools.s3.service.S3ClientService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
+
 @Service
 @Slf4j
 public class S3TransferStrategy implements DataTransferStrategy {
@@ -14,8 +16,9 @@ public class S3TransferStrategy implements DataTransferStrategy {
 //    String bucketName
 
     @Override
-    public void transfer(TransferProcess transferProcess) {
+    public CompletableFuture<Void> transfer(TransferProcess transferProcess) {
         log.info("Executing S3 to S3 transfer for process {}", transferProcess.getId());
         // Implementation will go here
+        return CompletableFuture.failedFuture(new UnsupportedOperationException("S3 transfer not implemented"));
     }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/event/DataTransferEventListenerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/event/DataTransferEventListenerTest.java
@@ -1,14 +1,7 @@
 package it.eng.datatransfer.event;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.ArgumentMatchers.any;
-
-import java.util.Optional;
-
+import it.eng.datatransfer.repository.TransferRequestMessageRepository;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,94 +10,98 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
-import it.eng.datatransfer.repository.TransferRequestMessageRepository;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DataTransferEventListenerTest {
 
-	@Mock
-	private ApplicationEventPublisher publisher;
-	@Mock
-	private TransferRequestMessageRepository transferRequestMessageRepository;
+    @Mock
+    private ApplicationEventPublisher publisher;
+    @Mock
+    private TransferRequestMessageRepository transferRequestMessageRepository;
 
-	@InjectMocks
-	private DataTransferEventListener dataTransferEventListener;
-	
-	@Test
-	@DisplayName("Handle TransferProcessChange event")
-	void handleTransferProcessChange() {
-		TransferProcessChangeEvent changeEvent = TransferProcessChangeEvent.Builder.newInstance()
-				.oldTransferProcess(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER)
-				.newTransferProcess(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED)
-				.build();
-		assertDoesNotThrow(() -> dataTransferEventListener.handleTransferProcessChange(changeEvent));
-	}
+    @InjectMocks
+    private DataTransferEventListener dataTransferEventListener;
 
-	@Test
-	@DisplayName("Handle TransferStartMessage")
-	void handleTransferStartMessage() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-		
-		dataTransferEventListener.handleTransferStartMessage(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE);
-		
-		verify(publisher, times(0)).publishEvent(any(StartFTPServerEvent.class));
-	}
-	
-	@Test
-	@DisplayName("Handle TransferStartMessage - SFTP")
-	void handleTransferStartMessage_sftp() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
-		
-		dataTransferEventListener.handleTransferStartMessage(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE);
-		
-		verify(publisher).publishEvent(any(StartFTPServerEvent.class));
-	}
+    @Test
+    @DisplayName("Handle TransferProcessChange event")
+    void handleTransferProcessChange() {
+        TransferProcessChangeEvent changeEvent = TransferProcessChangeEvent.Builder.newInstance()
+                .oldTransferProcess(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER)
+                .newTransferProcess(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED)
+                .build();
+        assertDoesNotThrow(() -> dataTransferEventListener.handleTransferProcessChange(changeEvent));
+    }
 
-	@Test
-	@DisplayName("Handle TransferSuspensionMessage")
-	void handleTransferSuspensionMessage() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-		
-		dataTransferEventListener.handleTransferSuspensionMessage(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE);
-		
-		verify(publisher, times(0)).publishEvent(any(StopFTPServerEvent.class));
-	}
-	
-	@Test
-	@DisplayName("Handle TransferSuspensionMessage - SFTP")
-	void handleTransferSuspensionMessage_sftp() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
-		
-		dataTransferEventListener.handleTransferSuspensionMessage(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE);
-		
-		verify(publisher).publishEvent(any(StopFTPServerEvent.class));
-	}
+    @Test
+    @DisplayName("Handle TransferStartMessage")
+    void handleTransferStartMessage() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
 
-	@Test
-	@DisplayName("Handle TransferCompletionMessage")
-	void handleTransferCompletionMessage() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-	
-		dataTransferEventListener.handleTransferCompletionMessage(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
-		
-		verify(publisher, times(0)).publishEvent(any(StopFTPServerEvent.class));
-	}
-	
-	@Test
-	@DisplayName("Handle TransferCompletionMessage - SFTP")
-	void handleTransferCompletionMessage_sftp() {
-		when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
-	
-		dataTransferEventListener.handleTransferCompletionMessage(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
-		
-		verify(publisher).publishEvent(any(StopFTPServerEvent.class));
-	}
+        dataTransferEventListener.handleTransferStartMessage(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE);
+
+        verify(publisher, times(0)).publishEvent(any(StartFTPServerEvent.class));
+    }
+
+    @Test
+    @DisplayName("Handle TransferStartMessage - SFTP")
+    void handleTransferStartMessage_sftp() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
+
+        dataTransferEventListener.handleTransferStartMessage(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE);
+
+        verify(publisher).publishEvent(any(StartFTPServerEvent.class));
+    }
+
+    @Test
+    @DisplayName("Handle TransferSuspensionMessage")
+    void handleTransferSuspensionMessage() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+
+        dataTransferEventListener.handleTransferSuspensionMessage(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE);
+
+        verify(publisher, times(0)).publishEvent(any(StopFTPServerEvent.class));
+    }
+
+    @Test
+    @DisplayName("Handle TransferSuspensionMessage - SFTP")
+    void handleTransferSuspensionMessage_sftp() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
+
+        dataTransferEventListener.handleTransferSuspensionMessage(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE);
+
+        verify(publisher).publishEvent(any(StopFTPServerEvent.class));
+    }
+
+    @Test
+    @DisplayName("Handle TransferCompletionMessage")
+    void handleTransferCompletionMessage() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+
+        dataTransferEventListener.handleTransferCompletionMessage(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
+
+        verify(publisher, times(0)).publishEvent(any(StopFTPServerEvent.class));
+    }
+
+    @Test
+    @DisplayName("Handle TransferCompletionMessage - SFTP")
+    void handleTransferCompletionMessage_sftp() {
+        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
+
+        dataTransferEventListener.handleTransferCompletionMessage(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
+
+        verify(publisher).publishEvent(any(StopFTPServerEvent.class));
+    }
 
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/model/TransferProcessTest.java
@@ -1,123 +1,116 @@
 package it.eng.datatransfer.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import it.eng.datatransfer.serializer.TransferSerializer;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.tools.model.DSpaceConstants;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
-import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.tools.model.DSpaceConstants;
-import jakarta.validation.ValidationException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransferProcessTest {
 
-	private TransferProcess transferProcess = TransferProcess.Builder.newInstance()
-			.consumerPid(ModelUtil.CONSUMER_PID)
-			.providerPid(ModelUtil.PROVIDER_PID)
-			.state(TransferState.STARTED)
-			.build();
-	
-	@Test
-	@DisplayName("Verify valid plain object serialization")
-	public void testPlain() {
-		String result = TransferSerializer.serializePlain(transferProcess);
-		assertFalse(result.contains(DSpaceConstants.CONTEXT));
-		assertFalse(result.contains(DSpaceConstants.TYPE));
-		assertTrue(result.contains(DSpaceConstants.ID));
-		assertTrue(result.contains(DSpaceConstants.CONSUMER_PID));
-		assertTrue(result.contains(DSpaceConstants.PROVIDER_PID));
-		
-		TransferProcess javaObj = TransferSerializer.deserializePlain(result, TransferProcess.class);
-		validateJavaObject(javaObj);
-	}
-	
-	@Test
-	@DisplayName("Verify valid protocol object serialization")
-	public void testPlain_protocol() {
-		JsonNode result = TransferSerializer.serializeProtocolJsonNode(transferProcess);
-		assertNull(result.get(DSpaceConstants.ID));
-		assertNotNull(result.get(DSpaceConstants.CONTEXT).asText());
-		assertNotNull(result.get(DSpaceConstants.TYPE).asText());
-		assertNotNull(result.get(DSpaceConstants.DSPACE_CONSUMER_PID).asText());
-		assertNotNull(result.get(DSpaceConstants.DSPACE_PROVIDER_PID).asText());
-		
-		TransferProcess javaObj = TransferSerializer.deserializeProtocol(result, TransferProcess.class);
-		validateJavaObject(javaObj);
-	}
-	
-	@Test
-	@DisplayName("No required fields")
-	public void validateInvalid() {
-		assertThrows(ValidationException.class,
-				() -> TransferProcess.Builder.newInstance()
-				.build());
-	}
-	
-	@Test
-	@DisplayName("Missing @context and @type")
-	public void missingContextAndType() {
-		JsonNode result = TransferSerializer.serializePlainJsonNode(transferProcess);
-		assertThrows(ValidationException.class, () -> TransferSerializer.deserializeProtocol(result, TransferProcess.class));
-	}
-	
-	@Test
-	@DisplayName("From initial TransferProcess with new TrasnferState")
-	public void fromInitialWithNewState() {
-		TransferProcess tpCopied = ModelUtil.TRANSFER_PROCESS_REQUESTED.copyWithNewTransferState(TransferState.STARTED);
-		assertEquals(ModelUtil.TRANSFER_PROCESS_REQUESTED.getId(), tpCopied.getId());
-		assertEquals(ModelUtil.CONSUMER_PID, tpCopied.getConsumerPid());
-		assertEquals(ModelUtil.PROVIDER_PID, tpCopied.getProviderPid());
-		assertEquals(ModelUtil.AGREEMENT_ID, tpCopied.getAgreementId());
-		assertEquals(TransferState.STARTED, tpCopied.getState());
-	}
-	
-	@Test
-	@DisplayName("From Requested")
-	public void fromRequested() {
-		assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.STARTED));
-		assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.TERMINATED));
-		assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.SUSPENDED));
-		assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.COMPLETED));
-	}
-	
-	@Test
-	@DisplayName("From Started")
-	public void fromStarted() {
-		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.SUSPENDED));
-		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.TERMINATED));
-		assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.COMPLETED));
-		assertFalse(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.REQUESTED));
-	}
-	
-	@Test
-	@DisplayName("From Suspended")
-	public void fromSuspended() {
-		assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.STARTED));
-		assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.TERMINATED));
-		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.REQUESTED));
-		assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.COMPLETED));
-	}
-	
-	@Test
-	@DisplayName("Check if id is the same after serialization")
-	public void checkId() {
-		String sss = TransferSerializer.serializePlain(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
-		TransferProcess tp = TransferSerializer.deserializePlain(sss, TransferProcess.class);
-		assertEquals(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId(), tp.getId());
-	}
+    private TransferProcess transferProcess = TransferProcess.Builder.newInstance()
+            .consumerPid(ModelUtil.CONSUMER_PID)
+            .providerPid(ModelUtil.PROVIDER_PID)
+            .state(TransferState.STARTED)
+            .build();
 
-	private void validateJavaObject(TransferProcess javaObj) {
-		assertNotNull(javaObj);
-		assertNotNull(javaObj.getConsumerPid());
-		assertNotNull(javaObj.getProviderPid());
-		assertNotNull(javaObj.getState());
-	}
+    @Test
+    @DisplayName("Verify valid plain object serialization")
+    public void testPlain() {
+        String result = TransferSerializer.serializePlain(transferProcess);
+        assertFalse(result.contains(DSpaceConstants.CONTEXT));
+        assertFalse(result.contains(DSpaceConstants.TYPE));
+        assertTrue(result.contains(DSpaceConstants.ID));
+        assertTrue(result.contains(DSpaceConstants.CONSUMER_PID));
+        assertTrue(result.contains(DSpaceConstants.PROVIDER_PID));
+
+        TransferProcess javaObj = TransferSerializer.deserializePlain(result, TransferProcess.class);
+        validateJavaObject(javaObj);
+    }
+
+    @Test
+    @DisplayName("Verify valid protocol object serialization")
+    public void testPlain_protocol() {
+        JsonNode result = TransferSerializer.serializeProtocolJsonNode(transferProcess);
+        assertNull(result.get(DSpaceConstants.ID));
+        assertNotNull(result.get(DSpaceConstants.CONTEXT).asText());
+        assertNotNull(result.get(DSpaceConstants.TYPE).asText());
+        assertNotNull(result.get(DSpaceConstants.DSPACE_CONSUMER_PID).asText());
+        assertNotNull(result.get(DSpaceConstants.DSPACE_PROVIDER_PID).asText());
+
+        TransferProcess javaObj = TransferSerializer.deserializeProtocol(result, TransferProcess.class);
+        validateJavaObject(javaObj);
+    }
+
+    @Test
+    @DisplayName("No required fields")
+    public void validateInvalid() {
+        assertThrows(ValidationException.class,
+                () -> TransferProcess.Builder.newInstance()
+                        .build());
+    }
+
+    @Test
+    @DisplayName("Missing @context and @type")
+    public void missingContextAndType() {
+        JsonNode result = TransferSerializer.serializePlainJsonNode(transferProcess);
+        assertThrows(ValidationException.class, () -> TransferSerializer.deserializeProtocol(result, TransferProcess.class));
+    }
+
+    @Test
+    @DisplayName("From initial TransferProcess with new TrasnferState")
+    public void fromInitialWithNewState() {
+        TransferProcess tpCopied = ModelUtil.TRANSFER_PROCESS_REQUESTED.copyWithNewTransferState(TransferState.STARTED);
+        assertEquals(ModelUtil.TRANSFER_PROCESS_REQUESTED.getId(), tpCopied.getId());
+        assertEquals(ModelUtil.CONSUMER_PID, tpCopied.getConsumerPid());
+        assertEquals(ModelUtil.PROVIDER_PID, tpCopied.getProviderPid());
+        assertEquals(ModelUtil.AGREEMENT_ID, tpCopied.getAgreementId());
+        assertEquals(TransferState.STARTED, tpCopied.getState());
+    }
+
+    @Test
+    @DisplayName("From Requested")
+    public void fromRequested() {
+        assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.STARTED));
+        assertTrue(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.TERMINATED));
+        assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.SUSPENDED));
+        assertFalse(ModelUtil.TRANSFER_PROCESS_REQUESTED.getState().canTransitTo(TransferState.COMPLETED));
+    }
+
+    @Test
+    @DisplayName("From Started")
+    public void fromStarted() {
+        assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.SUSPENDED));
+        assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.TERMINATED));
+        assertTrue(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.COMPLETED));
+        assertFalse(ModelUtil.TRANSFER_PROCESS_STARTED.getState().canTransitTo(TransferState.REQUESTED));
+    }
+
+    @Test
+    @DisplayName("From Suspended")
+    public void fromSuspended() {
+        assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.STARTED));
+        assertTrue(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.TERMINATED));
+        assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.REQUESTED));
+        assertFalse(ModelUtil.TRANSFER_PROCESS_SUSPENDED.getState().canTransitTo(TransferState.COMPLETED));
+    }
+
+    @Test
+    @DisplayName("Check if id is the same after serialization")
+    public void checkId() {
+        String sss = TransferSerializer.serializePlain(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
+        TransferProcess tp = TransferSerializer.deserializePlain(sss, TransferProcess.class);
+        assertEquals(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId(), tp.getId());
+    }
+
+    private void validateJavaObject(TransferProcess javaObj) {
+        assertNotNull(javaObj);
+        assertNotNull(javaObj.getConsumerPid());
+        assertNotNull(javaObj.getProviderPid());
+        assertNotNull(javaObj.getState());
+    }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -188,18 +189,18 @@ class DataTransferAPIControllerTest {
     @Test
     @DisplayName("Download data - success")
     public void downloadData_success() throws IllegalStateException, IOException {
-        doNothing().when(apiService).downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
-        ;
-
+        when(apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         assertDoesNotThrow(() -> controller.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
-
     }
 
     @Test
     @DisplayName("Download data - fail")
     public void downloadData_fail() throws IllegalStateException, IOException {
-        doThrow(new DataTransferAPIException("message")).when(apiService).downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        doThrow(new DataTransferAPIException("message"))
+                .when(apiService)
+                .downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
         assertThrows(DataTransferAPIException.class, () -> controller.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/api/DataTransferAPIControllerTest.java
@@ -1,28 +1,30 @@
 package it.eng.datatransfer.rest.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import it.eng.datatransfer.event.TransferArtifactEvent;
 import it.eng.datatransfer.exceptions.DataTransferAPIException;
 import it.eng.datatransfer.model.DataTransferFormat;
 import it.eng.datatransfer.model.DataTransferRequest;
 import it.eng.datatransfer.model.TransferState;
 import it.eng.datatransfer.serializer.TransferSerializer;
 import it.eng.datatransfer.service.api.DataTransferAPIService;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.tools.model.DSpaceConstants;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import it.eng.tools.response.GenericApiResponse;
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,26 +35,25 @@ import static org.mockito.Mockito.*;
 class DataTransferAPIControllerTest {
 
     @Mock
-    private HttpServletResponse response;
-
-    @Mock
     private DataTransferAPIService apiService;
+    @Mock
+    private ApplicationEventPublisher publisher;
 
     @InjectMocks
     private DataTransferAPIController controller;
 
-    private DataTransferRequest dataTransferRequest = new DataTransferRequest(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED.getId(),
+    private final DataTransferRequest dataTransferRequest = new DataTransferRequest(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED.getId(),
             DataTransferFormat.HTTP_PULL.name(),
             null);
-
 
     @Test
     @DisplayName("Find transfer process by id, state and all")
     public void getTransfersProcess() {
         when(apiService.findDataTransfers(anyString(), anyString(), isNull()))
-                .thenReturn(Arrays.asList(TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER)));
+                .thenReturn(Collections.singletonList(TransferSerializer.serializePlainJsonNode(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER)));
         ResponseEntity<GenericApiResponse<Collection<JsonNode>>> response = controller.getTransfersProcess("test", TransferState.REQUESTED.name(), null);
         assertNotNull(response);
+        assertNotNull(response.getBody());
         assertTrue(response.getBody().isSuccess());
         assertFalse(response.getBody().getData().isEmpty());
 
@@ -60,21 +61,24 @@ class DataTransferAPIControllerTest {
                 .thenReturn(new ArrayList<>());
         response = controller.getTransfersProcess("test_not_found", null, null);
         assertNotNull(response);
+        assertNotNull(response.getBody());
         assertTrue(response.getBody().isSuccess());
         assertTrue(response.getBody().getData().isEmpty());
 
         when(apiService.findDataTransfers(isNull(), anyString(), anyString()))
-                .thenReturn(Arrays.asList(TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED)));
-        response = controller.getTransfersProcess(null, TransferState.STARTED.name(), DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getRole());
+                .thenReturn(Collections.singletonList(TransferSerializer.serializePlainJsonNode(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED)));
+        response = controller.getTransfersProcess(null, TransferState.STARTED.name(), DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getRole());
         assertNotNull(response);
+        assertNotNull(response.getBody());
         assertTrue(response.getBody().isSuccess());
         assertFalse(response.getBody().getData().isEmpty());
 
         when(apiService.findDataTransfers(isNull(), isNull(), isNull()))
-                .thenReturn(Arrays.asList(TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
-                        TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED)));
+                .thenReturn(Arrays.asList(TransferSerializer.serializePlainJsonNode(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
+                        TransferSerializer.serializePlainJsonNode(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED)));
         response = controller.getTransfersProcess(null, null, null);
         assertNotNull(response);
+        assertNotNull(response.getBody());
         assertTrue(response.getBody().isSuccess());
         assertFalse(response.getBody().getData().isEmpty());
 
@@ -83,13 +87,8 @@ class DataTransferAPIControllerTest {
     @Test
     @DisplayName("Request transfer process success")
     public void requestTransfer_success() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("transferProcessId", DataTranferMockObjectUtil.FORWARD_TO);
-        map.put(DSpaceConstants.FORMAT, DataTransferFormat.HTTP_PULL.name());
-        map.put(DSpaceConstants.DATA_ADDRESS, TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.DATA_ADDRESS));
-
         when(apiService.requestTransfer(any(DataTransferRequest.class)))
-                .thenReturn(TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+                .thenReturn(TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
 
         ResponseEntity<GenericApiResponse<JsonNode>> response = controller.requestTransfer(dataTransferRequest);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -99,11 +98,6 @@ class DataTransferAPIControllerTest {
     @Test
     @DisplayName("Request transfer process failed")
     public void requestTransfer_failed() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("transferProcessId", DataTranferMockObjectUtil.FORWARD_TO);
-        map.put(DSpaceConstants.FORMAT, DataTransferFormat.HTTP_PULL.name());
-        map.put(DSpaceConstants.DATA_ADDRESS, TransferSerializer.serializePlainJsonNode(DataTranferMockObjectUtil.DATA_ADDRESS));
-
         doThrow(new DataTransferAPIException("Something not correct - tests"))
                 .when(apiService).requestTransfer(any(DataTransferRequest.class));
 
@@ -112,30 +106,30 @@ class DataTransferAPIControllerTest {
 
     @Test
     @DisplayName("Start transfer process success")
-    public void startTransfer_success() throws UnsupportedEncodingException {
+    public void startTransfer_success() {
 
-        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(apiService).startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        verify(apiService).startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
     }
 
     @Test
     @DisplayName("Start transfer process failed")
-    public void startTransfer_failed() throws UnsupportedEncodingException {
+    public void startTransfer_failed() {
 
         doThrow(new DataTransferAPIException("Something not correct - tests"))
-                .when(apiService).startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+                .when(apiService).startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
-        assertThrows(DataTransferAPIException.class, () -> controller.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> controller.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }
 
     @Test
     @DisplayName("Complete transfer process success")
     public void completeTransfer_success() {
 
-        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(apiService).completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+        verify(apiService).completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
     }
 
     @Test
@@ -143,18 +137,18 @@ class DataTransferAPIControllerTest {
     public void completeTransfer_failed() {
 
         doThrow(new DataTransferAPIException("Something not correct - tests"))
-                .when(apiService).completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+                .when(apiService).completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
 
-        assertThrows(DataTransferAPIException.class, () -> controller.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> controller.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
     }
 
     @Test
     @DisplayName("Suspend transfer process success")
     public void suspendTransfer_success() {
 
-        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
+        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(apiService).suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
+        verify(apiService).suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
     }
 
     @Test
@@ -162,18 +156,18 @@ class DataTransferAPIControllerTest {
     public void suspendTransfer_failed() {
 
         doThrow(new DataTransferAPIException("Something not correct - tests"))
-                .when(apiService).suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
+                .when(apiService).suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId());
 
-        assertThrows(DataTransferAPIException.class, () -> controller.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId()));
+        assertThrows(DataTransferAPIException.class, () -> controller.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER.getId()));
     }
 
     @Test
     @DisplayName("Terminate transfer process success")
     public void terminateTransfer_success() {
 
-        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
+        ResponseEntity<GenericApiResponse<JsonNode>> response = controller.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(apiService).terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
+        verify(apiService).terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
     }
 
     @Test
@@ -181,44 +175,64 @@ class DataTransferAPIControllerTest {
     public void terminateTransfer_failed() {
 
         doThrow(new DataTransferAPIException("Something not correct - tests"))
-                .when(apiService).terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
+                .when(apiService).terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId());
 
-        assertThrows(DataTransferAPIException.class, () -> controller.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> controller.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED.getId()));
     }
 
     @Test
     @DisplayName("Download data - success")
-    public void downloadData_success() throws IllegalStateException, IOException {
-        when(apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+    public void downloadData_success() throws IllegalStateException {
+        ArgumentCaptor<TransferArtifactEvent> eventCaptor = ArgumentCaptor.forClass(TransferArtifactEvent.class);
+        when(apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
-        assertDoesNotThrow(() -> controller.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertDoesNotThrow(() -> controller.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+
+        verify(publisher).publishEvent(eventCaptor.capture());
+
+        TransferArtifactEvent capturedEvent = eventCaptor.getValue();
+        assertTrue(capturedEvent.isDownload());
+        assertEquals(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId(),
+                capturedEvent.getTransferProcessId());
+        assertEquals("Download completed successfully for process " + DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId(), capturedEvent.getMessage());
     }
 
     @Test
     @DisplayName("Download data - fail")
-    public void downloadData_fail() throws IllegalStateException, IOException {
-        doThrow(new DataTransferAPIException("message"))
-                .when(apiService)
-                .downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+    public void downloadData_fail() throws IllegalStateException {
+        ArgumentCaptor<TransferArtifactEvent> eventCaptor = ArgumentCaptor.forClass(TransferArtifactEvent.class);
+        DataTransferAPIException exception = new DataTransferAPIException("message");
 
-        assertThrows(DataTransferAPIException.class, () -> controller.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        when(apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(CompletableFuture.failedFuture(exception));
+
+        controller.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+
+        verify(publisher).publishEvent(eventCaptor.capture());
+
+        TransferArtifactEvent capturedEvent = eventCaptor.getValue();
+        assertFalse(capturedEvent.isDownload());
+        assertEquals(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId(),
+                capturedEvent.getTransferProcessId());
+        assertEquals("Download failed: " + exception.getMessage(),
+                capturedEvent.getMessage());
     }
 
     @Test
     @DisplayName("View data - success")
-    public void viewData_success() throws IllegalStateException, IOException {
-        when(apiService.viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+    public void viewData_success() throws IllegalStateException {
+        when(apiService.viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
                 .thenReturn("http://presignUrl.test/viewData");
 
-        assertDoesNotThrow(() -> controller.viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertDoesNotThrow(() -> controller.viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }
 
     @Test
     @DisplayName("View data - fail")
-    public void viewData_fail() throws IllegalStateException, IOException {
-        doThrow(new DataTransferAPIException("message")).when(apiService).viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+    public void viewData_fail() throws IllegalStateException {
+        doThrow(new DataTransferAPIException("message")).when(apiService).viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
-        assertThrows(DataTransferAPIException.class, () -> controller.viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> controller.viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackControllerTest.java
@@ -1,11 +1,14 @@
 package it.eng.datatransfer.rest.protocol;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
-
+import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
+import it.eng.datatransfer.model.TransferCompletionMessage;
+import it.eng.datatransfer.model.TransferStartMessage;
+import it.eng.datatransfer.model.TransferSuspensionMessage;
+import it.eng.datatransfer.model.TransferTerminationMessage;
+import it.eng.datatransfer.serializer.TransferSerializer;
+import it.eng.datatransfer.service.DataTransferService;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,137 +18,133 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
-import it.eng.datatransfer.model.TransferCompletionMessage;
-import it.eng.datatransfer.model.TransferStartMessage;
-import it.eng.datatransfer.model.TransferSuspensionMessage;
-import it.eng.datatransfer.model.TransferTerminationMessage;
-import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.service.DataTransferService;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import jakarta.validation.ValidationException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsumerDataTransferCallbackControllerTest {
-	
-	@Mock
-	private DataTransferService dataTransferService;
 
-	@InjectMocks
-	private ConsumerDataTransferCallbackController controller;
-	
-	@Test
-	@DisplayName("Start TransferProcess")
-	public void startDataTransfer() {
-		when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-		assertEquals(HttpStatus.OK, 
-				controller.startDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-						TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)).getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Start TransferProcess - invalid request body")
-	public void startDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.startDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
-	}
-	
-	@Test
-	@DisplayName("Start TransferProcess - error service")
-	public void startDataTransfer_errorService() {
-		when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
-			.thenThrow(new TransferProcessNotFoundException("TransferProcess not found test"));
-		assertThrows(TransferProcessNotFoundException.class, () ->
-			controller.startDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)));
-	}
-	
-	// complete
-	@Test
-	@DisplayName("Complete TransferProcess")
-	public void completeDataTransfer() {
-		when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), any(String.class), isNull()))
-		.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
-		ResponseEntity<Void> response = controller.completeDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());	
-		}
-	
-	@Test
-	@DisplayName("Complete TransferProcess - invalid request body")
-	public void completeDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.completeDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)));
-	}
-	
-	@Test
-	@DisplayName("Complete TransferProcess - error service")
-	public void completeDataTransfer_errorService() {
-		when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), any(String.class), isNull()))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.completeDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
-	}
-	
-	// terminate transfer
-	@Test
-	@DisplayName("Terminate TransferProcess")
-	public void terminateDataTransfer() {
-		when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), any(String.class), isNull()))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED);
-		ResponseEntity<Void> response = controller.terminateDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());	
-	}
-	
-	@Test
-	@DisplayName("Terminate TransferProcess - invalid request body")
-	public void terminateDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.terminateDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)));
-	}
-	
-	@Test
-	@DisplayName("Terminate TransferProcess - error service")
-	public void terminateDataTransfer_errorService() {
-		when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), any(String.class), isNull()))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.terminateDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE)));
-	}
-	
-	// suspend transfer
-	@Test
-	@DisplayName("Suspend/pause TransferProcess")
-	public void suspenseDataTransfer() {
-		when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), any(String.class), isNull()))
-		.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
-		ResponseEntity<Void> response = controller.suspenseDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());	
-	}
-	
-	@Test
-	@DisplayName("Suspend TransferProcess - invalid request body")
-	public void suspenseDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.suspenseDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)));
-	}
-	
-	@Test
-	@DisplayName("Suspend TransferProcess - error service")
-	public void suspendDataTransfer_errorService() {
-		when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), any(String.class), isNull()))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.suspenseDataTransfer(DataTranferMockObjectUtil.CONSUMER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE)));
-	}
+    @Mock
+    private DataTransferService dataTransferService;
+
+    @InjectMocks
+    private ConsumerDataTransferCallbackController controller;
+
+    @Test
+    @DisplayName("Start TransferProcess")
+    public void startDataTransfer() {
+        when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+        assertEquals(HttpStatus.OK,
+                controller.startDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)).getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Start TransferProcess - invalid request body")
+    public void startDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.startDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
+    }
+
+    @Test
+    @DisplayName("Start TransferProcess - error service")
+    public void startDataTransfer_errorService() {
+        when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), any(String.class), isNull()))
+                .thenThrow(new TransferProcessNotFoundException("TransferProcess not found test"));
+        assertThrows(TransferProcessNotFoundException.class, () ->
+                controller.startDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)));
+    }
+
+    // complete
+    @Test
+    @DisplayName("Complete TransferProcess")
+    public void completeDataTransfer() {
+        when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), any(String.class), isNull()))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
+        ResponseEntity<Void> response = controller.completeDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Complete TransferProcess - invalid request body")
+    public void completeDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.completeDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)));
+    }
+
+    @Test
+    @DisplayName("Complete TransferProcess - error service")
+    public void completeDataTransfer_errorService() {
+        when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), any(String.class), isNull()))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.completeDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
+    }
+
+    // terminate transfer
+    @Test
+    @DisplayName("Terminate TransferProcess")
+    public void terminateDataTransfer() {
+        when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), any(String.class), isNull()))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED);
+        ResponseEntity<Void> response = controller.terminateDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Terminate TransferProcess - invalid request body")
+    public void terminateDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.terminateDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)));
+    }
+
+    @Test
+    @DisplayName("Terminate TransferProcess - error service")
+    public void terminateDataTransfer_errorService() {
+        when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), any(String.class), isNull()))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.terminateDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE)));
+    }
+
+    // suspend transfer
+    @Test
+    @DisplayName("Suspend/pause TransferProcess")
+    public void suspenseDataTransfer() {
+        when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), any(String.class), isNull()))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
+        ResponseEntity<Void> response = controller.suspenseDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Suspend TransferProcess - invalid request body")
+    public void suspenseDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.suspenseDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)));
+    }
+
+    @Test
+    @DisplayName("Suspend TransferProcess - error service")
+    public void suspendDataTransfer_errorService() {
+        when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), any(String.class), isNull()))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.suspenseDataTransfer(DataTransferMockObjectUtil.CONSUMER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE)));
+    }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/DataTransferCallbackTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/DataTransferCallbackTest.java
@@ -1,46 +1,45 @@
 package it.eng.datatransfer.rest.protocol;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import org.junit.jupiter.api.Test;
 
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DataTransferCallbackTest {
 
-	private String URL_WITHOUT_SLASH = "http://server.com:123/context";
-	private String URL_WITH_SLASH = URL_WITHOUT_SLASH + "/";
+    private String URL_WITHOUT_SLASH = "http://server.com:123/context";
+    private String URL_WITH_SLASH = URL_WITHOUT_SLASH + "/";
 
-	@Test
-	public void getConsumerDataTransferStart() {
-		String replacedUrl = DataTransferCallback.getConsumerDataTransferStart(URL_WITHOUT_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferStart(URL_WITH_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		assertEquals(URL_WITH_SLASH + "transfers/" + DataTranferMockObjectUtil.CONSUMER_PID + "/start", replacedUrl);
-		assertEquals(replacedUrl, replacedUrlWithSlash);
-	}
-	
-	@Test
-	public void getConsumerDataTransferCompletion() {
-		String replacedUrl = DataTransferCallback.getConsumerDataTransferCompletion(URL_WITHOUT_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferCompletion(URL_WITH_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		assertEquals(URL_WITH_SLASH + "transfers/" + DataTranferMockObjectUtil.CONSUMER_PID + "/completion", replacedUrl);
-		assertEquals(replacedUrl, replacedUrlWithSlash);
-	}
-	
-	@Test
-	public void getConsumerDataTransferTermination() {
-		String replacedUrl = DataTransferCallback.getConsumerDataTransferTermination(URL_WITHOUT_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferTermination(URL_WITH_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		assertEquals(URL_WITH_SLASH + "transfers/" + DataTranferMockObjectUtil.CONSUMER_PID + "/termination", replacedUrl);
-		assertEquals(replacedUrl, replacedUrlWithSlash);
-	}
-	
-	@Test
-	public void getConsumerDataTransferSuspension() {
-		String replacedUrl = DataTransferCallback.getConsumerDataTransferSuspension(URL_WITHOUT_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferSuspension(URL_WITH_SLASH, DataTranferMockObjectUtil.CONSUMER_PID);
-		assertEquals(URL_WITH_SLASH + "transfers/" + DataTranferMockObjectUtil.CONSUMER_PID + "/suspension", replacedUrl);
-		assertEquals(replacedUrl, replacedUrlWithSlash);
-	}
-	
+    @Test
+    public void getConsumerDataTransferStart() {
+        String replacedUrl = DataTransferCallback.getConsumerDataTransferStart(URL_WITHOUT_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferStart(URL_WITH_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        assertEquals(URL_WITH_SLASH + "transfers/" + DataTransferMockObjectUtil.CONSUMER_PID + "/start", replacedUrl);
+        assertEquals(replacedUrl, replacedUrlWithSlash);
+    }
+
+    @Test
+    public void getConsumerDataTransferCompletion() {
+        String replacedUrl = DataTransferCallback.getConsumerDataTransferCompletion(URL_WITHOUT_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferCompletion(URL_WITH_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        assertEquals(URL_WITH_SLASH + "transfers/" + DataTransferMockObjectUtil.CONSUMER_PID + "/completion", replacedUrl);
+        assertEquals(replacedUrl, replacedUrlWithSlash);
+    }
+
+    @Test
+    public void getConsumerDataTransferTermination() {
+        String replacedUrl = DataTransferCallback.getConsumerDataTransferTermination(URL_WITHOUT_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferTermination(URL_WITH_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        assertEquals(URL_WITH_SLASH + "transfers/" + DataTransferMockObjectUtil.CONSUMER_PID + "/termination", replacedUrl);
+        assertEquals(replacedUrl, replacedUrlWithSlash);
+    }
+
+    @Test
+    public void getConsumerDataTransferSuspension() {
+        String replacedUrl = DataTransferCallback.getConsumerDataTransferSuspension(URL_WITHOUT_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        String replacedUrlWithSlash = DataTransferCallback.getConsumerDataTransferSuspension(URL_WITH_SLASH, DataTransferMockObjectUtil.CONSUMER_PID);
+        assertEquals(URL_WITH_SLASH + "transfers/" + DataTransferMockObjectUtil.CONSUMER_PID + "/suspension", replacedUrl);
+        assertEquals(replacedUrl, replacedUrlWithSlash);
+    }
+
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferControllerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferControllerTest.java
@@ -1,11 +1,13 @@
 package it.eng.datatransfer.rest.protocol;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import it.eng.datatransfer.exceptions.TransferProcessExistsException;
+import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
+import it.eng.datatransfer.model.*;
+import it.eng.datatransfer.serializer.TransferSerializer;
+import it.eng.datatransfer.service.DataTransferService;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,188 +17,181 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
-import it.eng.datatransfer.exceptions.TransferProcessExistsException;
-import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
-import it.eng.datatransfer.model.TransferCompletionMessage;
-import it.eng.datatransfer.model.TransferRequestMessage;
-import it.eng.datatransfer.model.TransferStartMessage;
-import it.eng.datatransfer.model.TransferSuspensionMessage;
-import it.eng.datatransfer.model.TransferTerminationMessage;
-import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.service.DataTransferService;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import jakarta.validation.ValidationException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ProviderDataTransferControllerTest {
-	
-	@Mock
-	private DataTransferService dataTransferService;
 
-	@InjectMocks
-	private ProviderDataTransferController controller;
-	
-	@Test
-	@DisplayName("Get TransferProcess for ProviderPid")
-	public void geTransferProcess() {
-		when(dataTransferService.findTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
-		assertEquals(HttpStatus.OK, controller.getTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID).getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Get TransferProcess for ProviderPid - not found")
-	public void transferProcessNtFound() {
-		when(dataTransferService.findTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenThrow(new TransferProcessNotFoundException("Not found"));
-		assertThrows(TransferProcessNotFoundException.class, 
-				()-> controller.getTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID).getStatusCode());
-	}
-	
-	// initiate transfer
-	@Test
-	@DisplayName("Initiate TransferProcess")
-	public void initateDataTransfer() {
-		when(dataTransferService.initiateDataTransfer(any(TransferRequestMessage.class)))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
-		ResponseEntity<JsonNode> response = controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-		assertEquals(HttpStatus.CREATED, response.getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Initiate TransferProcess - invalid request body")
-	public void initateDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE))
-		);
-	}
-	
-	@Test
-	@DisplayName("Initiate TransferProcess - service error")
-	public void initateDataTransfer_service_error() {
-		when(dataTransferService.initiateDataTransfer(any(TransferRequestMessage.class)))
-			.thenThrow(new TransferProcessExistsException("message", DataTranferMockObjectUtil.PROVIDER_PID));
-		assertThrows(TransferProcessExistsException.class, () ->
-			controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE))
-		);
-	}
-	// start
-	@Test
-	@DisplayName("Start TransferProcess")
-	public void startDataTransfer() {
-	when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), isNull(), any(String.class)))
-		.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-		
-	ResponseEntity<Void> response = controller.startDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-			TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE));
-	
-	assertEquals(HttpStatus.OK, response.getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Start TransferProcess - invalid request body")
-	public void startDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.startDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
-	}
-	
-	@Test
-	@DisplayName("Start TransferProcess - error service")
-	public void startDataTransfer_errorService() {
-		when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), isNull(), any(String.class)))
-			.thenThrow(new TransferProcessNotFoundException("TransferProcess not found test"));
-		assertThrows(TransferProcessNotFoundException.class, () ->
-			controller.startDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID, 
-					TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE)));
-	}
-	
-	// complete
-	@Test
-	@DisplayName("Complete TransferProcess")
-	public void completeDataTransfer() {
-		when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), isNull(), any(String.class)))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
-		ResponseEntity<Void> response =  controller.completeDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Complete TransferProcess - invalid request body")
-	public void completeDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.completeDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE))
-		);
-	}
-	
-	@Test
-	@DisplayName("Complete TransferProcess - error service")
-	public void completeDataTransfer_errorService() {
-		when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), isNull(), any(String.class)))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.completeDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
-	}
-	
-	// terminate data transfer
-	@Test
-	@DisplayName("Terminate TransferProcess")
-	public void terminateDataTransfer() {
-		when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), isNull(), any(String.class)))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED);
-		ResponseEntity<Void> response = controller.terminateDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());	
-	}
-	
-	@Test
-	@DisplayName("Terminate TransferProcess - invalid request body")
-	public void terminateDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.terminateDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE))
-		);
-	}
-	
-	@Test
-	@DisplayName("Terminate TransferProcess - error service")
-	public void terminateDataTransfer_errorService() {
-		when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), isNull(), any(String.class)))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.terminateDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE)));
-	}
-	
-	// suspend data transfer
-	@Test
-	@DisplayName("Suspend/pause TransferProcess")
-	public void suspenseDataTransfer() {
-		when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), isNull(), any(String.class)))
-			.thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER);
-		ResponseEntity<Void> response =  controller.suspenseDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE));
-		assertEquals(HttpStatus.OK, response.getStatusCode());
-	}
-	
-	@Test
-	@DisplayName("Suspend TransferProcess - invalid request body")
-	public void suspenseDataTransfer_invalidBody() {
-		assertThrows(ValidationException.class, () ->
-			controller.suspenseDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE))
-		);
-	}
-	
-	@Test
-	@DisplayName("Suspend TransferProcess - error service")
-	public void suspendDataTransfer_errorService() {
-		when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), isNull(), any(String.class)))
-			.thenThrow(TransferProcessNotFoundException.class);
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> controller.suspenseDataTransfer(DataTranferMockObjectUtil.PROVIDER_PID,
-				TransferSerializer.serializeProtocolJsonNode(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE)));
-	}
+    @Mock
+    private DataTransferService dataTransferService;
+
+    @InjectMocks
+    private ProviderDataTransferController controller;
+
+    @Test
+    @DisplayName("Get TransferProcess for ProviderPid")
+    public void geTransferProcess() {
+        when(dataTransferService.findTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
+        assertEquals(HttpStatus.OK, controller.getTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID).getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Get TransferProcess for ProviderPid - not found")
+    public void transferProcessNtFound() {
+        when(dataTransferService.findTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenThrow(new TransferProcessNotFoundException("Not found"));
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.getTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID).getStatusCode());
+    }
+
+    // initiate transfer
+    @Test
+    @DisplayName("Initiate TransferProcess")
+    public void initateDataTransfer() {
+        when(dataTransferService.initiateDataTransfer(any(TransferRequestMessage.class)))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
+        ResponseEntity<JsonNode> response = controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Initiate TransferProcess - invalid request body")
+    public void initateDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE))
+        );
+    }
+
+    @Test
+    @DisplayName("Initiate TransferProcess - service error")
+    public void initateDataTransfer_service_error() {
+        when(dataTransferService.initiateDataTransfer(any(TransferRequestMessage.class)))
+                .thenThrow(new TransferProcessExistsException("message", DataTransferMockObjectUtil.PROVIDER_PID));
+        assertThrows(TransferProcessExistsException.class, () ->
+                controller.initiateDataTransfer(TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE))
+        );
+    }
+
+    // start
+    @Test
+    @DisplayName("Start TransferProcess")
+    public void startDataTransfer() {
+        when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), isNull(), any(String.class)))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+
+        ResponseEntity<Void> response = controller.startDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Start TransferProcess - invalid request body")
+    public void startDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.startDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
+    }
+
+    @Test
+    @DisplayName("Start TransferProcess - error service")
+    public void startDataTransfer_errorService() {
+        when(dataTransferService.startDataTransfer(any(TransferStartMessage.class), isNull(), any(String.class)))
+                .thenThrow(new TransferProcessNotFoundException("TransferProcess not found test"));
+        assertThrows(TransferProcessNotFoundException.class, () ->
+                controller.startDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE)));
+    }
+
+    // complete
+    @Test
+    @DisplayName("Complete TransferProcess")
+    public void completeDataTransfer() {
+        when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), isNull(), any(String.class)))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED);
+        ResponseEntity<Void> response = controller.completeDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Complete TransferProcess - invalid request body")
+    public void completeDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.completeDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE))
+        );
+    }
+
+    @Test
+    @DisplayName("Complete TransferProcess - error service")
+    public void completeDataTransfer_errorService() {
+        when(dataTransferService.completeDataTransfer(any(TransferCompletionMessage.class), isNull(), any(String.class)))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.completeDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE)));
+    }
+
+    // terminate data transfer
+    @Test
+    @DisplayName("Terminate TransferProcess")
+    public void terminateDataTransfer() {
+        when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), isNull(), any(String.class)))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED);
+        ResponseEntity<Void> response = controller.terminateDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Terminate TransferProcess - invalid request body")
+    public void terminateDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.terminateDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE))
+        );
+    }
+
+    @Test
+    @DisplayName("Terminate TransferProcess - error service")
+    public void terminateDataTransfer_errorService() {
+        when(dataTransferService.terminateDataTransfer(any(TransferTerminationMessage.class), isNull(), any(String.class)))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.terminateDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE)));
+    }
+
+    // suspend data transfer
+    @Test
+    @DisplayName("Suspend/pause TransferProcess")
+    public void suspenseDataTransfer() {
+        when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), isNull(), any(String.class)))
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER);
+        ResponseEntity<Void> response = controller.suspenseDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Suspend TransferProcess - invalid request body")
+    public void suspenseDataTransfer_invalidBody() {
+        assertThrows(ValidationException.class, () ->
+                controller.suspenseDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID, TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE))
+        );
+    }
+
+    @Test
+    @DisplayName("Suspend TransferProcess - error service")
+    public void suspendDataTransfer_errorService() {
+        when(dataTransferService.suspendDataTransfer(any(TransferSuspensionMessage.class), isNull(), any(String.class)))
+                .thenThrow(TransferProcessNotFoundException.class);
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> controller.suspenseDataTransfer(DataTransferMockObjectUtil.PROVIDER_PID,
+                        TransferSerializer.serializeProtocolJsonNode(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE)));
+    }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/AgreementServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/AgreementServiceTest.java
@@ -1,14 +1,13 @@
 package it.eng.datatransfer.service;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
-
-import java.util.Optional;
-
+import it.eng.datatransfer.exceptions.AgreementNotFoundException;
+import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.property.ConnectorProperties;
+import it.eng.tools.response.GenericApiResponse;
+import it.eng.tools.usagecontrol.UsageControlProperties;
+import it.eng.tools.util.CredentialUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,83 +15,81 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import it.eng.datatransfer.exceptions.AgreementNotFoundException;
-import it.eng.datatransfer.repository.TransferProcessRepository;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.tools.client.rest.OkHttpRestClient;
-import it.eng.tools.property.ConnectorProperties;
-import it.eng.tools.response.GenericApiResponse;
-import it.eng.tools.usagecontrol.UsageControlProperties;
-import it.eng.tools.util.CredentialUtils;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AgreementServiceTest {
 
-	@Mock
-	private TransferProcessRepository transferProcessRepository;
-	@Mock
-	private UsageControlProperties usageControlProperties;
-	@Mock
-	private OkHttpRestClient okHttpRestClient;
-	@Mock
-	private GenericApiResponse<String> apiResponse;
-	@Mock
-	private CredentialUtils credentialUtils;
-	@Mock
-	private ConnectorProperties connectorProperties;
-	
-	@InjectMocks
-	private AgreementService service;
-	
-	@Test
-	@DisplayName("Agreement valid - usageControl enabled")
-	void isAgreementValid_uc_enabled() {
-		when(usageControlProperties.usageControlEnabled()).thenReturn(true);
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		when(credentialUtils.getAPICredentials()).thenReturn("credentials");
-		when(connectorProperties.getConnectorURL()).thenReturn("http://test.localhost:8080");
-		when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), any(String.class)))
-			.thenReturn(apiResponse);
-		when(apiResponse.isSuccess()).thenReturn(true);
+    @Mock
+    private TransferProcessRepository transferProcessRepository;
+    @Mock
+    private UsageControlProperties usageControlProperties;
+    @Mock
+    private OkHttpRestClient okHttpRestClient;
+    @Mock
+    private GenericApiResponse<String> apiResponse;
+    @Mock
+    private CredentialUtils credentialUtils;
+    @Mock
+    private ConnectorProperties connectorProperties;
 
-		boolean isValid = service.isAgreementValid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID);
-		assertTrue(isValid);
-	}
-	
-	@Test
-	@DisplayName("Agreement invalid - usageControl enabled")
-	void isAgreementValid_uc_enabled_call_false() {
-		when(usageControlProperties.usageControlEnabled()).thenReturn(true);
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		when(credentialUtils.getAPICredentials()).thenReturn("credentials");
-		when(connectorProperties.getConnectorURL()).thenReturn("http://test.localhost:8080");
-		when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), any(String.class)))
-			.thenReturn(apiResponse);
-		when(apiResponse.isSuccess()).thenReturn(false);
+    @InjectMocks
+    private AgreementService service;
 
-		boolean isValid = service.isAgreementValid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID);
-		assertFalse(isValid);
-	}
-	
-	@Test
-	@DisplayName("Agreement invalid - transferProcess not found")
-	void isAgreementValid_tn_not_found() {
-		when(usageControlProperties.usageControlEnabled()).thenReturn(true);
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(AgreementNotFoundException.class, ()->
-			service.isAgreementValid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID));
-	}
-	
-	@Test
-	@DisplayName("Agreement valid - usageControl disabled")
-	void isAgreementValid_uc_disabled() {
-		when(usageControlProperties.usageControlEnabled()).thenReturn(false);
-		boolean isValid = service.isAgreementValid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID);
-		assertTrue(isValid);
-	}
+    @Test
+    @DisplayName("Agreement valid - usageControl enabled")
+    void isAgreementValid_uc_enabled() {
+        when(usageControlProperties.usageControlEnabled()).thenReturn(true);
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(credentialUtils.getAPICredentials()).thenReturn("credentials");
+        when(connectorProperties.getConnectorURL()).thenReturn("http://test.localhost:8080");
+        when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), any(String.class)))
+                .thenReturn(apiResponse);
+        when(apiResponse.isSuccess()).thenReturn(true);
+
+        boolean isValid = service.isAgreementValid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID);
+        assertTrue(isValid);
+    }
+
+    @Test
+    @DisplayName("Agreement invalid - usageControl enabled")
+    void isAgreementValid_uc_enabled_call_false() {
+        when(usageControlProperties.usageControlEnabled()).thenReturn(true);
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(credentialUtils.getAPICredentials()).thenReturn("credentials");
+        when(connectorProperties.getConnectorURL()).thenReturn("http://test.localhost:8080");
+        when(okHttpRestClient.sendRequestProtocol(any(String.class), isNull(), any(String.class)))
+                .thenReturn(apiResponse);
+        when(apiResponse.isSuccess()).thenReturn(false);
+
+        boolean isValid = service.isAgreementValid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID);
+        assertFalse(isValid);
+    }
+
+    @Test
+    @DisplayName("Agreement invalid - transferProcess not found")
+    void isAgreementValid_tn_not_found() {
+        when(usageControlProperties.usageControlEnabled()).thenReturn(true);
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.empty());
+
+        assertThrows(AgreementNotFoundException.class, () ->
+                service.isAgreementValid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID));
+    }
+
+    @Test
+    @DisplayName("Agreement valid - usageControl disabled")
+    void isAgreementValid_uc_disabled() {
+        when(usageControlProperties.usageControlEnabled()).thenReturn(false);
+        boolean isValid = service.isAgreementValid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID);
+        assertTrue(isValid);
+    }
 
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/DataTransferServiceTest.java
@@ -1,21 +1,18 @@
 package it.eng.datatransfer.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-
+import it.eng.datatransfer.exceptions.TransferProcessInternalException;
+import it.eng.datatransfer.exceptions.TransferProcessInvalidFormatException;
+import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
+import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
+import it.eng.datatransfer.model.DataTransferFormat;
+import it.eng.datatransfer.model.TransferProcess;
+import it.eng.datatransfer.model.TransferState;
+import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.datatransfer.repository.TransferRequestMessageRepository;
+import it.eng.datatransfer.serializer.TransferSerializer;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.tools.client.rest.OkHttpRestClient;
+import it.eng.tools.response.GenericApiResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,421 +27,417 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpMethod;
 
-import it.eng.datatransfer.exceptions.TransferProcessInternalException;
-import it.eng.datatransfer.exceptions.TransferProcessInvalidFormatException;
-import it.eng.datatransfer.exceptions.TransferProcessInvalidStateException;
-import it.eng.datatransfer.exceptions.TransferProcessNotFoundException;
-import it.eng.datatransfer.model.DataTransferFormat;
-import it.eng.datatransfer.model.TransferProcess;
-import it.eng.datatransfer.model.TransferState;
-import it.eng.datatransfer.repository.TransferProcessRepository;
-import it.eng.datatransfer.repository.TransferRequestMessageRepository;
-import it.eng.datatransfer.serializer.TransferSerializer;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
-import it.eng.tools.client.rest.OkHttpRestClient;
-import it.eng.tools.response.GenericApiResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DataTransferServiceTest {
 
-	@Mock
-	private TransferProcessRepository transferProcessRepository;
-	@Mock
-	private TransferRequestMessageRepository transferRequestMessageRepository;
-	@Mock
-	private ApplicationEventPublisher publisher;
     @Mock
-	private GenericApiResponse<String> apiResponse;
+    private TransferProcessRepository transferProcessRepository;
+    @Mock
+    private TransferRequestMessageRepository transferRequestMessageRepository;
+    @Mock
+    private ApplicationEventPublisher publisher;
+    @Mock
+    private GenericApiResponse<String> apiResponse;
     @Mock
     private OkHttpRestClient okHttpRestClient;
 
-	@InjectMocks
-	private DataTransferService service;
-	
-	@Captor
-	private ArgumentCaptor<TransferProcess> argTransferProcess;
+    @InjectMocks
+    private DataTransferService service;
 
-	@Test
-	@DisplayName("Data transfer exists and state is started")
-	public void dataTransferExistsAndStarted() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		assertTrue(service.isDataTransferStarted(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID));
-	}
-	
-	@Test
-	@DisplayName("Data transfer exists and state is not started")
-	public void dataTransferExistsAndNotStarted() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-		assertFalse(service.isDataTransferStarted(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID));
-	}
-	
-	@Test
-	@DisplayName("Data transfer not found")
-	public void dataTransferDoesNotExists() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID))
-			.thenReturn(Optional.empty());
-		assertFalse(service.isDataTransferStarted(DataTranferMockObjectUtil.CONSUMER_PID, DataTranferMockObjectUtil.PROVIDER_PID));
-	}
-	
-	@Test
-	@DisplayName("Find TransferProcess by providerPid")
-	public void getTransferProcessByProviderPid() {
-		when(transferProcessRepository.findByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID)).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		TransferProcess tp = service.findTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID);
-		assertNotNull(tp);
-	}
+    @Captor
+    private ArgumentCaptor<TransferProcess> argTransferProcess;
 
-	@Test
-	@DisplayName("TransferProcess by providerPid not found")
-	public void transferProcessByProviderPid_NotFound() {
-		when(transferProcessRepository.findByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID)).thenReturn(Optional.empty());
-		assertThrows(TransferProcessNotFoundException.class, 
-				()-> service.findTransferProcessByProviderPid(DataTranferMockObjectUtil.PROVIDER_PID));
-	}
-	
-	@Test
-	@DisplayName("DataTransfer requested - success")
-	public void initiateTransferProcess() {
-		when(transferProcessRepository.findByAgreementId(DataTranferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
-		
-		List<String> formats = new ArrayList<>();
-		formats.add(DataTransferFormat.HTTP_PULL.name());
-		GenericApiResponse<List<String>> resp = GenericApiResponse.success(formats, "Ok");
-		when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
-			.thenReturn(TransferSerializer.serializePlain(resp));
-    	
-		TransferProcess transferProcessRequested = service.initiateDataTransfer(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE);
-		
-		assertNotNull(transferProcessRequested);
-		assertEquals(TransferState.REQUESTED, transferProcessRequested.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.REQUESTED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("DataTransfer requested - fail - dct:format")
-	public void initiateTransferProcess_format_not_supported() {
-		when(transferProcessRepository.findByAgreementId(DataTranferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
-		
-		List<String> formats = new ArrayList<>();
-		formats.add("ABC");
-		GenericApiResponse<List<String>> resp = GenericApiResponse.success(formats, "Ok");
-		when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
-			.thenReturn(TransferSerializer.serializePlain(resp));
-    	
-		assertThrows(TransferProcessInvalidFormatException.class, 
-					() -> service.initiateDataTransfer(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-	}
-	
-	@Test
-	@DisplayName("DataTransfer requested - fail - dct:format - null")
-	public void initiateTransferProcess_format_null() {
-		when(transferProcessRepository.findByAgreementId(DataTranferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
-		
-		when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
-			.thenReturn(null);
-    	
-		assertThrows(TransferProcessInternalException.class, 
-					() -> service.initiateDataTransfer(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-	}
-	
-	@Test
-	@DisplayName("DataTransfer requested - intialized TransferProcess does not exist")
-	public void initiateTransferProcess_exists() {
-		when(transferProcessRepository.findByAgreementId(DataTranferMockObjectUtil.AGREEMENT_ID))
-			.thenReturn(Optional.empty());
-		assertThrows(TransferProcessNotFoundException.class,
-				() -> service.initiateDataTransfer(DataTranferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
-		
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	// TransferStartMessage
-	@Test
-	@DisplayName("StartDataTransfer from REQUESTED - provider")
-	public void startDataTransfer_fromRequested_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-		
-		assertThrows(TransferProcessInvalidStateException.class, 
-				() -> service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer from REQUESTED - consumer callback")
-	public void startDataTransfer_fromRequested_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_CONSUMER));
-		
-		TransferProcess transferProcessStarted = service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null);
-		
-		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer from SUSPENDED - provider")
-	public void startDataTransfer_fromSuspended_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER));
-		
-		TransferProcess transferProcessStarted = service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID);
-		
-		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer from SUSPENDED - consumer callback")
-	public void startDataTransfer_fromSuspended_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_CONSUMER));
-		
-		TransferProcess transferProcessStarted = service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null);
-		
-		assertEquals(TransferState.STARTED, transferProcessStarted.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer - transfer process not found - provider")
-	public void startDataTransfer_tpNotFound_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer - transfer process not found - consumer callback")
-	public void startDataTransfer_tpNotFound_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("StartDataTransfer - invalid state")
-	public void startDataTransfer_invalidState() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		
-		assertThrows(TransferProcessInvalidStateException.class, 
-				() -> service.startDataTransfer(DataTranferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	// TransferCompletionMessage
-	@Test
-	@DisplayName("TransferCompletionMessage from STARTED - provider")
-	public void completeDataTransfer_fromStarted_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		
-		TransferProcess transferProcessCompleted = service.completeDataTransfer(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID);
-		
-		assertEquals(TransferState.COMPLETED, transferProcessCompleted.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.COMPLETED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("TransferCompletionMessage from STARTED - consumer callback")
-	public void completeDataTransfer_fromStarted_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		
-		TransferProcess transferProcessCompleted = service.completeDataTransfer(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE,
-				DataTranferMockObjectUtil.CONSUMER_PID, null);
-		
-		assertEquals(TransferState.COMPLETED, transferProcessCompleted.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.COMPLETED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("TransferCompletionMessage - transfer process not found - provider")
-	public void completeDataTransfer_tpNotFound_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.completeDataTransfer(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("TransferCompletionMessage - transfer process not found - consumer callback")
-	public void completeDataTransfer_tpNotFound_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.completeDataTransfer(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("TransferCompletionMessage - invalid state")
-	public void completeDataTransfer_invalidState() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-		
-		assertThrows(TransferProcessInvalidStateException.class, 
-				() -> service.completeDataTransfer(DataTranferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	// suspend
-	@Test
-	@DisplayName("TransferSuspensionMessage from STARTED - provider")
-	public void suspendDataTransfer_fromStarted_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		
-		TransferProcess transferProcessSuspended = service.suspendDataTransfer(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, 
-				null, DataTranferMockObjectUtil.PROVIDER_PID);
-		
-		assertEquals(TransferState.SUSPENDED, transferProcessSuspended.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.SUSPENDED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("TransferSuspensionMessage from STARTED - consumer callback")
-	public void suspendDataTransfer_fromStarted_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
-		
-		TransferProcess transferProcessSuspended = service.suspendDataTransfer(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE,
-				DataTranferMockObjectUtil.CONSUMER_PID, null);
-		
-		assertEquals(TransferState.SUSPENDED, transferProcessSuspended.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.SUSPENDED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("TransferSuspensionMessage - transfer process not found - provider")
-	public void suspendDataTransfer_tpNotFound_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.suspendDataTransfer(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("TransferSuspensionMessage - transfer process not found - consumer callback")
-	public void suspendDataTransfer_tpNotFound_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.suspendDataTransfer(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("TransferSuspensionMessage - invalid state")
-	public void suspendDataTransfer_invalidState() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-		
-		assertThrows(TransferProcessInvalidStateException.class, 
-				() -> service.suspendDataTransfer(DataTranferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	private static Stream<Arguments> provideTransferProcess() {
-	    return Stream.of(
-	      Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
-	      Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED),
-	      Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
-	    );
-	}
-	
-	// terminate
-	@DisplayName("TransferTerminationMessage - provider")
-	@ParameterizedTest
-	@MethodSource("provideTransferProcess")
-	public void terminateDataTransfer_provider(TransferProcess input) {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(input));
-		
-		TransferProcess transferProcessSuspended = service.terminateDataTransfer(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, 
-				null, DataTranferMockObjectUtil.PROVIDER_PID);
-		
-		assertEquals(TransferState.TERMINATED, transferProcessSuspended.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.TERMINATED, argTransferProcess.getValue().getState());
-	}
-	
-	@DisplayName("TransferTerminationMessage - consumer callback")
-	@ParameterizedTest
-	@MethodSource("provideTransferProcess")
-	public void terminateDataTransfer_consumer(TransferProcess input) {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(input));
-		
-		TransferProcess transferProcessSuspended = service.terminateDataTransfer(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE,
-				DataTranferMockObjectUtil.CONSUMER_PID, null);
-		
-		assertEquals(TransferState.TERMINATED, transferProcessSuspended.getState());
-		verify(transferProcessRepository).save(argTransferProcess.capture());
-		assertEquals(TransferState.TERMINATED, argTransferProcess.getValue().getState());
-	}
-	
-	@Test
-	@DisplayName("TransferTerminationMessage - transfer process not found - provider")
-	public void terminateDataTransfer_tpNotFound_provider() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.terminateDataTransfer(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	@Test
-	@DisplayName("TransferTerminationMessage - transfer process not found - consumer callback")
-	public void terminateDataTransfer_tpNotFound_consumer() {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.empty());
-		
-		assertThrows(TransferProcessNotFoundException.class, 
-				() -> service.terminateDataTransfer(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, DataTranferMockObjectUtil.CONSUMER_PID, null));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
-	
-	private static Stream<Arguments> provideInvalidTransferProcess() {
-	    return Stream.of(
-	      Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
-	      Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
-	    );
-	}
-	
-	@DisplayName("TransferTerminationMessage - invalid state")
-	@ParameterizedTest
-	@MethodSource("provideInvalidTransferProcess")
-	public void terminateDataTransfer_invalidState(TransferProcess input) {
-		when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
-			.thenReturn(Optional.of(input));
-		
-		assertThrows(TransferProcessInvalidStateException.class, 
-				() -> service.terminateDataTransfer(DataTranferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, null, DataTranferMockObjectUtil.PROVIDER_PID));
-		verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
-	}
+    @Test
+    @DisplayName("Data transfer exists and state is started")
+    public void dataTransferExistsAndStarted() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        assertTrue(service.isDataTransferStarted(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID));
+    }
+
+    @Test
+    @DisplayName("Data transfer exists and state is not started")
+    public void dataTransferExistsAndNotStarted() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+        assertFalse(service.isDataTransferStarted(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID));
+    }
+
+    @Test
+    @DisplayName("Data transfer not found")
+    public void dataTransferDoesNotExists() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID))
+                .thenReturn(Optional.empty());
+        assertFalse(service.isDataTransferStarted(DataTransferMockObjectUtil.CONSUMER_PID, DataTransferMockObjectUtil.PROVIDER_PID));
+    }
+
+    @Test
+    @DisplayName("Find TransferProcess by providerPid")
+    public void getTransferProcessByProviderPid() {
+        when(transferProcessRepository.findByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID)).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        TransferProcess tp = service.findTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID);
+        assertNotNull(tp);
+    }
+
+    @Test
+    @DisplayName("TransferProcess by providerPid not found")
+    public void transferProcessByProviderPid_NotFound() {
+        when(transferProcessRepository.findByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID)).thenReturn(Optional.empty());
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.findTransferProcessByProviderPid(DataTransferMockObjectUtil.PROVIDER_PID));
+    }
+
+    @Test
+    @DisplayName("DataTransfer requested - success")
+    public void initiateTransferProcess() {
+        when(transferProcessRepository.findByAgreementId(DataTransferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+
+        List<String> formats = new ArrayList<>();
+        formats.add(DataTransferFormat.HTTP_PULL.name());
+        GenericApiResponse<List<String>> resp = GenericApiResponse.success(formats, "Ok");
+        when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
+                .thenReturn(TransferSerializer.serializePlain(resp));
+
+        TransferProcess transferProcessRequested = service.initiateDataTransfer(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE);
+
+        assertNotNull(transferProcessRequested);
+        assertEquals(TransferState.REQUESTED, transferProcessRequested.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.REQUESTED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("DataTransfer requested - fail - dct:format")
+    public void initiateTransferProcess_format_not_supported() {
+        when(transferProcessRepository.findByAgreementId(DataTransferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+
+        List<String> formats = new ArrayList<>();
+        formats.add("ABC");
+        GenericApiResponse<List<String>> resp = GenericApiResponse.success(formats, "Ok");
+        when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
+                .thenReturn(TransferSerializer.serializePlain(resp));
+
+        assertThrows(TransferProcessInvalidFormatException.class,
+                () -> service.initiateDataTransfer(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("DataTransfer requested - fail - dct:format - null")
+    public void initiateTransferProcess_format_null() {
+        when(transferProcessRepository.findByAgreementId(DataTransferMockObjectUtil.AGREEMENT_ID)).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+
+        when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
+                .thenReturn(null);
+
+        assertThrows(TransferProcessInternalException.class,
+                () -> service.initiateDataTransfer(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("DataTransfer requested - intialized TransferProcess does not exist")
+    public void initiateTransferProcess_exists() {
+        when(transferProcessRepository.findByAgreementId(DataTransferMockObjectUtil.AGREEMENT_ID))
+                .thenReturn(Optional.empty());
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.initiateDataTransfer(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    // TransferStartMessage
+    @Test
+    @DisplayName("StartDataTransfer from REQUESTED - provider")
+    public void startDataTransfer_fromRequested_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+
+        assertThrows(TransferProcessInvalidStateException.class,
+                () -> service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer from REQUESTED - consumer callback")
+    public void startDataTransfer_fromRequested_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_CONSUMER));
+
+        TransferProcess transferProcessStarted = service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null);
+
+        assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer from SUSPENDED - provider")
+    public void startDataTransfer_fromSuspended_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER));
+
+        TransferProcess transferProcessStarted = service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID);
+
+        assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer from SUSPENDED - consumer callback")
+    public void startDataTransfer_fromSuspended_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_CONSUMER));
+
+        TransferProcess transferProcessStarted = service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null);
+
+        assertEquals(TransferState.STARTED, transferProcessStarted.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.STARTED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer - transfer process not found - provider")
+    public void startDataTransfer_tpNotFound_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer - transfer process not found - consumer callback")
+    public void startDataTransfer_tpNotFound_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("StartDataTransfer - invalid state")
+    public void startDataTransfer_invalidState() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+
+        assertThrows(TransferProcessInvalidStateException.class,
+                () -> service.startDataTransfer(DataTransferMockObjectUtil.TRANSFER_START_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    // TransferCompletionMessage
+    @Test
+    @DisplayName("TransferCompletionMessage from STARTED - provider")
+    public void completeDataTransfer_fromStarted_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+
+        TransferProcess transferProcessCompleted = service.completeDataTransfer(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID);
+
+        assertEquals(TransferState.COMPLETED, transferProcessCompleted.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.COMPLETED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("TransferCompletionMessage from STARTED - consumer callback")
+    public void completeDataTransfer_fromStarted_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+
+        TransferProcess transferProcessCompleted = service.completeDataTransfer(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE,
+                DataTransferMockObjectUtil.CONSUMER_PID, null);
+
+        assertEquals(TransferState.COMPLETED, transferProcessCompleted.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.COMPLETED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("TransferCompletionMessage - transfer process not found - provider")
+    public void completeDataTransfer_tpNotFound_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.completeDataTransfer(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("TransferCompletionMessage - transfer process not found - consumer callback")
+    public void completeDataTransfer_tpNotFound_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.completeDataTransfer(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("TransferCompletionMessage - invalid state")
+    public void completeDataTransfer_invalidState() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+
+        assertThrows(TransferProcessInvalidStateException.class,
+                () -> service.completeDataTransfer(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    // suspend
+    @Test
+    @DisplayName("TransferSuspensionMessage from STARTED - provider")
+    public void suspendDataTransfer_fromStarted_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+
+        TransferProcess transferProcessSuspended = service.suspendDataTransfer(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE,
+                null, DataTransferMockObjectUtil.PROVIDER_PID);
+
+        assertEquals(TransferState.SUSPENDED, transferProcessSuspended.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.SUSPENDED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("TransferSuspensionMessage from STARTED - consumer callback")
+    public void suspendDataTransfer_fromStarted_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+
+        TransferProcess transferProcessSuspended = service.suspendDataTransfer(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE,
+                DataTransferMockObjectUtil.CONSUMER_PID, null);
+
+        assertEquals(TransferState.SUSPENDED, transferProcessSuspended.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.SUSPENDED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("TransferSuspensionMessage - transfer process not found - provider")
+    public void suspendDataTransfer_tpNotFound_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.suspendDataTransfer(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("TransferSuspensionMessage - transfer process not found - consumer callback")
+    public void suspendDataTransfer_tpNotFound_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.suspendDataTransfer(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("TransferSuspensionMessage - invalid state")
+    public void suspendDataTransfer_invalidState() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+
+        assertThrows(TransferProcessInvalidStateException.class,
+                () -> service.suspendDataTransfer(DataTransferMockObjectUtil.TRANSFER_SUSPENSION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    private static Stream<Arguments> provideTransferProcess() {
+        return Stream.of(
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
+        );
+    }
+
+    // terminate
+    @DisplayName("TransferTerminationMessage - provider")
+    @ParameterizedTest
+    @MethodSource("provideTransferProcess")
+    public void terminateDataTransfer_provider(TransferProcess input) {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(input));
+
+        TransferProcess transferProcessSuspended = service.terminateDataTransfer(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE,
+                null, DataTransferMockObjectUtil.PROVIDER_PID);
+
+        assertEquals(TransferState.TERMINATED, transferProcessSuspended.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.TERMINATED, argTransferProcess.getValue().getState());
+    }
+
+    @DisplayName("TransferTerminationMessage - consumer callback")
+    @ParameterizedTest
+    @MethodSource("provideTransferProcess")
+    public void terminateDataTransfer_consumer(TransferProcess input) {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(input));
+
+        TransferProcess transferProcessSuspended = service.terminateDataTransfer(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE,
+                DataTransferMockObjectUtil.CONSUMER_PID, null);
+
+        assertEquals(TransferState.TERMINATED, transferProcessSuspended.getState());
+        verify(transferProcessRepository).save(argTransferProcess.capture());
+        assertEquals(TransferState.TERMINATED, argTransferProcess.getValue().getState());
+    }
+
+    @Test
+    @DisplayName("TransferTerminationMessage - transfer process not found - provider")
+    public void terminateDataTransfer_tpNotFound_provider() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.terminateDataTransfer(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    @Test
+    @DisplayName("TransferTerminationMessage - transfer process not found - consumer callback")
+    public void terminateDataTransfer_tpNotFound_consumer() {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        assertThrows(TransferProcessNotFoundException.class,
+                () -> service.terminateDataTransfer(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, DataTransferMockObjectUtil.CONSUMER_PID, null));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
+
+    private static Stream<Arguments> provideInvalidTransferProcess() {
+        return Stream.of(
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
+        );
+    }
+
+    @DisplayName("TransferTerminationMessage - invalid state")
+    @ParameterizedTest
+    @MethodSource("provideInvalidTransferProcess")
+    public void terminateDataTransfer_invalidState(TransferProcess input) {
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(any(String.class), any(String.class)))
+                .thenReturn(Optional.of(input));
+
+        assertThrows(TransferProcessInvalidStateException.class,
+                () -> service.terminateDataTransfer(DataTransferMockObjectUtil.TRANSFER_TERMINATION_MESSAGE, null, DataTransferMockObjectUtil.PROVIDER_PID));
+        verify(transferProcessRepository, times(0)).save(argTransferProcess.capture());
+    }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/api/DataTransferAPIServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/api/DataTransferAPIServiceTest.java
@@ -10,7 +10,7 @@ import it.eng.datatransfer.properties.DataTransferProperties;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.serializer.TransferSerializer;
 import it.eng.datatransfer.service.api.strategy.HttpPullTransferStrategy;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import it.eng.tools.client.rest.OkHttpRestClient;
 import it.eng.tools.event.policyenforcement.ArtifactConsumedEvent;
 import it.eng.tools.model.IConstants;
@@ -81,7 +81,7 @@ class DataTransferAPIServiceTest {
     @InjectMocks
     private DataTransferAPIService apiService;
 
-    private final DataTransferRequest dataTransferRequest = new DataTransferRequest(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED.getId(),
+    private final DataTransferRequest dataTransferRequest = new DataTransferRequest(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED.getId(),
             DataTransferFormat.HTTP_PULL.name(),
             null);
 
@@ -89,7 +89,7 @@ class DataTransferAPIServiceTest {
     @DisplayName("Find transfer process by id, state and all")
     public void findDataTransfers() {
 
-        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
         Collection<JsonNode> response = apiService.findDataTransfers("test", TransferState.REQUESTED.name(), null);
         assertNotNull(response);
         assertEquals(1, response.size());
@@ -99,13 +99,13 @@ class DataTransferAPIServiceTest {
         assertNotNull(response);
         assertTrue(response.isEmpty());
 
-        when(transferProcessRepository.findByStateAndRole(anyString(), anyString())).thenReturn(Collections.singletonList(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findByStateAndRole(anyString(), anyString())).thenReturn(Collections.singletonList(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
         response = apiService.findDataTransfers(null, TransferState.STARTED.name(), IConstants.ROLE_PROVIDER);
         assertNotNull(response);
         assertEquals(1, response.size());
 
         when(transferProcessRepository.findByRole(anyString()))
-                .thenReturn(Arrays.asList(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER, DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+                .thenReturn(Arrays.asList(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER, DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
         response = apiService.findDataTransfers(null, null, IConstants.ROLE_PROVIDER);
         assertNotNull(response);
         assertEquals(2, response.size());
@@ -114,13 +114,13 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Request transfer process success")
     public void startNegotiation_success() {
-        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-        when(apiResponse.getData()).thenReturn(TransferSerializer.serializeProtocol(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+        when(apiResponse.getData()).thenReturn(TransferSerializer.serializeProtocol(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(properties.consumerCallbackAddress()).thenReturn(DataTranferMockObjectUtil.CALLBACK_ADDRESS);
-        when(transferProcessRepository.save(any(TransferProcess.class))).thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
+        when(properties.consumerCallbackAddress()).thenReturn(DataTransferMockObjectUtil.CALLBACK_ADDRESS);
+        when(transferProcessRepository.save(any(TransferProcess.class))).thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER);
 
         apiService.requestTransfer(dataTransferRequest);
 
@@ -131,11 +131,11 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Request transfer process failed")
     public void startNegotiation_failed() {
-        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
-        when(apiResponse.getData()).thenReturn(TransferSerializer.serializeProtocol(DataTranferMockObjectUtil.TRANSFER_ERROR));
-        when(properties.consumerCallbackAddress()).thenReturn(DataTranferMockObjectUtil.CALLBACK_ADDRESS);
+        when(apiResponse.getData()).thenReturn(TransferSerializer.serializeProtocol(DataTransferMockObjectUtil.TRANSFER_ERROR));
+        when(properties.consumerCallbackAddress()).thenReturn(DataTransferMockObjectUtil.CALLBACK_ADDRESS);
 
         assertThrows(DataTransferAPIException.class, () ->
                 apiService.requestTransfer(dataTransferRequest));
@@ -146,12 +146,12 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Request transfer process json exception")
     public void startNegotiation_jsonException() {
-        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
+        when(transferProcessRepository.findById(anyString())).thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_INITIALIZED));
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.getData()).thenReturn("not a JSON");
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(properties.consumerCallbackAddress()).thenReturn(DataTranferMockObjectUtil.CALLBACK_ADDRESS);
+        when(properties.consumerCallbackAddress()).thenReturn(DataTransferMockObjectUtil.CALLBACK_ADDRESS);
 
         assertThrows(DataTransferAPIException.class, () ->
                 apiService.requestTransfer(dataTransferRequest));
@@ -165,12 +165,12 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_FILE);
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_FILE);
 
-        apiService.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId());
+        apiService.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId());
 
         verify(transferProcessRepository).save(any(TransferProcess.class));
     }
@@ -178,7 +178,7 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Start transfer process failed - transfer process not found")
     public void startTransfer_failedNegotiationNotFound() {
-        assertThrows(DataTransferAPIException.class, () -> apiService.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()));
 
         verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -189,15 +189,15 @@ class DataTransferAPIServiceTest {
     @MethodSource("startTransfer_wrongStates")
     public void startTransfer_wrongNegotiationState(TransferProcess input) {
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
                 .thenReturn(Optional.of(input));
         when(artifactTransferService.findArtifact(input))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_FILE);
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_FILE);
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+                () -> apiService.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
-        verify(transferProcessRepository).findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        verify(transferProcessRepository).findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
     }
 
@@ -207,12 +207,12 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(false);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_FILE);
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER));
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_FILE);
 
-        assertThrows(DataTransferAPIException.class, () -> apiService.startTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.startTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER.getId()));
 
         verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -224,10 +224,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        apiService.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        apiService.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
         verify(transferProcessRepository).save(any(TransferProcess.class));
     }
@@ -235,7 +235,7 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Complete transfer process failed - transfer process not found")
     public void completeTransfer_failedNegotiationNotFound() {
-        assertThrows(DataTransferAPIException.class, () -> apiService.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -246,13 +246,13 @@ class DataTransferAPIServiceTest {
     @MethodSource("completeTransfer_wrongStates")
     public void completeTransfer_wrongNegotiationState(TransferProcess input) {
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
                 .thenReturn(Optional.of(input));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
+                () -> apiService.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
 
-        verify(transferProcessRepository).findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+        verify(transferProcessRepository).findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
     }
 
@@ -262,10 +262,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(false);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        assertThrows(DataTransferAPIException.class, () -> apiService.completeTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.completeTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -277,10 +277,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        apiService.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        apiService.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
         verify(transferProcessRepository).save(any(TransferProcess.class));
     }
@@ -288,7 +288,7 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Suspend transfer process failed - transfer process not found")
     public void suspendTransfer_failedNegotiationNotFound() {
-        assertThrows(DataTransferAPIException.class, () -> apiService.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -299,13 +299,13 @@ class DataTransferAPIServiceTest {
     @MethodSource("suspendTransfer_wrongStates")
     public void suspendTransfer_wrongNegotiationState(TransferProcess input) {
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
                 .thenReturn(Optional.of(input));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
+                () -> apiService.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
 
-        verify(transferProcessRepository).findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+        verify(transferProcessRepository).findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
     }
 
@@ -315,10 +315,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(false);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        assertThrows(DataTransferAPIException.class, () -> apiService.suspendTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.suspendTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -330,10 +330,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(true);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        apiService.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        apiService.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
         verify(transferProcessRepository).save(any(TransferProcess.class));
     }
@@ -341,7 +341,7 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Terminate transfer process failed - transfer process not found")
     public void terminateTransfer_failedNegotiationNotFound() {
-        assertThrows(DataTransferAPIException.class, () -> apiService.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient, times(0)).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -352,13 +352,13 @@ class DataTransferAPIServiceTest {
     @MethodSource("terminateTransfer_wrongStates")
     public void terminateTransfer_wrongNegotiationState(TransferProcess input) {
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()))
                 .thenReturn(Optional.of(input));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
+                () -> apiService.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId()));
 
-        verify(transferProcessRepository).findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
+        verify(transferProcessRepository).findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED.getId());
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
     }
 
@@ -368,10 +368,10 @@ class DataTransferAPIServiceTest {
         when(credentialUtils.getConnectorCredentials()).thenReturn("credentials");
         when(okHttpRestClient.sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class))).thenReturn(apiResponse);
         when(apiResponse.isSuccess()).thenReturn(false);
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
-        assertThrows(DataTransferAPIException.class, () -> apiService.terminateTransfer(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertThrows(DataTransferAPIException.class, () -> apiService.terminateTransfer(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(okHttpRestClient).sendRequestProtocol(any(String.class), any(JsonNode.class), any(String.class));
         verify(transferProcessRepository, times(0)).save(any(TransferProcess.class));
@@ -380,8 +380,8 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("Download data - success")
     public void downloadData_success() {
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null,
                 "successful response");
@@ -390,27 +390,27 @@ class DataTransferAPIServiceTest {
                 .thenReturn(TransferSerializer.serializePlain(internalResponse));
 
         when(transferProcessRepository.save(any(TransferProcess.class)))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED);
         when(transferStrategyFactory.getStrategy(any(String.class))).thenReturn(httpPullTransferStrategy);
         when(httpPullTransferStrategy.transfer(isA(TransferProcess.class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
-        assertDoesNotThrow(() -> apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+        assertDoesNotThrow(() -> apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(transferStrategyFactory, times(1)).getStrategy(any(String.class));
         verify(httpPullTransferStrategy).transfer(argCaptorTransferProcess.capture());
         verify(transferProcessRepository, times(1)).save(any(TransferProcess.class));
 
         TransferProcess capturedProcess = argCaptorTransferProcess.getValue();
-        assertEquals(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId(), capturedProcess.getId());
+        assertEquals(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId(), capturedProcess.getId());
         assertEquals(DataTransferFormat.HTTP_PULL.name(), capturedProcess.getFormat());
     }
 
     @Test
     @DisplayName("Download data - fail - can not store data")
     public void downloadData_transferFail() {
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null, "successful response");
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
@@ -421,14 +421,14 @@ class DataTransferAPIServiceTest {
         doThrow(DataTransferAPIException.class).when(httpPullTransferStrategy).transfer(isA(TransferProcess.class));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+                () -> apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }
 
     @Test
     @DisplayName("Download data - fail - strategy not found")
     public void downloadData_fail_strategyNotFound() {
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null, "successful response");
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
@@ -439,21 +439,21 @@ class DataTransferAPIServiceTest {
                 .thenThrow(DataTransferAPIException.class);
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+                () -> apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
     }
 
     @Test
     @DisplayName("Download data - fail - policy not valid")
     public void downloadData_fail_policyNotValid() {
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         GenericApiResponse<String> internalResponse = GenericApiResponse.error("Policy not valid");
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
         when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
                 .thenReturn(TransferSerializer.serializePlain(internalResponse));
 
-        CompletableFuture<Void> future = apiService.downloadData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
+        CompletableFuture<Void> future = apiService.downloadData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId());
 
         assertTrue(future.isCompletedExceptionally());
         ExecutionException ex = assertThrows(ExecutionException.class, future::get);
@@ -478,10 +478,10 @@ class DataTransferAPIServiceTest {
     @DisplayName("View data - success")
     public void viewData_success() {
         String bucketName = "test-bucket";
-        String objectKey = DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
+        String objectKey = DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null, "successful response");
         when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
@@ -505,10 +505,10 @@ class DataTransferAPIServiceTest {
     @DisplayName("View data - fail - generate presignURL exception")
     public void viewData_fail_canNotAccessData() {
         String bucketName = "test-bucket";
-        String objectKey = DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
+        String objectKey = DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
 
         when(transferProcessRepository.findById(objectKey))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null, "successful response");
         when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
@@ -526,10 +526,10 @@ class DataTransferAPIServiceTest {
     @DisplayName("View data - fail - file not found")
     public void viewData_fail_fileNotFound() {
         String bucketName = "test-bucket";
-        String objectKey = DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
+        String objectKey = DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId();
 
         when(transferProcessRepository.findById(objectKey))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
         GenericApiResponse<String> internalResponse = GenericApiResponse.success(null, "successful response");
         when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
@@ -550,14 +550,14 @@ class DataTransferAPIServiceTest {
     public void viewData_fail_policyNotValid() {
         GenericApiResponse<String> internalResponse = GenericApiResponse.error("Policy not valid");
 
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED));
         when(usageControlProperties.usageControlEnabled()).thenReturn(true);
         when(okHttpRestClient.sendInternalRequest(any(String.class), any(HttpMethod.class), isNull()))
                 .thenReturn(TransferSerializer.serializePlain(internalResponse));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()));
+                () -> apiService.viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED.getId()));
 
         verify(s3ClientService, times(0)).fileExists(anyString(), anyString());
         verify(s3ClientService, times(0)).generateGetPresignedUrl(anyString(), anyString(), any(Duration.class));
@@ -566,11 +566,11 @@ class DataTransferAPIServiceTest {
     @Test
     @DisplayName("View data - fail - not downloaded")
     public void viewData_fail_notDownloaded() {
-        when(transferProcessRepository.findById(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
-                .thenReturn(Optional.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED));
+        when(transferProcessRepository.findById(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         assertThrows(DataTransferAPIException.class,
-                () -> apiService.viewData(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
+                () -> apiService.viewData(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED.getId()));
 
         verify(s3ClientService, times(0)).fileExists(anyString(), anyString());
         verify(s3ClientService, times(0)).generateGetPresignedUrl(anyString(), anyString(), any(Duration.class));
@@ -578,42 +578,42 @@ class DataTransferAPIServiceTest {
 
     private static Stream<Arguments> startTransfer_wrongStates() {
         return Stream.of(
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
         );
     }
 
     private static Stream<Arguments> completeTransfer_wrongStates() {
         return Stream.of(
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
         );
     }
 
     private static Stream<Arguments> suspendTransfer_wrongStates() {
         return Stream.of(
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
         );
     }
 
     private static Stream<Arguments> terminateTransfer_wrongStates() {
         return Stream.of(
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_COMPLETED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED)
         );
     }
 
     private static Stream<Arguments> download_wrongStates() {
         return Stream.of(
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
-                Arguments.of(DataTranferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_TERMINATED),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_REQUESTED_PROVIDER),
+                Arguments.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_SUSPENDED_PROVIDER)
         );
     }
 }

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/api/RestArtifactServiceTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/api/RestArtifactServiceTest.java
@@ -3,7 +3,7 @@ package it.eng.datatransfer.service.api;
 import it.eng.datatransfer.exceptions.DataTransferAPIException;
 import it.eng.datatransfer.exceptions.DownloadException;
 import it.eng.datatransfer.service.DataTransferService;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import it.eng.tools.client.rest.OkHttpRestClient;
 import it.eng.tools.model.ExternalData;
 import it.eng.tools.response.GenericApiResponse;
@@ -73,9 +73,9 @@ public class RestArtifactServiceTest {
     @DisplayName("Get artifact - dataset has no artifact")
     public void getArtifact_datasetHasNoArtifactId() {
         when(dataTransferService.findTransferProcess(CONSUMER_PID, PROVIDER_PID))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
         doThrow(DownloadException.class).when(artifactTransferService)
-                .findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+                .findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
 
         assertThrows(DownloadException.class, () -> restArtifactService.getArtifact(TRANSACTION_ID, mockHttpServletResponse));
     }
@@ -85,9 +85,9 @@ public class RestArtifactServiceTest {
     public void getExternalData_success() {
         mockHttpServletResponse = new MockHttpServletResponse();
         when(dataTransferService.findTransferProcess(CONSUMER_PID, PROVIDER_PID))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_EXTERNAL);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_EXTERNAL);
 
         ExternalData externalData = new ExternalData();
         externalData.setData("some_data".getBytes());
@@ -95,7 +95,7 @@ public class RestArtifactServiceTest {
         GenericApiResponse<ExternalData> externalResponse = new GenericApiResponse<ExternalData>();
         externalResponse.setData(externalData);
         externalResponse.setSuccess(true);
-        when(okHttpRestClient.downloadData(DataTranferMockObjectUtil.ARTIFACT_EXTERNAL.getValue(), null))
+        when(okHttpRestClient.downloadData(DataTransferMockObjectUtil.ARTIFACT_EXTERNAL.getValue(), null))
                 .thenReturn(externalResponse);
 
         assertDoesNotThrow(() -> restArtifactService.getArtifact(TRANSACTION_ID, mockHttpServletResponse));
@@ -105,12 +105,12 @@ public class RestArtifactServiceTest {
     @DisplayName("Get external data - fail")
     public void getExternalData_fail() {
         when(dataTransferService.findTransferProcess(CONSUMER_PID, PROVIDER_PID))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_EXTERNAL);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_EXTERNAL);
         GenericApiResponse<ExternalData> externalResponse = new GenericApiResponse<ExternalData>();
         externalResponse.setSuccess(false);
-        when(okHttpRestClient.downloadData(DataTranferMockObjectUtil.ARTIFACT_EXTERNAL.getValue(), null))
+        when(okHttpRestClient.downloadData(DataTransferMockObjectUtil.ARTIFACT_EXTERNAL.getValue(), null))
                 .thenReturn(externalResponse);
 
         assertThrows(DownloadException.class, () -> restArtifactService.getArtifact(TRANSACTION_ID, mockHttpServletResponse));
@@ -121,12 +121,12 @@ public class RestArtifactServiceTest {
     public void getFile_success() {
         mockHttpServletResponse = new MockHttpServletResponse();
         when(dataTransferService.findTransferProcess(CONSUMER_PID, PROVIDER_PID))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_FILE);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_FILE);
 
         when(s3Properties.getBucketName()).thenReturn(TEST_BUCKET);
-        when(s3ClientService.fileExists(TEST_BUCKET, DataTranferMockObjectUtil.ARTIFACT_FILE.getValue()))
+        when(s3ClientService.fileExists(TEST_BUCKET, DataTransferMockObjectUtil.ARTIFACT_FILE.getValue()))
                 .thenReturn(true);
 
         ResponseBytes<GetObjectResponse> s3Response = Mockito.mock(ResponseBytes.class);
@@ -145,12 +145,12 @@ public class RestArtifactServiceTest {
     @DisplayName("Get file - fail")
     public void getFile_fail() {
         when(dataTransferService.findTransferProcess(CONSUMER_PID, PROVIDER_PID))
-                .thenReturn(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED);
-        when(artifactTransferService.findArtifact(DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED))
-                .thenReturn(DataTranferMockObjectUtil.ARTIFACT_FILE);
+                .thenReturn(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED);
+        when(artifactTransferService.findArtifact(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED))
+                .thenReturn(DataTransferMockObjectUtil.ARTIFACT_FILE);
 
         when(s3Properties.getBucketName()).thenReturn(TEST_BUCKET);
-        when(s3ClientService.fileExists(TEST_BUCKET, DataTranferMockObjectUtil.ARTIFACT_FILE.getValue()))
+        when(s3ClientService.fileExists(TEST_BUCKET, DataTransferMockObjectUtil.ARTIFACT_FILE.getValue()))
                 .thenReturn(false);
 
         assertThrows(DataTransferAPIException.class, () -> restArtifactService.getArtifact(TRANSACTION_ID, mockHttpServletResponse));

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategyTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategyTest.java
@@ -121,7 +121,8 @@ public class HttpPullTransferStrategyTest {
             // Act & Assert
             DataTransferAPIException ex = assertThrows(DataTransferAPIException.class,
                     () -> strategy.transfer(transferProcess));
-            assertTrue(ex.getMessage().contains("Download failed"));
+            assertTrue(ex.getMessage().contains("Failed to get stream. HTTP response code"));
+            assertEquals(HttpURLConnection.HTTP_NOT_FOUND, mockConnection.getResponseCode());
         }
     }
 

--- a/data-transfer/src/test/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategyTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/service/api/strategy/HttpPullTransferStrategyTest.java
@@ -2,7 +2,7 @@ package it.eng.datatransfer.service.api.strategy;
 
 import it.eng.datatransfer.exceptions.DataTransferAPIException;
 import it.eng.datatransfer.model.*;
-import it.eng.datatransfer.util.DataTranferMockObjectUtil;
+import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.s3.properties.S3Properties;
 import it.eng.tools.s3.service.S3ClientService;
@@ -48,7 +48,7 @@ public class HttpPullTransferStrategyTest {
     @Test
     @DisplayName("Should execute transfer successfully")
     void transfer_success() throws Exception {
-        TransferProcess transferProcess = DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED;
+        TransferProcess transferProcess = DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED;
 
         when(s3Properties.getBucketName()).thenReturn(TEST_BUCKET);
 
@@ -109,7 +109,7 @@ public class HttpPullTransferStrategyTest {
     @DisplayName("Should throw DataTransferAPIException on upload failure")
     void transfer_uploadFails_throwsException() throws Exception {
         // Arrange
-        TransferProcess transferProcess = DataTranferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED;
+        TransferProcess transferProcess = DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_AND_DOWNLOADED;
 
         try (MockedConstruction<URL> mockedUrl = mockConstruction(URL.class,
                 (mock, context) -> {
@@ -227,19 +227,19 @@ public class HttpPullTransferStrategyTest {
     private TransferProcess mockTransferProcess(String endpoint, List<EndpointProperty> props) {
         DataAddress dataAddress = DataAddress.Builder.newInstance()
                 .endpoint(endpoint)
-                .endpointType(DataTranferMockObjectUtil.ENDPOINT_TYPE)
+                .endpointType(DataTransferMockObjectUtil.ENDPOINT_TYPE)
                 .endpointProperties(props)
                 .build();
 
         return TransferProcess.Builder.newInstance()
-                .consumerPid(DataTranferMockObjectUtil.CONSUMER_PID)
-                .providerPid(DataTranferMockObjectUtil.PROVIDER_PID)
+                .consumerPid(DataTransferMockObjectUtil.CONSUMER_PID)
+                .providerPid(DataTransferMockObjectUtil.PROVIDER_PID)
                 .dataAddress(dataAddress)
-                .datasetId(DataTranferMockObjectUtil.DATASET_ID)
+                .datasetId(DataTransferMockObjectUtil.DATASET_ID)
                 .isDownloaded(true)
                 .dataId(new ObjectId().toHexString())
-                .agreementId(DataTranferMockObjectUtil.AGREEMENT_ID)
-                .callbackAddress(DataTranferMockObjectUtil.CALLBACK_ADDRESS)
+                .agreementId(DataTransferMockObjectUtil.AGREEMENT_ID)
+                .callbackAddress(DataTransferMockObjectUtil.CALLBACK_ADDRESS)
                 .role(IConstants.ROLE_PROVIDER)
                 .state(TransferState.STARTED)
                 .format(DataTransferFormat.HTTP_PULL.name())

--- a/data-transfer/src/test/java/it/eng/datatransfer/util/DataTransferMockObjectUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/util/DataTransferMockObjectUtil.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-public class DataTranferMockObjectUtil {
+public class DataTransferMockObjectUtil {
 
     public static final String CONSUMER_PID = "urn:uuid:CONSUMER_PID";
     public static final String PROVIDER_PID = "urn:uuid:PROVIDER_PID";

--- a/tools/src/main/java/it/eng/tools/s3/service/S3ClientServiceImpl.java
+++ b/tools/src/main/java/it/eng/tools/s3/service/S3ClientServiceImpl.java
@@ -244,10 +244,11 @@ public class S3ClientServiceImpl implements S3ClientService {
         if (objectKey == null || objectKey.isEmpty()) {
             throw new IllegalArgumentException("Object key cannot be null or empty");
         }
+        BucketCredentialsEntity bucketCredentials = bucketCredentialsService.getBucketCredentials(bucketName);
         try (S3Presigner presigner = S3Presigner.builder()
                 .endpointOverride(URI.create(s3Properties.getExternalPresignedEndpoint()))
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(s3Properties.getAccessKey(), s3Properties.getSecretKey())))
+                        AwsBasicCredentials.create(bucketCredentials.getAccessKey(), bucketCredentials.getSecretKey())))
                 .region(Region.of(s3Properties.getRegion()))
                 .serviceConfiguration(software.amazon.awssdk.services.s3.S3Configuration.builder()
                         .pathStyleAccessEnabled(true)

--- a/tools/src/test/java/it/eng/tools/s3/service/S3ClientServiceImplTest.java
+++ b/tools/src/test/java/it/eng/tools/s3/service/S3ClientServiceImplTest.java
@@ -615,8 +615,12 @@ public class S3ClientServiceImplTest {
         String expectedUrl = "https://test-bucket.s3.amazonaws.com/test-file.txt";
 
         when(s3Properties.getExternalPresignedEndpoint()).thenReturn("https://s3.amazonaws.com");
-        when(s3Properties.getAccessKey()).thenReturn("testAccessKey");
-        when(s3Properties.getSecretKey()).thenReturn("testSecretKey");
+        BucketCredentialsEntity bucketCredentials = BucketCredentialsEntity.Builder.newInstance()
+                .accessKey("accessKey")
+                .secretKey("secretKey")
+                .bucketName(bucketName)
+                .build();
+        when(bucketCredentialsService.getBucketCredentials(bucketName)).thenReturn(bucketCredentials);
         when(s3Properties.getRegion()).thenReturn("us-east-1");
         when(s3Client.headObject(any(HeadObjectRequest.class)))
                 .thenReturn(HeadObjectResponse.builder()
@@ -640,8 +644,12 @@ public class S3ClientServiceImplTest {
         String objectKey = "non-existent-file.txt";
         Duration expiration = Duration.ofMinutes(5);
         when(s3Properties.getExternalPresignedEndpoint()).thenReturn("https://s3.testaws.com");
-        when(s3Properties.getAccessKey()).thenReturn("testAccessKey");
-        when(s3Properties.getSecretKey()).thenReturn("testSecretKey");
+        BucketCredentialsEntity bucketCredentials = BucketCredentialsEntity.Builder.newInstance()
+                .accessKey("accessKey")
+                .secretKey("secretKey")
+                .bucketName(bucketName)
+                .build();
+        when(bucketCredentialsService.getBucketCredentials(bucketName)).thenReturn(bucketCredentials);
         when(s3Properties.getRegion()).thenReturn("us-east-1");
 
         when(s3Client.headObject(any(HeadObjectRequest.class)))


### PR DESCRIPTION
### Added

- New event and logic for logging DataTransfer events

### Changed

- DataTransferAPIController.downloadData is now async - response with code 202 is returned and download is done in
  background
- Refactored DataTransferStrategy and implementing classes to return CompletableFuture<Void> for transfer method
- GeneratePresignURL uses BucketCredentials
- Renamed DataTranferMockObjectUtil to DataTransferMockObjectUtil
- Updated tests and Postman collection