### PR TITLE
Feature/agreement details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.12-SNAPSHOT] - 19.06.2026.
+
+### Added
+- `GET /api/v1/negotiations/agreements/{agreementId}` — new management endpoint returning a single agreement by ID, enriched with `currentCount` if an active policy enforcement record exists for that agreement.
+- `PolicyEnforcementListener` — new event listener that increments the access count via `PolicyAdministrationPoint` on every `ArtifactTransferredEvent`, enabling real-time tracking of how many times an artifact has been transferred under a given agreement.
+- `AgreementAPIService.findAgreementByIdEnriched()` — fetches the agreement and appends `currentCount` from `PolicyEnforcementRepository` before returning the JSON representation.
+
+### Changed
+- `AccessCountPolicyEvaluator` — fixed off-by-one in `LT` and `LTEQ` operator evaluation: both now use `currentCount + 1` so the current access attempt is counted before the limit check, preventing one extra access beyond the configured limit.
+
 ## [0.6.11-SNAPSHOT] - 16.04.2026.
 
 ### Added

--- a/connector/src/main/java/it/eng/connector/model/PasswordValidationResult.java
+++ b/connector/src/main/java/it/eng/connector/model/PasswordValidationResult.java
@@ -15,7 +15,7 @@ public class PasswordValidationResult {
 	private boolean isValid;
 	private List<String> violations;
 	
-	public PasswordValidationResult valid(String passwod) {
+	public PasswordValidationResult valid(String password) {
 		return new PasswordValidationResult(password, true, List.of());
 	}
 	

--- a/connector/src/main/resources/application-consumer.properties
+++ b/connector/src/main/resources/application-consumer.properties
@@ -1,7 +1,7 @@
 #spring.datasource.generate-unique-name=false
 #spring.datasource.name=trueconnector
 spring.application.name=connector_consumer
-application.automatic.negotiation=false
+application.automatic.negotiation=true
 application.automatic.negotiation.retry.max=3
 application.automatic.negotiation.retry.delay.ms=5000
 

--- a/connector/src/main/resources/application-provider.properties
+++ b/connector/src/main/resources/application-provider.properties
@@ -1,7 +1,7 @@
 #spring.datasource.generate-unique-name=false
 #spring.datasource.name=trueconnector
 spring.application.name=connector_provider
-application.automatic.negotiation=false
+application.automatic.negotiation=true
 application.automatic.negotiation.retry.max=3
 application.automatic.negotiation.retry.delay.ms=5000
 

--- a/connector/src/test/java/it/eng/connector/integration/BaseKeycloakIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseKeycloakIntegrationTest.java
@@ -3,6 +3,7 @@ package it.eng.connector.integration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
+import org.testcontainers.DockerClientFactory;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -41,6 +42,12 @@ public abstract class BaseKeycloakIntegrationTest extends BaseIntegrationTest {
             .withStartupTimeout(KEYCLOAK_STARTUP_TIMEOUT);
 
     static {
+        // Podman closes idle HTTP keep-alive connections faster than Docker does.
+        // Apache HttpClient reuses pooled connections without checking if the server
+        // closed them, causing NoHttpResponseException on the first Docker call after
+        // a gap between test classes. This probe intentionally triggers and discards
+        // the stale connection so that container.start() gets a fresh one
+        try { DockerClientFactory.instance().client().pingCmd().exec(); } catch (Exception ignored) {}
         KEYCLOAK_CONTAINER.start();
         importRealm();
     }

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/AutomaticDataTransferIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/AutomaticDataTransferIT.java
@@ -16,6 +16,8 @@ import it.eng.datatransfer.model.DataTransferFormat;
 import it.eng.datatransfer.model.TransferProcess;
 import it.eng.datatransfer.model.TransferState;
 import it.eng.datatransfer.repository.TransferProcessRepository;
+import it.eng.negotiation.model.PolicyEnforcement;
+import it.eng.negotiation.repository.PolicyEnforcementRepository;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.repository.ArtifactRepository;
@@ -377,6 +379,13 @@ public class AutomaticDataTransferIT {
                 .build();
         providerRepository.save(providerTp);
         log.info("Provider TP created — id='{}', agreementId='{}'", providerTp.getId(), agreementId);
+
+        // Negotiation would have created this record; we pre-create it here since the test
+        // bypasses the negotiation flow but ArtifactTransferredEvent still fires on the provider.
+        PolicyEnforcement policyEnforcement = new PolicyEnforcement();
+        policyEnforcement.setAgreementId(agreementId);
+        policyEnforcement.setCount(0);
+        providerCtx.getBean(PolicyEnforcementRepository.class).save(policyEnforcement);
 
         // Consumer side — callbackAddress is the provider's base URL where the consumer
         // sends TransferRequestMessage (via DataTransferCallback.getConsumerDataTransferRequest).

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/AutomaticDataTransferIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/AutomaticDataTransferIT.java
@@ -34,6 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MinIOContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -127,6 +128,13 @@ public class AutomaticDataTransferIT {
 
     @BeforeAll
     static void startApplications() {
+        // Podman closes idle HTTP keep-alive connections faster than Docker does.
+        // Apache HttpClient reuses pooled connections without checking if the server
+        // closed them, causing NoHttpResponseException on the first Docker call after
+        // a gap between test classes. This probe intentionally triggers and discards
+        // the stale connection so that container.start() gets a fresh one
+        try { DockerClientFactory.instance().client().pingCmd().exec(); } catch (Exception ignored) {}
+
         mongoDBContainer.start();
         providerMinIO.start();
         consumerMinIO.start();

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessCompletedIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessCompletedIT.java
@@ -6,6 +6,8 @@ import it.eng.datatransfer.model.*;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.serializer.TransferSerializer;
 import it.eng.datatransfer.util.DataTransferMockObjectUtil;
+import it.eng.negotiation.model.PolicyEnforcement;
+import it.eng.negotiation.repository.PolicyEnforcementRepository;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.s3.model.TemporaryBucketUser;
 import it.eng.tools.s3.repository.TemporaryBucketUserRepository;
@@ -26,16 +28,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class DataTransferProcessCompletedIT extends BaseIntegrationTest {
 // STARTED -> COMPLETED
 
+    private static final String AGREEMENT_ID = "test-agreement-id";
+
     @Autowired
     private TransferProcessRepository transferProcessRepository;
 
     @Autowired
     private TemporaryBucketUserRepository temporaryBucketUserRepository;
 
+    @Autowired
+    private PolicyEnforcementRepository policyEnforcementRepository;
+
     @AfterEach
     public void cleanup() {
         transferProcessRepository.deleteAll();
         temporaryBucketUserRepository.deleteAll();
+        policyEnforcementRepository.deleteAll();
     }
 
     // Provider
@@ -44,12 +52,18 @@ public class DataTransferProcessCompletedIT extends BaseIntegrationTest {
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void completeTransferProcess_provider() throws Exception {
 
+        PolicyEnforcement policyEnforcement = new PolicyEnforcement();
+        policyEnforcement.setAgreementId(AGREEMENT_ID);
+        policyEnforcement.setCount(0);
+        policyEnforcementRepository.save(policyEnforcement);
+
         TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
                 .consumerPid(createNewId())
                 .providerPid(createNewId())
                 .format(DataTransferFormat.HTTP_PULL.format())
                 .state(TransferState.STARTED)
                 .role(IConstants.ROLE_PROVIDER)
+                .agreementId(AGREEMENT_ID)
                 .build();
         transferProcessRepository.save(transferProcessStarted);
 
@@ -153,12 +167,19 @@ public class DataTransferProcessCompletedIT extends BaseIntegrationTest {
     @DisplayName("Complete transfer process - from started - consumer")
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void completeTransferProcess_consumer() throws Exception {
+
+        PolicyEnforcement policyEnforcement = new PolicyEnforcement();
+        policyEnforcement.setAgreementId(AGREEMENT_ID);
+        policyEnforcement.setCount(0);
+        policyEnforcementRepository.save(policyEnforcement);
+
         TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
                 .consumerPid(createNewId())
                 .providerPid(createNewId())
                 .format(DataTransferFormat.HTTP_PULL.format())
                 .state(TransferState.STARTED)
                 .role(IConstants.ROLE_PROVIDER)
+                .agreementId(AGREEMENT_ID)
                 .build();
         transferProcessRepository.save(transferProcessStarted);
 
@@ -260,12 +281,19 @@ public class DataTransferProcessCompletedIT extends BaseIntegrationTest {
     @DisplayName("Complete transfer process - temporary user deleted after HTTP-PUSH completion")
     @WithUserDetails(TestUtil.CONNECTOR_USER)
     public void completeTransferProcess_provider_httpPush_deletesTemporaryUser() throws Exception {
+
+        PolicyEnforcement policyEnforcement = new PolicyEnforcement();
+        policyEnforcement.setAgreementId(AGREEMENT_ID);
+        policyEnforcement.setCount(0);
+        policyEnforcementRepository.save(policyEnforcement);
+
         TransferProcess transferProcessStarted = TransferProcess.Builder.newInstance()
                 .consumerPid(createNewId())
                 .providerPid(createNewId())
                 .format(DataTransferFormat.HTTP_PUSH.format())
                 .state(TransferState.STARTED)
                 .role(IConstants.ROLE_PROVIDER)
+                .agreementId(AGREEMENT_ID)
                 .build();
         transferProcessRepository.save(transferProcessStarted);
 

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/AutomaticNegotiationIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/AutomaticNegotiationIT.java
@@ -34,6 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MinIOContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -124,6 +125,13 @@ public class AutomaticNegotiationIT {
 
     @BeforeAll
     static void startApplications() {
+        // Podman closes idle HTTP keep-alive connections faster than Docker does.
+        // Apache HttpClient reuses pooled connections without checking if the server
+        // closed them, causing NoHttpResponseException on the first Docker call after
+        // a gap between test classes. This probe intentionally triggers and discards
+        // the stale connection so that container.start() gets a fresh one
+        try { DockerClientFactory.instance().client().pingCmd().exec(); } catch (Exception ignored) {}
+
         mongoDBContainer.start();
         providerMinIO.start();
 

--- a/data-transfer/src/main/java/it/eng/datatransfer/event/DataTransferEventListener.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/event/DataTransferEventListener.java
@@ -4,6 +4,7 @@ import it.eng.datatransfer.model.*;
 import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.repository.TransferRequestMessageRepository;
 import it.eng.tools.event.datatransfer.InitializeTransferProcess;
+import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.service.AuditEventPublisher;
 import lombok.extern.slf4j.Slf4j;
@@ -78,11 +79,21 @@ public class DataTransferEventListener {
 
     @EventListener
     public void handleTransferCompletionMessage(TransferCompletionMessage transferCompletionMessage) {
-        log.info("Completeing transfer with consumerPid {} and providerPid {}", transferCompletionMessage.getConsumerPid(), transferCompletionMessage.getProviderPid());
-        Optional<TransferRequestMessage> transferRequestMessage = transferRequestMessageRepository.findByConsumerPid(transferCompletionMessage.getConsumerPid());
-        if (transferRequestMessage.isPresent() && transferRequestMessage.get().getFormat().equals(DataTransferFormat.SFTP.name())) {
-            publisher.publishEvent(new StopFTPServerEvent());
-        }
+        log.info("Completing transfer with consumerPid {} and providerPid {}", transferCompletionMessage.getConsumerPid(), transferCompletionMessage.getProviderPid());
+//        Optional<TransferRequestMessage> transferRequestMessage = transferRequestMessageRepository.findByConsumerPid(transferCompletionMessage.getConsumerPid());
+       Optional<TransferProcess> tp = transferProcessRepository.findByConsumerPidAndProviderPid(transferCompletionMessage.getConsumerPid(), transferCompletionMessage.getProviderPid());
+       tp.ifPresent(transferProcess -> {
+           if(IConstants.ROLE_PROVIDER.equals(transferProcess.getRole()))  {
+               publisher.publishEvent(new ArtifactTransferredEvent(transferProcess.getAgreementId()));
+           }
+           if (transferProcess.getFormat().equals(DataTransferFormat.SFTP.name())) {
+               publisher.publishEvent(new StopFTPServerEvent());
+           }
+       });
+
+//        if (transferRequestMessage.isPresent() && transferRequestMessage.get().getFormat().equals(DataTransferFormat.SFTP.name())) {
+//            publisher.publishEvent(new StopFTPServerEvent());
+//        }
     }
 
     @EventListener

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferAPIService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferAPIService.java
@@ -15,6 +15,7 @@ import it.eng.tools.client.rest.OkHttpRestClient;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.event.AuditEventType;
 import it.eng.tools.event.policyenforcement.ArtifactConsumedEvent;
+import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
 import it.eng.tools.model.Artifact;
 import it.eng.tools.model.IConstants;
 import it.eng.tools.response.GenericApiResponse;
@@ -664,6 +665,10 @@ public class DataTransferAPIService {
                 .whenComplete((transfer, throwable) -> {
                     if (throwable == null) {
                         log.info("Download completed successfully for process {}", transferProcessId);
+
+                        if(IConstants.ROLE_PROVIDER.equals(transferProcessDownloading.getRole()))  {
+                            publisher.publishEvent(new ArtifactTransferredEvent(transferProcessDownloading.getAgreementId()));
+                        }
 
                         publisher.publishEvent(
                                 AuditEventType.TRANSFER_COMPLETED,

--- a/data-transfer/src/test/java/it/eng/datatransfer/event/DataTransferEventListenerTest.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/event/DataTransferEventListenerTest.java
@@ -1,5 +1,6 @@
 package it.eng.datatransfer.event;
 
+import it.eng.datatransfer.repository.TransferProcessRepository;
 import it.eng.datatransfer.repository.TransferRequestMessageRepository;
 import it.eng.datatransfer.util.DataTransferMockObjectUtil;
 import it.eng.tools.service.AuditEventPublisher;
@@ -24,6 +25,8 @@ class DataTransferEventListenerTest {
     private AuditEventPublisher publisher;
     @Mock
     private TransferRequestMessageRepository transferRequestMessageRepository;
+    @Mock
+    private TransferProcessRepository transferProcessRepository;
 
     @InjectMocks
     private DataTransferEventListener dataTransferEventListener;
@@ -85,8 +88,8 @@ class DataTransferEventListenerTest {
     @Test
     @DisplayName("Handle TransferCompletionMessage")
     void handleTransferCompletionMessage() {
-        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE));
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(anyString(), anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED));
 
         dataTransferEventListener.handleTransferCompletionMessage(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
 
@@ -96,8 +99,8 @@ class DataTransferEventListenerTest {
     @Test
     @DisplayName("Handle TransferCompletionMessage - SFTP")
     void handleTransferCompletionMessage_sftp() {
-        when(transferRequestMessageRepository.findByConsumerPid(anyString()))
-                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_REQUEST_MESSAGE_SFTP));
+        when(transferProcessRepository.findByConsumerPidAndProviderPid(anyString(), anyString()))
+                .thenReturn(Optional.of(DataTransferMockObjectUtil.TRANSFER_PROCESS_STARTED_SFTP));
 
         dataTransferEventListener.handleTransferCompletionMessage(DataTransferMockObjectUtil.TRANSFER_COMPLETION_MESSAGE);
 

--- a/data-transfer/src/test/java/it/eng/datatransfer/util/DataTransferMockObjectUtil.java
+++ b/data-transfer/src/test/java/it/eng/datatransfer/util/DataTransferMockObjectUtil.java
@@ -180,6 +180,17 @@ public class DataTransferMockObjectUtil {
             .state(TransferState.TERMINATED)
             .build();
 
+    public static final TransferProcess TRANSFER_PROCESS_STARTED_SFTP = TransferProcess.Builder.newInstance()
+            .consumerPid(CONSUMER_PID)
+            .providerPid(PROVIDER_PID)
+            .dataAddress(DATA_ADDRESS)
+            .agreementId(AGREEMENT_ID)
+            .callbackAddress(CALLBACK_ADDRESS)
+            .role(IConstants.ROLE_PROVIDER)
+            .state(TransferState.STARTED)
+            .format(DataTransferFormat.SFTP.name())
+            .build();
+
     public static final TransferRequestMessage TRANSFER_REQUEST_MESSAGE = TransferRequestMessage.Builder.newInstance()
             .consumerPid(CONSUMER_PID)
             .agreementId(AGREEMENT_ID)

--- a/negotiation/src/main/java/it/eng/negotiation/configuration/HateoasNegotiationConfig.java
+++ b/negotiation/src/main/java/it/eng/negotiation/configuration/HateoasNegotiationConfig.java
@@ -1,5 +1,6 @@
 package it.eng.negotiation.configuration;
 
+import it.eng.negotiation.model.Agreement;
 import it.eng.negotiation.model.ContractNegotiation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,12 @@ public class HateoasNegotiationConfig {
 
     @Bean
     public PagedResourcesAssembler<ContractNegotiation> contractNegotiationPagedResourcesAssembler(
+            HateoasPageableHandlerMethodArgumentResolver resolver) {
+        return new PagedResourcesAssembler<>(resolver, null);
+    }
+
+    @Bean
+    public PagedResourcesAssembler<Agreement> agreementPagedResourcesAssembler(
             HateoasPageableHandlerMethodArgumentResolver resolver) {
         return new PagedResourcesAssembler<>(resolver, null);
     }

--- a/negotiation/src/main/java/it/eng/negotiation/listener/ContractNegotiationListener.java
+++ b/negotiation/src/main/java/it/eng/negotiation/listener/ContractNegotiationListener.java
@@ -2,6 +2,7 @@ package it.eng.negotiation.listener;
 
 import it.eng.negotiation.service.ContractNegotiationEventHandlerService;
 import it.eng.tools.event.policyenforcement.ArtifactConsumedEvent;
+import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;

--- a/negotiation/src/main/java/it/eng/negotiation/listener/PolicyEnforcementListener.java
+++ b/negotiation/src/main/java/it/eng/negotiation/listener/PolicyEnforcementListener.java
@@ -1,0 +1,27 @@
+package it.eng.negotiation.listener;
+
+import it.eng.negotiation.policy.service.PolicyAdministrationPoint;
+import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class PolicyEnforcementListener {
+
+    private final PolicyAdministrationPoint policyAdministrationPoint;
+
+    public PolicyEnforcementListener(PolicyAdministrationPoint policyAdministrationPoint) {
+        this.policyAdministrationPoint = policyAdministrationPoint;
+    }
+
+    @EventListener
+    public void handleArtifactTransferredEvent(ArtifactTransferredEvent artifactTransferredEvent) {
+        log.info("Increasing access count for artifactId {}", artifactTransferredEvent.getAgreementId());
+        policyAdministrationPoint.updateAccessCount(artifactTransferredEvent.getAgreementId());
+
+    }
+
+
+}

--- a/negotiation/src/main/java/it/eng/negotiation/listener/PolicyEnforcementListener.java
+++ b/negotiation/src/main/java/it/eng/negotiation/listener/PolicyEnforcementListener.java
@@ -16,6 +16,11 @@ public class PolicyEnforcementListener {
         this.policyAdministrationPoint = policyAdministrationPoint;
     }
 
+    /**
+     * Handles the artifact transferred event and updates the access count.
+     * @param artifactTransferredEvent the event carrying the agreementId
+     */
+
     @EventListener
     public void handleArtifactTransferredEvent(ArtifactTransferredEvent artifactTransferredEvent) {
         log.info("Increasing access count for artifactId {}", artifactTransferredEvent.getAgreementId());

--- a/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
@@ -49,7 +49,7 @@ public class AccessCountPolicyEvaluator implements PolicyEvaluator {
 		
 		switch (operator) {	
 		case LT:
-			if (!(currentCount < count)) {
+			if (!((currentCount) < count)) {
 				return PolicyDecision.Builder.newInstance()
 						.allowed(false)
 						.message("Access count exceeded")
@@ -59,7 +59,10 @@ public class AccessCountPolicyEvaluator implements PolicyEvaluator {
 			}
 			break;
 		case LTEQ:
-			if (!(currentCount <= count)) {
+			// added +1 because currentCount starts from zero and represents the number of times the user has already accessed the resource,
+			// and we want to allow access if the user has not yet reached the limit.
+			//TODO check with team if LTEQ makes sense for this type of policy, because it is not clear if the user can access the resource when currentCount == count or not.
+			if (!((currentCount+1) <= count)) {
 				return PolicyDecision.Builder.newInstance()
 						.allowed(false)
 						.message("Access count exceeded")

--- a/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
@@ -49,6 +49,8 @@ public class AccessCountPolicyEvaluator implements PolicyEvaluator {
 		
 		switch (operator) {	
 		case LT:
+			// added +1 because currentCount starts from zero and represents the number of times the user has already accessed the resource,
+			// and we want to allow access if the user has not yet reached the limit.
 			if (!((currentCount+1) < count)) {
 				return PolicyDecision.Builder.newInstance()
 						.allowed(false)
@@ -61,7 +63,6 @@ public class AccessCountPolicyEvaluator implements PolicyEvaluator {
 		case LTEQ:
 			// added +1 because currentCount starts from zero and represents the number of times the user has already accessed the resource,
 			// and we want to allow access if the user has not yet reached the limit.
-			//TODO check with team if LTEQ makes sense for this type of policy, because it is not clear if the user can access the resource when currentCount == count or not.
 			if (!((currentCount+1) <= count)) {
 				return PolicyDecision.Builder.newInstance()
 						.allowed(false)

--- a/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluator.java
@@ -49,7 +49,7 @@ public class AccessCountPolicyEvaluator implements PolicyEvaluator {
 		
 		switch (operator) {	
 		case LT:
-			if (!((currentCount) < count)) {
+			if (!((currentCount+1) < count)) {
 				return PolicyDecision.Builder.newInstance()
 						.allowed(false)
 						.message("Access count exceeded")

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
@@ -34,7 +34,7 @@ public class PolicyAdministrationPoint {
 	public void createPolicyEnforcement(String agreementId) {
 		PolicyEnforcement pe = new PolicyEnforcement();
 		pe.setAgreementId(agreementId);
-		pe.setCount(1);
+		pe.setCount(0);
 		policyEnforcementRepository.save(pe);
 	}
 	

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
@@ -34,6 +34,7 @@ public class PolicyAdministrationPoint {
 	public void createPolicyEnforcement(String agreementId) {
 		PolicyEnforcement pe = new PolicyEnforcement();
 		pe.setAgreementId(agreementId);
+		//configured to start from zero at the initialized phase of data transfer in order to avoid one extra access beyond the configured limit
 		pe.setCount(0);
 		policyEnforcementRepository.save(pe);
 	}

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
@@ -1,26 +1,97 @@
 package it.eng.negotiation.rest.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import it.eng.negotiation.model.Agreement;
+import it.eng.negotiation.serializer.NegotiationSerializer;
 import it.eng.negotiation.service.AgreementAPIService;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.response.GenericApiResponse;
+import it.eng.tools.rest.api.PagedAPIResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @RestController
-@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, path = ApiEndpoints.NEGOTIATION_AGREEMENTS_V1)
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE,
+        path = ApiEndpoints.NEGOTIATION_AGREEMENTS_V1)
 @Slf4j
 public class AgreementAPIController {
 
     private final AgreementAPIService agreementAPIService;
+    private final PagedResourcesAssembler<Agreement> pagedResourcesAssembler;
+    private final PlainAgreementAssembler plainAssembler;
 
-    public AgreementAPIController(AgreementAPIService agreementAPIService) {
+    public AgreementAPIController(AgreementAPIService agreementAPIService,
+                                  PagedResourcesAssembler<Agreement> pagedResourcesAssembler,
+                                  PlainAgreementAssembler plainAssembler) {
         super();
         this.agreementAPIService = agreementAPIService;
+        this.pagedResourcesAssembler = pagedResourcesAssembler;
+        this.plainAssembler = plainAssembler;
+    }
+
+    /**
+     * Returns a single agreement by its ID.
+     *
+     * @param agreementId the ID of the agreement to retrieve
+     * @return ResponseEntity containing the agreement or an error response if not found
+     */
+    @GetMapping(path = "/{agreementId}")
+    public ResponseEntity<GenericApiResponse<JsonNode>> getAgreementById(
+            @PathVariable("agreementId") String agreementId) {
+        log.info("Fetching agreement with id {}", agreementId);
+        JsonNode agreementEnriched = agreementAPIService.findAgreementByIdEnriched(agreementId);
+
+
+//        agreementAPIService.getCurrentCount(agreementId).ifPresent(count -> agreementJson.put("currentCount", count));
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(agreementEnriched,
+                        String.format("Agreement with id %s found", agreementId)));
+    }
+
+    /**
+     * Returns a paginated list of all agreements.
+     *
+     * @param page the page number, zero-based (default 0)
+     * @param size the number of items per page (default 20)
+     * @param sort the sort field and direction in the format "field,direction" (default "timestamp,desc")
+     * @return ResponseEntity containing a paginated list of agreements
+     */
+    @GetMapping
+    public ResponseEntity<PagedAPIResponse> getAgreements(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "timestamp,desc") String[] sort) {
+        Sort.Direction direction = sort[1].equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Sort sorting = Sort.by(direction, sort[0]);
+        Pageable pageable = PageRequest.of(page, size, sorting);
+
+        Page<Agreement> agreements = agreementAPIService.findAgreements(pageable);
+        PagedModel<EntityModel<Object>> pagedModel = pagedResourcesAssembler.toModel(agreements, plainAssembler);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(PagedAPIResponse.of(pagedModel,
+                        "Agreements - Page " + page + " of " + agreements.getTotalPages()
+                                + ", Size: " + size + ", Sort: " + sorting));
     }
 
     /**
@@ -37,5 +108,4 @@ public class AgreementAPIController {
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(GenericApiResponse.success("Agreement enforcement is valid", "Agreement enforcement is ok"));
     }
-
 }

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
@@ -1,31 +1,17 @@
 package it.eng.negotiation.rest.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import it.eng.negotiation.model.Agreement;
-import it.eng.negotiation.serializer.NegotiationSerializer;
 import it.eng.negotiation.service.AgreementAPIService;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.response.GenericApiResponse;
-import it.eng.tools.rest.api.PagedAPIResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Optional;
 
 @RestController
 @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE,
@@ -34,64 +20,10 @@ import java.util.Optional;
 public class AgreementAPIController {
 
     private final AgreementAPIService agreementAPIService;
-    private final PagedResourcesAssembler<Agreement> pagedResourcesAssembler;
-    private final PlainAgreementAssembler plainAssembler;
 
-    public AgreementAPIController(AgreementAPIService agreementAPIService,
-                                  PagedResourcesAssembler<Agreement> pagedResourcesAssembler,
-                                  PlainAgreementAssembler plainAssembler) {
+    public AgreementAPIController(AgreementAPIService agreementAPIService) {
         super();
         this.agreementAPIService = agreementAPIService;
-        this.pagedResourcesAssembler = pagedResourcesAssembler;
-        this.plainAssembler = plainAssembler;
-    }
-
-    /**
-     * Returns a single agreement by its ID.
-     *
-     * @param agreementId the ID of the agreement to retrieve
-     * @return ResponseEntity containing the agreement or an error response if not found
-     */
-    @GetMapping(path = "/{agreementId}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getAgreementById(
-            @PathVariable("agreementId") String agreementId) {
-        log.info("Fetching agreement with id {}", agreementId);
-        JsonNode agreementEnriched = agreementAPIService.findAgreementByIdEnriched(agreementId);
-
-
-//        agreementAPIService.getCurrentCount(agreementId).ifPresent(count -> agreementJson.put("currentCount", count));
-
-        return ResponseEntity.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(GenericApiResponse.success(agreementEnriched,
-                        String.format("Agreement with id %s found", agreementId)));
-    }
-
-    /**
-     * Returns a paginated list of all agreements.
-     *
-     * @param page the page number, zero-based (default 0)
-     * @param size the number of items per page (default 20)
-     * @param sort the sort field and direction in the format "field,direction" (default "timestamp,desc")
-     * @return ResponseEntity containing a paginated list of agreements
-     */
-    @GetMapping
-    public ResponseEntity<PagedAPIResponse> getAgreements(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "timestamp,desc") String[] sort) {
-        Sort.Direction direction = sort[1].equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
-        Sort sorting = Sort.by(direction, sort[0]);
-        Pageable pageable = PageRequest.of(page, size, sorting);
-
-        Page<Agreement> agreements = agreementAPIService.findAgreements(pageable);
-        PagedModel<EntityModel<Object>> pagedModel = pagedResourcesAssembler.toModel(agreements, plainAssembler);
-
-        return ResponseEntity.ok()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(PagedAPIResponse.of(pagedModel,
-                        "Agreements - Page " + page + " of " + agreements.getTotalPages()
-                                + ", Size: " + size + ", Sort: " + sorting));
     }
 
     /**
@@ -108,4 +40,24 @@ public class AgreementAPIController {
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(GenericApiResponse.success("Agreement enforcement is valid", "Agreement enforcement is ok"));
     }
+
+    /**
+     * Returns a single agreement by its ID.
+     *
+     * @param agreementId the ID of the agreement to retrieve
+     * @return ResponseEntity containing the agreement or an error response if not found
+     */
+    @GetMapping(path = "/{agreementId}")
+    public ResponseEntity<GenericApiResponse<JsonNode>> getAgreementById(
+            @PathVariable("agreementId") String agreementId) {
+        log.info("Fetching agreement with id {}", agreementId);
+        JsonNode agreementEnriched = agreementAPIService.findAgreementByIdEnriched(agreementId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(GenericApiResponse.success(agreementEnriched,
+                        String.format("Agreement with id %s found", agreementId)));
+    }
+
+
 }

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/PlainAgreementAssembler.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/PlainAgreementAssembler.java
@@ -22,7 +22,7 @@ public class PlainAgreementAssembler implements RepresentationModelAssembler<Agr
 
     @Override
     public EntityModel<Object> toModel(Agreement entity) {
-        var plainJson = (ObjectNode) NegotiationSerializer.serializePlainJsonNode(entity);
+        ObjectNode plainJson = (ObjectNode) NegotiationSerializer.serializePlainJsonNode(entity);
         Map<String, Object> content = new ObjectMapper().convertValue(plainJson, new TypeReference<>() {});
         return EntityModel.of(content,
                 linkTo(methodOn(AgreementAPIController.class).getAgreementById(entity.getId())).withSelfRel());

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/PlainAgreementAssembler.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/PlainAgreementAssembler.java
@@ -1,0 +1,30 @@
+package it.eng.negotiation.rest.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import it.eng.negotiation.model.Agreement;
+import it.eng.negotiation.serializer.NegotiationSerializer;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+/**
+ * Assembler that converts an {@link Agreement} into an {@link EntityModel} with a self-link.
+ */
+@Component
+public class PlainAgreementAssembler implements RepresentationModelAssembler<Agreement, EntityModel<Object>> {
+
+    @Override
+    public EntityModel<Object> toModel(Agreement entity) {
+        var plainJson = (ObjectNode) NegotiationSerializer.serializePlainJsonNode(entity);
+        Map<String, Object> content = new ObjectMapper().convertValue(plainJson, new TypeReference<>() {});
+        return EntityModel.of(content,
+                linkTo(methodOn(AgreementAPIController.class).getAgreementById(entity.getId())).withSelfRel());
+    }
+}

--- a/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
@@ -6,8 +6,15 @@ import it.eng.negotiation.model.Agreement;
 import it.eng.negotiation.policy.model.PolicyDecision;
 import it.eng.negotiation.policy.service.PolicyEnforcementPoint;
 import it.eng.negotiation.repository.AgreementRepository;
+import it.eng.negotiation.repository.PolicyEnforcementRepository;
+import it.eng.negotiation.serializer.NegotiationSerializer;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -15,13 +22,45 @@ public class AgreementAPIService {
 
     private final PolicyEnforcementPoint policyEnforcementPoint;
     private final AgreementRepository agreementRepository;
+    private final PolicyEnforcementRepository policyEnforcementRepository;
 
-    public AgreementAPIService(AgreementRepository agreementRepository, PolicyEnforcementPoint policyEnforcementPoint) {
+    public AgreementAPIService(AgreementRepository agreementRepository, PolicyEnforcementPoint policyEnforcementPoint, PolicyEnforcementRepository policyEnforcementRepository) {
         super();
         this.policyEnforcementPoint = policyEnforcementPoint;
         this.agreementRepository = agreementRepository;
+        this.policyEnforcementRepository = policyEnforcementRepository;
     }
 
+    /**
+     * Returns a single agreement by its ID.
+     *
+     * @param agreementId the ID of the agreement to retrieve
+     * @return the agreement with the given ID
+     * @throws ContractNegotiationAPIException if no agreement is found with the given ID
+     */
+    public Agreement findAgreementById(String agreementId) {
+        return agreementRepository.findById(agreementId)
+                .orElseThrow(() -> new ContractNegotiationAPIException("Agreement with id " + agreementId + " not found."));
+    }
+
+    /**
+     * Returns a paginated list of all agreements.
+     *
+     * @param pageable pagination and sorting parameters
+     * @return a page of agreements
+     */
+    public Page<Agreement> findAgreements(Pageable pageable) {
+        log.info("Fetching agreements...");
+        return agreementRepository.findAll(pageable);
+    }
+
+    /**
+     * Enforces the policy for the given agreement.
+     *
+     * @param agreementId the ID of the agreement to enforce
+     * @throws ContractNegotiationAPIException if no agreement is found with the given ID
+     * @throws PolicyEnforcementException if the agreement policy evaluation fails
+     */
     public void enforceAgreement(String agreementId) {
         Agreement agreement = agreementRepository.findById(agreementId)
                 .orElseThrow(() -> new ContractNegotiationAPIException("Agreement with Id " + agreementId + " not found."));
@@ -37,5 +76,32 @@ public class AgreementAPIService {
             log.info("Agreement is invalid");
             throw new PolicyEnforcementException("Agreement with id'" + agreementId + "' evaluated as invalid");
         }
+    }
+
+    /**
+     * Retrieves the current count for the given agreement.
+     *
+     * @param agreementId the ID of the agreement
+     * @return an Optional containing the count, or empty if no enforcement found
+     */
+    public Optional<Integer> getCurrentCount(String agreementId) {
+        return policyEnforcementRepository.findByAgreementId(agreementId)
+                .map(enforcement -> enforcement.getCount());
+    }
+
+    /**
+     * Returns a single agreement by its ID, enriched with current policy enforcement count.
+     *
+     * @param agreementId the ID of the agreement to retrieve
+     * @return JsonNode representation of the agreement, with currentCount field if enforcement exists
+     * @throws ContractNegotiationAPIException if no agreement is found with the given ID
+     */
+    public JsonNode findAgreementByIdEnriched(String agreementId) {
+        Agreement agreement =  agreementRepository.findById(agreementId)
+                .orElseThrow(() -> new ContractNegotiationAPIException("Agreement with id " + agreementId + " not found."));
+        ObjectNode json = (ObjectNode) NegotiationSerializer.serializePlainJsonNode(agreement);
+        getCurrentCount(agreementId).ifPresent(count -> json.put("currentCount", count));
+        return json;
+
     }
 }

--- a/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
@@ -3,6 +3,7 @@ package it.eng.negotiation.service;
 import it.eng.negotiation.exception.ContractNegotiationAPIException;
 import it.eng.negotiation.exception.PolicyEnforcementException;
 import it.eng.negotiation.model.Agreement;
+import it.eng.negotiation.model.PolicyEnforcement;
 import it.eng.negotiation.policy.model.PolicyDecision;
 import it.eng.negotiation.policy.service.PolicyEnforcementPoint;
 import it.eng.negotiation.repository.AgreementRepository;
@@ -86,7 +87,7 @@ public class AgreementAPIService {
      */
     public Optional<Integer> getCurrentCount(String agreementId) {
         return policyEnforcementRepository.findByAgreementId(agreementId)
-                .map(enforcement -> enforcement.getCount());
+                .map(PolicyEnforcement::getCount);
     }
 
     /**

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
@@ -11,6 +11,7 @@ import it.eng.negotiation.rest.protocol.ContractNegotiationCallback;
 import it.eng.negotiation.serializer.NegotiationSerializer;
 import it.eng.tools.client.rest.OkHttpRestClient;
 import it.eng.tools.event.policyenforcement.ArtifactConsumedEvent;
+import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.service.AuditEventPublisher;
 import it.eng.tools.util.CredentialUtils;
@@ -120,4 +121,11 @@ public class ContractNegotiationEventHandlerService extends BaseProtocolService 
         log.info("Increasing access count for artifactId {}", artifactConsumedEvent.getAgreementId());
         policyAdministrationPoint.updateAccessCount(artifactConsumedEvent.getAgreementId());
     }
+
+//    public void artifactTransferredEvent(ArtifactTransferredEvent artifactTransferredEvent) {
+//        log.info("Increasing access count for artifactId {}", artifactTransferredEvent.getAgreementId());
+//        policyAdministrationPoint.updateAccessCount(artifactTransferredEvent.getAgreementId());
+//    }
+
+
 }

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
@@ -11,7 +11,6 @@ import it.eng.negotiation.rest.protocol.ContractNegotiationCallback;
 import it.eng.negotiation.serializer.NegotiationSerializer;
 import it.eng.tools.client.rest.OkHttpRestClient;
 import it.eng.tools.event.policyenforcement.ArtifactConsumedEvent;
-import it.eng.tools.event.policyenforcement.ArtifactTransferredEvent;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.service.AuditEventPublisher;
 import it.eng.tools.util.CredentialUtils;
@@ -121,11 +120,5 @@ public class ContractNegotiationEventHandlerService extends BaseProtocolService 
         log.info("Increasing access count for artifactId {}", artifactConsumedEvent.getAgreementId());
         policyAdministrationPoint.updateAccessCount(artifactConsumedEvent.getAgreementId());
     }
-
-//    public void artifactTransferredEvent(ArtifactTransferredEvent artifactTransferredEvent) {
-//        log.info("Increasing access count for artifactId {}", artifactTransferredEvent.getAgreementId());
-//        policyAdministrationPoint.updateAccessCount(artifactTransferredEvent.getAgreementId());
-//    }
-
 
 }

--- a/negotiation/src/test/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluatorTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluatorTest.java
@@ -70,7 +70,7 @@ class AccessCountPolicyEvaluatorTest {
 	                .description("Access count policy")
 	                .enabled(true)
 	                .validFrom(LocalDateTime.now().minusDays(1))
-	                .attribute(PolicyConstants.COUNT, 3) // Max count
+	                .attribute(PolicyConstants.COUNT, 4) // Max count
 	                .attribute(PolicyConstants.OPERATOR, Operator.LT) // Operator
 	                .build();
 		  
@@ -102,7 +102,7 @@ class AccessCountPolicyEvaluatorTest {
 	                .description("Access count policy")
 	                .enabled(true)
 	                .validFrom(LocalDateTime.now().minusDays(1))
-	                .attribute("count", 3) // Max count
+	                .attribute("count", 4) // Max count
 	                .attribute("operator", Operator.LT) // Operator
 	                .build();
 		  

--- a/negotiation/src/test/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluatorTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/policy/evaluator/AccessCountPolicyEvaluatorTest.java
@@ -175,7 +175,7 @@ class AccessCountPolicyEvaluatorTest {
 	                .agreementId("agreement-123")
 	                .resourceId("resource-123")
 	                .userId("user-123")
-	                .attribute(PolicyConstants.CURRENT_COUNT, 4) // Current count
+	                .attribute(PolicyConstants.CURRENT_COUNT, 3) // Current count
 	                .action(Action.ANONYMIZE)
 	                .build();
 	        

--- a/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
@@ -1,49 +1,140 @@
 package it.eng.negotiation.rest.api;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import it.eng.negotiation.exception.ContractNegotiationAPIException;
+import it.eng.negotiation.model.Agreement;
+import it.eng.negotiation.model.NegotiationMockObjectUtil;
+import it.eng.negotiation.serializer.NegotiationSerializer;
+import it.eng.negotiation.service.AgreementAPIService;
+import it.eng.tools.response.GenericApiResponse;
+import it.eng.tools.rest.api.PagedAPIResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import it.eng.negotiation.exception.ContractNegotiationAPIException;
-import it.eng.negotiation.model.NegotiationMockObjectUtil;
-import it.eng.negotiation.service.AgreementAPIService;
-import it.eng.tools.response.GenericApiResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AgreementAPIControllerTest {
 
-	@Mock
-	private AgreementAPIService agreementAPIService;
-	
-	@InjectMocks
-	private AgreementAPIController controller;
-	
-	@Test
-	@DisplayName("Enforce agreement")
-	void enforceAgreement() {
-		doNothing().when(agreementAPIService).enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId());
-		ResponseEntity<GenericApiResponse<String>> response = controller.enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId());
-		assertNotNull(response);
-		assertTrue(response.getBody().isSuccess());
-	}
-	
-	@Test
-	@DisplayName("Enforce agreement - not valid")
-	void enforceAgreement_serviceError() {
-		doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
-		.when(agreementAPIService).enforceAgreement(any(String.class));
-		assertThrows(ContractNegotiationAPIException.class, 
-				() -> controller.enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId()));
-	}
+    @Mock
+    private AgreementAPIService agreementAPIService;
+    @Mock
+    private PagedResourcesAssembler<Agreement> pagedResourcesAssembler;
+    @Mock
+    private PlainAgreementAssembler plainAssembler;
+    @Mock
+    private Pageable pageable;
+
+    @InjectMocks
+    private AgreementAPIController controller;
+
+    private static final PagedModel.PageMetadata PAGE_METADATA = new PagedModel.PageMetadata(20, 0, 1, 1);
+
+    @Test
+    @DisplayName("Get agreement by id - success")
+    void getAgreementById() {
+        JsonNode agreementJson = NegotiationSerializer.serializePlainJsonNode(NegotiationMockObjectUtil.AGREEMENT);
+        when(agreementAPIService.findAgreementByIdEnriched(NegotiationMockObjectUtil.AGREEMENT.getId()))
+                .thenReturn(agreementJson);
+
+        ResponseEntity<GenericApiResponse<JsonNode>> response =
+                controller.getAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isSuccess());
+        assertNotNull(response.getBody().getData());
+    }
+
+    @Test
+    @DisplayName("Get agreement by id - not found")
+    void getAgreementById_notFound() {
+        when(agreementAPIService.findAgreementByIdEnriched(any(String.class)))
+                .thenThrow(new ContractNegotiationAPIException("Agreement not found"));
+
+        assertThrows(ContractNegotiationAPIException.class,
+                () -> controller.getAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId()));
+    }
+
+    @Test
+    @DisplayName("Get agreements - success")
+    void getAgreements() {
+        Page<Agreement> agreementPage = new PageImpl<>(List.of(NegotiationMockObjectUtil.AGREEMENT), pageable, 1);
+        List<EntityModel<Agreement>> content = List.of(EntityModel.of(NegotiationMockObjectUtil.AGREEMENT));
+        PagedModel<EntityModel<Agreement>> pagedModel = PagedModel.of(content, PAGE_METADATA);
+
+        when(agreementAPIService.findAgreements(any(Pageable.class))).thenReturn(agreementPage);
+        when(pagedResourcesAssembler.toModel(agreementPage, plainAssembler)).thenReturn((PagedModel) pagedModel);
+
+        ResponseEntity<PagedAPIResponse> response = controller.getAgreements(0, 20, new String[]{"timestamp", "desc"});
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getResponse().isSuccess());
+        assertFalse(response.getBody().getResponse().getData().getContent().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Get agreements - empty page")
+    void getAgreements_emptyPage() {
+        Page<Agreement> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        PagedModel<EntityModel<Agreement>> emptyModel = PagedModel.of(List.of(), PAGE_METADATA);
+
+        when(agreementAPIService.findAgreements(any(Pageable.class))).thenReturn(emptyPage);
+        when(pagedResourcesAssembler.toModel(emptyPage, plainAssembler)).thenReturn((PagedModel) emptyModel);
+
+        ResponseEntity<PagedAPIResponse> response = controller.getAgreements(0, 20, new String[]{"timestamp", "desc"});
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getResponse().getData().getContent().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Enforce agreement - success")
+    void enforceAgreement() {
+        doNothing().when(agreementAPIService).enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+        ResponseEntity<GenericApiResponse<String>> response =
+                controller.enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isSuccess());
+    }
+
+    @Test
+    @DisplayName("Enforce agreement - not valid")
+    void enforceAgreement_serviceError() {
+        doThrow(new ContractNegotiationAPIException("Something not correct - tests"))
+                .when(agreementAPIService).enforceAgreement(any(String.class));
+
+        assertThrows(ContractNegotiationAPIException.class,
+                () -> controller.enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId()));
+    }
 }

--- a/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/rest/api/AgreementAPIControllerTest.java
@@ -7,26 +7,17 @@ import it.eng.negotiation.model.NegotiationMockObjectUtil;
 import it.eng.negotiation.serializer.NegotiationSerializer;
 import it.eng.negotiation.service.AgreementAPIService;
 import it.eng.tools.response.GenericApiResponse;
-import it.eng.tools.rest.api.PagedAPIResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,8 +40,6 @@ class AgreementAPIControllerTest {
 
     @InjectMocks
     private AgreementAPIController controller;
-
-    private static final PagedModel.PageMetadata PAGE_METADATA = new PagedModel.PageMetadata(20, 0, 1, 1);
 
     @Test
     @DisplayName("Get agreement by id - success")
@@ -77,42 +66,6 @@ class AgreementAPIControllerTest {
 
         assertThrows(ContractNegotiationAPIException.class,
                 () -> controller.getAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId()));
-    }
-
-    @Test
-    @DisplayName("Get agreements - success")
-    void getAgreements() {
-        Page<Agreement> agreementPage = new PageImpl<>(List.of(NegotiationMockObjectUtil.AGREEMENT), pageable, 1);
-        List<EntityModel<Agreement>> content = List.of(EntityModel.of(NegotiationMockObjectUtil.AGREEMENT));
-        PagedModel<EntityModel<Agreement>> pagedModel = PagedModel.of(content, PAGE_METADATA);
-
-        when(agreementAPIService.findAgreements(any(Pageable.class))).thenReturn(agreementPage);
-        when(pagedResourcesAssembler.toModel(agreementPage, plainAssembler)).thenReturn((PagedModel) pagedModel);
-
-        ResponseEntity<PagedAPIResponse> response = controller.getAgreements(0, 20, new String[]{"timestamp", "desc"});
-
-        assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue(response.getBody().getResponse().isSuccess());
-        assertFalse(response.getBody().getResponse().getData().getContent().isEmpty());
-    }
-
-    @Test
-    @DisplayName("Get agreements - empty page")
-    void getAgreements_emptyPage() {
-        Page<Agreement> emptyPage = new PageImpl<>(List.of(), pageable, 0);
-        PagedModel<EntityModel<Agreement>> emptyModel = PagedModel.of(List.of(), PAGE_METADATA);
-
-        when(agreementAPIService.findAgreements(any(Pageable.class))).thenReturn(emptyPage);
-        when(pagedResourcesAssembler.toModel(emptyPage, plainAssembler)).thenReturn((PagedModel) emptyModel);
-
-        ResponseEntity<PagedAPIResponse> response = controller.getAgreements(0, 20, new String[]{"timestamp", "desc"});
-
-        assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue(response.getBody().getResponse().getData().getContent().isEmpty());
     }
 
     @Test

--- a/negotiation/src/test/java/it/eng/negotiation/service/AgreementAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/AgreementAPIServiceTest.java
@@ -1,9 +1,14 @@
 package it.eng.negotiation.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,13 +17,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import it.eng.negotiation.exception.ContractNegotiationAPIException;
 import it.eng.negotiation.exception.PolicyEnforcementException;
+import it.eng.negotiation.model.Agreement;
 import it.eng.negotiation.model.NegotiationMockObjectUtil;
+import it.eng.negotiation.model.PolicyEnforcement;
 import it.eng.negotiation.policy.model.PolicyDecision;
 import it.eng.negotiation.policy.service.PolicyAdministrationPoint;
 import it.eng.negotiation.policy.service.PolicyEnforcementPoint;
 import it.eng.negotiation.repository.AgreementRepository;
+import it.eng.negotiation.repository.PolicyEnforcementRepository;
 
 @ExtendWith(MockitoExtension.class)
 class AgreementAPIServiceTest {
@@ -29,6 +42,8 @@ class AgreementAPIServiceTest {
 	private PolicyAdministrationPoint policyAdministrationPoint;
 	@Mock
 	private PolicyEnforcementPoint policyEnforcementPoint;
+	@Mock
+	private PolicyEnforcementRepository policyEnforcementRepository;
 	
 	@InjectMocks
 	private AgreementAPIService service;
@@ -43,6 +58,45 @@ class AgreementAPIServiceTest {
 			.message("Policy denied test")
 			.build();
 	
+	@Mock
+	private Pageable pageable;
+
+	// find agreement by id
+	@Test
+	@DisplayName("Find agreement by id - success")
+	public void findAgreementById() {
+		when(agreementRepository.findById(NegotiationMockObjectUtil.AGREEMENT.getId()))
+				.thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
+
+		Agreement result = service.findAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+		assertNotNull(result);
+		assertEquals(NegotiationMockObjectUtil.AGREEMENT.getId(), result.getId());
+	}
+
+	@Test
+	@DisplayName("Find agreement by id - not found")
+	public void findAgreementById_notFound() {
+		when(agreementRepository.findById(any(String.class))).thenReturn(Optional.empty());
+
+		assertThrows(ContractNegotiationAPIException.class,
+				() -> service.findAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId()));
+	}
+
+	// find agreements
+	@Test
+	@DisplayName("Find agreements - returns page")
+	public void findAgreements() {
+		Page<Agreement> agreementPage = new PageImpl<>(List.of(NegotiationMockObjectUtil.AGREEMENT), pageable, 1);
+		when(agreementRepository.findAll(any(Pageable.class))).thenReturn(agreementPage);
+
+		Page<Agreement> result = service.findAgreements(pageable);
+
+		assertNotNull(result);
+		assertFalse(result.isEmpty());
+		assertEquals(1, result.getTotalElements());
+	}
+
 	// enforce agreement
 	@Test
 	@DisplayName("Enforce agreement ok")
@@ -54,6 +108,46 @@ class AgreementAPIServiceTest {
 		assertDoesNotThrow(()-> service.enforceAgreement(NegotiationMockObjectUtil.AGREEMENT.getId()));
 	}
 	
+	// find agreement by id enriched
+	@Test
+	@DisplayName("Find agreement by id enriched - with enforcement count")
+	public void findAgreementByIdEnriched_withEnforcement() {
+		PolicyEnforcement pe = new PolicyEnforcement("pe-id", NegotiationMockObjectUtil.AGREEMENT.getId(), 3);
+		when(agreementRepository.findById(NegotiationMockObjectUtil.AGREEMENT.getId()))
+				.thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
+		when(policyEnforcementRepository.findByAgreementId(NegotiationMockObjectUtil.AGREEMENT.getId()))
+				.thenReturn(Optional.of(pe));
+
+		JsonNode result = service.findAgreementByIdEnriched(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+		assertNotNull(result);
+		assertNotNull(result.get("currentCount"));
+		assertEquals(3, result.get("currentCount").asInt());
+	}
+
+	@Test
+	@DisplayName("Find agreement by id enriched - no enforcement record")
+	public void findAgreementByIdEnriched_withoutEnforcement() {
+		when(agreementRepository.findById(NegotiationMockObjectUtil.AGREEMENT.getId()))
+				.thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
+		when(policyEnforcementRepository.findByAgreementId(NegotiationMockObjectUtil.AGREEMENT.getId()))
+				.thenReturn(Optional.empty());
+
+		JsonNode result = service.findAgreementByIdEnriched(NegotiationMockObjectUtil.AGREEMENT.getId());
+
+		assertNotNull(result);
+		assertFalse(result.has("currentCount"));
+	}
+
+	@Test
+	@DisplayName("Find agreement by id enriched - agreement not found")
+	public void findAgreementByIdEnriched_notFound() {
+		when(agreementRepository.findById(any(String.class))).thenReturn(Optional.empty());
+
+		assertThrows(ContractNegotiationAPIException.class,
+				() -> service.findAgreementByIdEnriched(NegotiationMockObjectUtil.AGREEMENT.getId()));
+	}
+
 	@Test
 	@DisplayName("Enforce agreement - not valid")
 	public void enforceAgreement_not_valid() {

--- a/tools/src/main/java/it/eng/tools/event/policyenforcement/ArtifactTransferredEvent.java
+++ b/tools/src/main/java/it/eng/tools/event/policyenforcement/ArtifactTransferredEvent.java
@@ -1,0 +1,10 @@
+package it.eng.tools.event.policyenforcement;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ArtifactTransferredEvent {
+    private String agreementId;
+}


### PR DESCRIPTION
### Added
- `GET /api/v1/negotiations/agreements/{agreementId}` — new management endpoint returning a single agreement by ID, enriched with `currentCount` if an active policy enforcement record exists for that agreement.
- `PolicyEnforcementListener` — new event listener that increments the access count via `PolicyAdministrationPoint` on every `ArtifactTransferredEvent`, enabling real-time tracking of how many times an artifact has been transferred under a given agreement.
- `AgreementAPIService.findAgreementByIdEnriched()` — fetches the agreement and appends `currentCount` from `PolicyEnforcementRepository` before returning the JSON representation.

### Changed
- `AccessCountPolicyEvaluator` — fixed off-by-one in `LT` and `LTEQ` operator evaluation: both now use `currentCount + 1` so the current access attempt is counted before the limit check, preventing one extra access beyond the configured limit.