### PR TITLE
[SLICE][MT2] Security & Access Control Hardening

### DIFF
--- a/.github/skills/slice-implementation/SKILL.md
+++ b/.github/skills/slice-implementation/SKILL.md
@@ -276,10 +276,13 @@ If a pre-existing bug blocks QA or docs, stop and comment on the blocking child 
 
 After all included open child issues are completed and integrated into the final slice branch:
 
-1. commit the final slice branch changes
-2. push the final slice branch
-3. open **one PR** against `develop`
-4. move the parent slice and every included open child issue to **In Review**
+1. run the complete `mvn clean verify` suite (Docker required) on the final slice branch — this is the mandatory pre-push gate; targeted test runs used during child-task execution do not satisfy this requirement; note any known pre-existing flaky failures explicitly rather than skipping the full suite
+2. commit the final slice branch changes
+3. push the final slice branch
+4. open **one PR** against `develop`
+5. wait for GitHub Actions to complete: `gh pr checks <PR-number> --watch`
+6. if checks fail, enter the fix-and-retry loop described in `.github/skills/task-implementation/SKILL.md` **GitHub Actions check after PR** section — each push-and-wait counts against the shared 3-cycle budget
+7. move the parent slice and every included open child issue to **In Review** only after all GitHub Actions checks pass
 
 ### Required PR body convention
 
@@ -331,3 +334,5 @@ If the workflow fails or is unavailable, use this fallback after merge:
 - do not treat `Relates to:` as a hard dependency
 - do not infer child membership from branch names alone
 - do not skip the per-child verification rules inherited from `.github/skills/task-implementation/SKILL.md`
+- do not move the parent slice or any child issue to **In Review** while any required GitHub Actions checks are still failing
+- do not close the slice as done based on targeted test results alone — the full `mvn clean verify` suite is the mandatory pre-push gate

--- a/.github/skills/task-implementation/SKILL.md
+++ b/.github/skills/task-implementation/SKILL.md
@@ -227,6 +227,7 @@ Rules:
 3. mark or respect `[manual]` items as manual verification targets
 4. after a failed check, fix the issue and re-run the relevant checks
 5. maximum **3 fix-and-retry cycles** per issue
+6. **full-suite gate**: before pushing to the remote branch, always run `mvn clean verify` (Docker required) as the final local check — targeted test runs (`-Dtest=...` or `-Dit.test=...`) are development aids only and do not substitute for this gate; a known pre-existing flaky test is not a reason to skip the full suite — run through it and note the known failure explicitly
 
 If the issue still fails after 3 cycles:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,18 @@ All notable changes to this project will be documented in this file.
   - `ROLE_SUPER_ADMIN` users are exempt from tenant-existence validation and may be created without a `tenantId`.
   - **Keycloak mode user registration** — `KeycloakUserService` and `KeycloakUserApiController` added. When `application.auth.provider=KEYCLOAK`, `POST /api/v1/users` delegates to the Keycloak Admin REST API (`POST /admin/realms/{realm}/users`) using the service account client credentials. Requires `application.keycloak.admin.server-url` and `application.keycloak.admin.realm` properties.
   - ADR [D-TEC-001](doc/decisions/technical/D-TEC-001-keycloak-user-registration.md) — documents the Keycloak user-registration design rationale.
+- **MT2 — Security & Access Control Hardening**
+  - `ROLE_SUPER_ADMIN` is now required for `/api/v1/users/**` and `/api/v1/properties/**` in both `BASIC` and `KEYCLOAK` authentication modes. Previously only `/api/v1/tenants/**` was restricted to `ROLE_SUPER_ADMIN`; `ROLE_ADMIN` users could access user and property management endpoints, creating a privilege-escalation gap.
+  - Integration tests added covering SUPER_ADMIN access (200) and ROLE_ADMIN denial (403) for all three restricted endpoint prefixes in both auth modes. DISABLED mode is explicitly verified as permit-all for all three endpoints.
 
 ### Changed
 - **MT1** — `POST /api/v1/tenants`: `id` and `callbackAddress` in the request body are now ignored (server-generated). See [connector/documentation/users.md](connector/documentation/users.md) for the updated API reference.
 - **MT1** — `POST /api/v1/users`: `tenantId` field added to the request body.
+- **MT2** — `ConnectorSecurityConfig`: hardcoded role strings `"SUPER_ADMIN"`, `"ADMIN"`, `"CONNECTOR"` replaced with constants derived from the `it.eng.connector.model.Role` enum. This makes the Role enum the single source of truth for all role names in the security configuration.
 
+### Security
+
+- **MT2 — SUPER_ADMIN access control** — Restricted `/api/v1/users/**` and `/api/v1/properties/**` to `ROLE_SUPER_ADMIN` in both `BASIC` and `KEYCLOAK` authentication modes. `ROLE_ADMIN` users now receive HTTP 403 on these endpoints, closing a privilege-escalation path where tenant admins could previously manage users or modify global runtime properties across all tenants. Only `/api/v1/tenants/**` was previously restricted; this hardens the full management surface.
 - **Multi-tenant foundation** — `Tenant` model, `TenantRepository`, `TenantService`, `TenantContextHolder` (ThreadLocal + MDC), `TenantAPIController` for full tenant lifecycle management via `/api/v1/tenants`.
 - `TenantAwareProtocolController` — abstract base class for all DSP protocol controllers; resolves the `{tenantId}` path variable and sets `TenantContextHolder` before any request processing.
 - `ApiTenantContextFilter` — sets tenant scope for management API requests from the authenticated user's `tenantId`; super-admins may override with `X-Tenant-Id` header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ All notable changes to this project will be documented in this file.
 - **MT2 — Security & Access Control Hardening**
   - `ROLE_SUPER_ADMIN` is now required for `/api/v1/users/**` and `/api/v1/properties/**` in both `BASIC` and `KEYCLOAK` authentication modes. Previously only `/api/v1/tenants/**` was restricted to `ROLE_SUPER_ADMIN`; `ROLE_ADMIN` users could access user and property management endpoints, creating a privilege-escalation gap.
   - Integration tests added covering SUPER_ADMIN access (200) and ROLE_ADMIN denial (403) for all three restricted endpoint prefixes in both auth modes. DISABLED mode is explicitly verified as permit-all for all three endpoints.
+  - **ROLE_ADMIN self-service user management** — `ROLE_ADMIN` users may now call `GET /api/v1/users/me` (own profile), `PUT /api/v1/users/{id}/update` (own name), and `PUT /api/v1/users/{id}/password` (own password) without requiring `ROLE_SUPER_ADMIN`. All other user-management endpoints remain restricted to `ROLE_SUPER_ADMIN`.
+  - **Role enum cleanup** — `Role` enum values renamed from `ROLE_ADMIN`/`ROLE_USER`/`ROLE_CONNECTOR`/`ROLE_SUPER_ADMIN` to `ADMIN`/`USER`/`CONNECTOR`/`SUPER_ADMIN`. `authorityName()` helper added to produce the Spring Security `ROLE_`-prefixed authority string. `User.getAuthorities()` now calls `role.authorityName()`. All inline `"ROLE_*"` string literals removed from production and test code.
+  - **Tenant.participantId immutability** — `TenantService.updateTenant()` no longer accepts a new `participantId` from the request body; any supplied value is silently ignored and the stored `participantId` is always preserved after tenant creation.
 
 ### Changed
 - **MT1** — `POST /api/v1/tenants`: `id` and `callbackAddress` in the request body are now ignored (server-generated). See [connector/documentation/users.md](connector/documentation/users.md) for the updated API reference.
 - **MT1** — `POST /api/v1/users`: `tenantId` field added to the request body.
 - **MT2** — `ConnectorSecurityConfig`: hardcoded role strings `"SUPER_ADMIN"`, `"ADMIN"`, `"CONNECTOR"` replaced with constants derived from the `it.eng.connector.model.Role` enum. This makes the Role enum the single source of truth for all role names in the security configuration.
+- **MT2** — `TenantService.updateTenant()`: `participantId` is now immutable — any value in the request body is silently ignored. The stored `participantId` is always preserved after tenant creation.
 
 ### Security
 

--- a/ci/docker/connector_a_resources/initial_data.json
+++ b/ci/docker/connector_a_resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "connector_a_tenant_id"
     },
     {
@@ -23,7 +23,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "connector_a_tenant_id"
     },
     {
@@ -36,7 +36,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     }
   ],
   "catalogs": [

--- a/ci/docker/connector_b_resources/initial_data.json
+++ b/ci/docker/connector_b_resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "connector_b_tenant_id"
     },
     {
@@ -23,7 +23,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "connector_b_tenant_id"
     },
     {
@@ -36,7 +36,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     }
   ],
   "catalogs": [

--- a/ci/docker/test-cases/api-tests-tenant/api-endpoints-tenant-tests.json
+++ b/ci/docker/test-cases/api-tests-tenant/api-endpoints-tenant-tests.json
@@ -190,7 +190,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated Tenant Name\",\n  \"description\": \"Updated by automated test\",\n  \"automaticNegotiation\": true,\n  \"automaticTransfer\": false,\n  \"id\": \"{{NEW_TENANT_ID}}\",\n  \"participantId\": \"urn:test:connector:updated\"\n}",
+              "raw": "{\n  \"name\": \"Updated Tenant Name\",\n  \"description\": \"Updated by automated test\",\n  \"automaticNegotiation\": true,\n  \"automaticTransfer\": false,\n  \"id\": \"{{NEW_TENANT_ID}}\",\n  \"participantId\": \"urn:test:connector\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -209,7 +209,7 @@
                   "  var jsonData = pm.response.json();",
                   "  pm.expect(jsonData.data.name).to.eql('Updated Tenant Name');",
                   "  pm.expect(jsonData.data.description).to.eql('Updated by automated test');",
-                  "  pm.expect(jsonData.data.participantId).to.eql('urn:test:connector:updated');",
+                  "  pm.expect(jsonData.data.participantId).to.eql('urn:test:connector');",
                   "  pm.expect(jsonData.data.automaticNegotiation).to.be.true;",
                   "});"
                 ]

--- a/ci/docker/test-cases/api-tests/api-endpoints-tests.json
+++ b/ci/docker/test-cases/api-tests/api-endpoints-tests.json
@@ -1,811 +1,826 @@
 {
-  "info": {
-    "_postman_id": "564c507b-556d-46c8-b855-6b66027c648d",
-    "name": "API tests",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "36278855"
-  },
-  "item": [
-    {
-      "name": "Users",
-      "item": [
-        {
-          "name": "Get all users",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "pm.test(\"Check if response contains admin@mail.com\", function () {\r",
-                  "    pm.expect(pm.response.text()).to.include(\"admin@mail.com\");\r",
-                  "});"
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{CONSUMER_SERVER_API_USERS}}",
-              "host": [
-                "{{CONSUMER_SERVER_API_USERS}}"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get user by email",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "pm.test(\"Check if response contains admin@mail.com\", function () {\r",
-                  "    pm.expect(pm.response.text()).to.include(\"admin@mail.com\");\r",
-                  "});"
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{CONSUMER_SERVER_API_USERS}}/admin@mail.com",
-              "host": [
-                "{{CONSUMER_SERVER_API_USERS}}"
-              ],
-              "path": [
-                "admin@mail.com"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create user",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 200\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "pm.test(\"Response body contains New user created\", function () {\r",
-                  "    pm.expect(pm.response.text()).to.include(\"New user created\");\r",
-                  "    pm.expect(pm.response.text()).to.include(\"user_gha@mail.com\");\r",
-                  "    pm.expect(pm.response.text()).to.include(\"GHA Test user\");\r",
-                  "    pm.expect(pm.response.text()).to.include(\"DSP-TRUEConnector\");\r",
-                  "});"
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n  \"firstName\" : \"GHA Test user\",\r\n  \"lastName\" : \"DSP-TRUEConnector\",\r\n  \"email\" : \"user_gha@mail.com\",\r\n  \"password\" : \"GhaPassword123!\",\r\n  \"role\" : \"ROLE_ADMIN\"\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{CONSUMER_SERVER_API_USERS}}",
-              "host": [
-                "{{CONSUMER_SERVER_API_USERS}}"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Get all catalogs",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is catalog\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Retrieve catalog id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"catalogId\", jsonData[\"data\"][\"@id\"])\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains data services\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid datasets\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const datasets = catalog.dataset;\r",
-              "    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
-              "        dataset !== null &&\r",
-              "        dataset.hasPolicy !== null &&\r",
-              "        dataset.hasPolicy.length > 0 &&\r",
-              "        dataset.distribution !== null &&\r",
-              "        dataset.distribution.length > 0\r",
-              "    ));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid distributions\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const distributions = catalog.distribution;\r",
-              "    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
-              "        distribution !== null &&\r",
-              "        distribution.accessService !== null));\r",
-              "});\r",
-              ""
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_CATALOG}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_CATALOG}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get catalog by id",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is catalog\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains data services\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid datasets\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const datasets = catalog.dataset;\r",
-              "    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
-              "        dataset !== null &&\r",
-              "        dataset.hasPolicy !== null &&\r",
-              "        dataset.hasPolicy.length > 0 &&\r",
-              "        dataset.distribution !== null &&\r",
-              "        dataset.distribution.length > 0\r",
-              "    ));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid distributions\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const distributions = catalog.distribution;\r",
-              "    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
-              "        distribution !== null &&\r",
-              "        distribution.accessService !== null));\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_CATALOG}}/{{catalogId}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_CATALOG}}"
-          ],
-          "path": [
-            "{{catalogId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get all dataservices",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Retrieve dataservice id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"dataserviceId\", jsonData[\"data\"][0][\"@id\"])\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DATASERVICE}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DATASERVICE}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get dataservice by id",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is dataservice\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"DSP TRUEConnector service offering team information\", \"endpointDescription\", \"endpointURL\", \"SFTP\", \"REST\", \"transfer\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              ""
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DATASERVICE}}/{{dataserviceId}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DATASERVICE}}"
-          ],
-          "path": [
-            "{{dataserviceId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get all datasets",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Retrieve dataset id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"datasetId\", jsonData[\"data\"][0][\"@id\"])\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DATASET}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DATASET}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get dataset by id",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is dataset\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"Dataset offering TRUEConnector team information\", \"distribution\", \"accessService\", \"SFTP\", \"REST\", \"transfer\", \"servesDataset\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              ""
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DATASET}}/{{datasetId}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DATASET}}"
-          ],
-          "path": [
-            "{{datasetId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get all distributions",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Retrieve distribution id\", function () {\r",
-              "    var jsonData = pm.response.json();\r",
-              "    pm.collectionVariables.set(\"distributionId\", jsonData[\"data\"][0][\"@id\"])\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DISTRIBUTION}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DISTRIBUTION}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get distribution by id",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is dataset\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"DSP TRUEConnector service offering team information\", \"endpointDescription\", \"endpointURL\", \"accessService\", \"SFTP\", \"REST\", \"transfer\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              ""
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_DISTRIBUTION}}/{{distributionId}}",
-          "host": [
-            "{{CONSUMER_SERVER_API_DISTRIBUTION}}"
-          ],
-          "path": [
-            "{{distributionId}}"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get proxy catalog",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Response is catalog\", function () {\r",
-              "\r",
-              "    result = false;\r",
-              "    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
-              "    responseText = pm.response.text();\r",
-              "\r",
-              "    arr.forEach((x) => {\r",
-              "      if (responseText.includes(x)){\r",
-              "      result = true;\r",
-              "    }\r",
-              "\r",
-              "    pm.expect(result).to.be.true;\r",
-              "    });\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains data services\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid datasets\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const datasets = catalog.dataset;\r",
-              "    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
-              "        dataset !== null &&\r",
-              "        dataset.hasPolicy !== null &&\r",
-              "        dataset.hasPolicy.length > 0 &&\r",
-              "        dataset.distribution !== null &&\r",
-              "        dataset.distribution.length > 0\r",
-              "    ));\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Catalog contains valid distributions\", function () {\r",
-              "    const catalog = pm.response.json()[\"data\"];\r",
-              "    const distributions = catalog.distribution;\r",
-              "    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
-              "        distribution !== null &&\r",
-              "        distribution.accessService !== null));\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [],
-        "body": {
-          "mode": "raw",
-          "raw": "{\r\n    \"Forward-To\" : \"{{PROVIDER_PROTOCOL}}\"\r\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_PROXY}}/catalogs",
-          "host": [
-            "{{CONSUMER_SERVER_API_PROXY}}"
-          ],
-          "path": [
-            "catalogs"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get Dataset formats",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Check if status code is 200\", function () {\r",
-              "    pm.response.to.have.status(200);\r",
-              "});\r",
-              "\r",
-              "pm.test(\"Check if at least one format exists in the array\", function () {\r",
-              "    const jsonData = pm.response.json();\r",
-              "    pm.expect(jsonData.data).to.be.an('array').that.is.not.empty;\r",
-              "    pm.expect(jsonData.data[0]).to.exist;\r",
-              "});"
-            ],
-            "type": "text/javascript",
-            "packages": {}
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [],
-        "body": {
-          "mode": "raw",
-          "raw": "{\r\n    \"Forward-To\" : \"{{PROVIDER_PROTOCOL}}\"\r\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{CONSUMER_SERVER_API_PROXY}}/datasets/{{datasetId}}/formats",
-          "host": [
-            "{{CONSUMER_SERVER_API_PROXY}}"
-          ],
-          "path": [
-            "datasets",
-            "{{datasetId}}",
-            "formats"
-          ]
-        }
-      },
-      "response": []
-    }
-  ],
-  "auth": {
-    "type": "basic",
-    "basic": [
-      {
-        "key": "password",
-        "value": "password",
-        "type": "string"
-      },
-      {
-        "key": "username",
-        "value": "admin@mail.com",
-        "type": "string"
-      }
-    ]
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [
-          ""
-        ]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "packages": {},
-        "exec": [
-          ""
-        ]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "key": "CONSUMER",
-      "value": "http://localhost:8080",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_CATALOG",
-      "value": "{{CONSUMER}}/api/v1/catalogs",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_DATASERVICE",
-      "value": "{{CONSUMER}}/api/v1/dataservices",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_DATASET",
-      "value": "{{CONSUMER}}/api/v1/datasets",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_DISTRIBUTION",
-      "value": "{{CONSUMER}}/api/v1/distributions",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_PROXY",
-      "value": "{{CONSUMER}}/api/v1/proxy",
-      "type": "string"
-    },
-    {
-      "key": "CONSUMER_SERVER_API_USERS",
-      "value": "{{CONSUMER}}/api/v1/users",
-      "type": "string"
-    },
-    {
-      "key": "PROVIDER_PROTOCOL",
-      "value": "http://172.17.0.1:8090/connector_b_tenant_id",
-      "type": "string"
-    },
-    {
-      "key": "catalogId",
-      "value": ""
-    },
-    {
-      "key": "dataserviceId",
-      "value": ""
-    },
-    {
-      "key": "datasetId",
-      "value": ""
-    },
-    {
-      "key": "distributionId",
-      "value": ""
-    },
-    {
-      "key": "tenantId",
-      "value": "",
-      "type": "string"
-    }
-  ]
+	"info": {
+		"_postman_id": "564c507b-556d-46c8-b855-6b66027c648d",
+		"name": "API tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "36278855"
+	},
+	"item": [
+		{
+			"name": "Users",
+			"item": [
+				{
+					"name": "Get all users",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"pm.test(\"Check if response contains admin@mail.com\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"admin@mail.com\");\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{CONSUMER_SERVER_API_USERS}}",
+							"host": [
+								"{{CONSUMER_SERVER_API_USERS}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get user by email",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"pm.test(\"Check if response contains admin@mail.com\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"admin@mail.com\");\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{CONSUMER_SERVER_API_USERS}}/admin@mail.com",
+							"host": [
+								"{{CONSUMER_SERVER_API_USERS}}"
+							],
+							"path": [
+								"admin@mail.com"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"pm.test(\"Response body contains New user created\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"New user created\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"user_gha@mail.com\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"GHA Test user\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"DSP-TRUEConnector\");\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"firstName\" : \"GHA Test user\",\r\n  \"lastName\" : \"DSP-TRUEConnector\",\r\n  \"email\" : \"user_gha@mail.com\",\r\n  \"password\" : \"GhaPassword123!\",\r\n  \"role\" : \"ROLE_ADMIN\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{CONSUMER_SERVER_API_USERS}}",
+							"host": [
+								"{{CONSUMER_SERVER_API_USERS}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "basic",
+				"basic": [
+					{
+						"key": "password",
+						"value": "password",
+						"type": "string"
+					},
+					{
+						"key": "username",
+						"value": "superadmin@mail.com",
+						"type": "string"
+					}
+				]
+			}
+		},
+		{
+			"name": "Get all catalogs",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is catalog\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Retrieve catalog id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"catalogId\", jsonData[\"data\"][\"@id\"])\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains data services\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid datasets\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const datasets = catalog.dataset;\r",
+							"    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
+							"        dataset !== null &&\r",
+							"        dataset.hasPolicy !== null &&\r",
+							"        dataset.hasPolicy.length > 0 &&\r",
+							"        dataset.distribution !== null &&\r",
+							"        dataset.distribution.length > 0\r",
+							"    ));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid distributions\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const distributions = catalog.distribution;\r",
+							"    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
+							"        distribution !== null &&\r",
+							"        distribution.accessService !== null));\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_CATALOG}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_CATALOG}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get catalog by id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is catalog\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains data services\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid datasets\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const datasets = catalog.dataset;\r",
+							"    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
+							"        dataset !== null &&\r",
+							"        dataset.hasPolicy !== null &&\r",
+							"        dataset.hasPolicy.length > 0 &&\r",
+							"        dataset.distribution !== null &&\r",
+							"        dataset.distribution.length > 0\r",
+							"    ));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid distributions\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const distributions = catalog.distribution;\r",
+							"    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
+							"        distribution !== null &&\r",
+							"        distribution.accessService !== null));\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_CATALOG}}/{{catalogId}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_CATALOG}}"
+					],
+					"path": [
+						"{{catalogId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all dataservices",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Retrieve dataservice id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"dataserviceId\", jsonData[\"data\"][0][\"@id\"])\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DATASERVICE}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DATASERVICE}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get dataservice by id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is dataservice\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"DSP TRUEConnector service offering team information\", \"endpointDescription\", \"endpointURL\", \"SFTP\", \"REST\", \"transfer\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DATASERVICE}}/{{dataserviceId}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DATASERVICE}}"
+					],
+					"path": [
+						"{{dataserviceId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all datasets",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Retrieve dataset id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"datasetId\", jsonData[\"data\"][0][\"@id\"])\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DATASET}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DATASET}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get dataset by id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is dataset\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"Dataset offering TRUEConnector team information\", \"distribution\", \"accessService\", \"SFTP\", \"REST\", \"transfer\", \"servesDataset\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DATASET}}/{{datasetId}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DATASET}}"
+					],
+					"path": [
+						"{{datasetId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all distributions",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Retrieve distribution id\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.collectionVariables.set(\"distributionId\", jsonData[\"data\"][0][\"@id\"])\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DISTRIBUTION}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DISTRIBUTION}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get distribution by id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is dataset\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"DSP TRUEConnector service offering team information\", \"endpointDescription\", \"endpointURL\", \"accessService\", \"SFTP\", \"REST\", \"transfer\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_DISTRIBUTION}}/{{distributionId}}",
+					"host": [
+						"{{CONSUMER_SERVER_API_DISTRIBUTION}}"
+					],
+					"path": [
+						"{{distributionId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get proxy catalog",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is catalog\", function () {\r",
+							"\r",
+							"    result = false;\r",
+							"    var arr = [\"Engineering Informatica S.p.A.\", \"TRUEConnector\", \"REST\", \"SFTP\", \"dataset\", \"distribution\", \"accessService\"];\r",
+							"    responseText = pm.response.text();\r",
+							"\r",
+							"    arr.forEach((x) => {\r",
+							"      if (responseText.includes(x)){\r",
+							"      result = true;\r",
+							"    }\r",
+							"\r",
+							"    pm.expect(result).to.be.true;\r",
+							"    });\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains data services\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    pm.expect(catalog.service).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(catalog.service).to.satisfy(services => services.every(service => service !== null));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid datasets\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const datasets = catalog.dataset;\r",
+							"    pm.expect(datasets).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(datasets).to.satisfy(datasets => datasets.every(dataset => \r",
+							"        dataset !== null &&\r",
+							"        dataset.hasPolicy !== null &&\r",
+							"        dataset.hasPolicy.length > 0 &&\r",
+							"        dataset.distribution !== null &&\r",
+							"        dataset.distribution.length > 0\r",
+							"    ));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Catalog contains valid distributions\", function () {\r",
+							"    const catalog = pm.response.json()[\"data\"];\r",
+							"    const distributions = catalog.distribution;\r",
+							"    pm.expect(distributions).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(distributions).to.satisfy(distributions => distributions.every(distribution => \r",
+							"        distribution !== null &&\r",
+							"        distribution.accessService !== null));\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"Forward-To\" : \"{{PROVIDER_PROTOCOL}}\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_PROXY}}/catalogs",
+					"host": [
+						"{{CONSUMER_SERVER_API_PROXY}}"
+					],
+					"path": [
+						"catalogs"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Dataset formats",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Check if status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Check if at least one format exists in the array\", function () {\r",
+							"    const jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.data).to.be.an('array').that.is.not.empty;\r",
+							"    pm.expect(jsonData.data[0]).to.exist;\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"Forward-To\" : \"{{PROVIDER_PROTOCOL}}\"\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_SERVER_API_PROXY}}/datasets/{{datasetId}}/formats",
+					"host": [
+						"{{CONSUMER_SERVER_API_PROXY}}"
+					],
+					"path": [
+						"datasets",
+						"{{datasetId}}",
+						"formats"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "basic",
+		"basic": [
+			{
+				"key": "password",
+				"value": "password",
+				"type": "string"
+			},
+			{
+				"key": "username",
+				"value": "admin@mail.com",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "CONSUMER",
+			"value": "http://localhost:8080",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_CATALOG",
+			"value": "{{CONSUMER}}/api/v1/catalogs",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_DATASERVICE",
+			"value": "{{CONSUMER}}/api/v1/dataservices",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_DATASET",
+			"value": "{{CONSUMER}}/api/v1/datasets",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_DISTRIBUTION",
+			"value": "{{CONSUMER}}/api/v1/distributions",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_PROXY",
+			"value": "{{CONSUMER}}/api/v1/proxy",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_SERVER_API_USERS",
+			"value": "{{CONSUMER}}/api/v1/users",
+			"type": "string"
+		},
+		{
+			"key": "PROVIDER_PROTOCOL",
+			"value": "http://172.17.0.1:8090/connector_b_tenant_id",
+			"type": "string"
+		},
+		{
+			"key": "catalogId",
+			"value": ""
+		},
+		{
+			"key": "dataserviceId",
+			"value": ""
+		},
+		{
+			"key": "datasetId",
+			"value": ""
+		},
+		{
+			"key": "distributionId",
+			"value": ""
+		},
+		{
+			"key": "tenantId",
+			"value": "",
+			"type": "string"
+		}
+	]
 }

--- a/ci/docker/test-cases/api-tests/api-endpoints-tests.json
+++ b/ci/docker/test-cases/api-tests/api-endpoints-tests.json
@@ -119,7 +119,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"firstName\" : \"GHA Test user\",\r\n  \"lastName\" : \"DSP-TRUEConnector\",\r\n  \"email\" : \"user_gha@mail.com\",\r\n  \"password\" : \"GhaPassword123!\",\r\n  \"role\" : \"ROLE_ADMIN\"\r\n}",
+							"raw": "{\r\n  \"firstName\" : \"GHA Test user\",\r\n  \"lastName\" : \"DSP-TRUEConnector\",\r\n  \"email\" : \"user_gha@mail.com\",\r\n  \"password\" : \"GhaPassword123!\",\r\n  \"role\" : \"ADMIN\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/ci/tck/connector_tck_resources/initial_data-tck.json
+++ b/ci/tck/connector_tck_resources/initial_data-tck.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN"
+      "role": "ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR"
+      "role": "CONNECTOR"
     }
   ],
   "catalogs": [

--- a/connector/documentation/users.md
+++ b/connector/documentation/users.md
@@ -40,7 +40,7 @@ Connector has implemented simple user management, including following:
  - update user
  - update password
  
-All endpoints requires Content-Type: application/json, and Authorization header with username:password for existing user with role ADMIN.
+All endpoints require `Content-Type: application/json` and an `Authorization` header for a user with `ROLE_SUPER_ADMIN`. `ROLE_ADMIN` users cannot access these endpoints and will receive HTTP 403.
  
 ### Create user 
 

--- a/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
+++ b/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
@@ -34,6 +34,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
@@ -74,10 +75,6 @@ import org.springframework.http.HttpHeaders;
 @EnableMethodSecurity
 public class ConnectorSecurityConfig {
 
-    private static final String ADMIN_ROLE = Role.ROLE_ADMIN.name().substring("ROLE_".length());
-    private static final String CONNECTOR_ROLE = Role.ROLE_CONNECTOR.name().substring("ROLE_".length());
-    private static final String SUPER_ADMIN_ROLE = Role.ROLE_SUPER_ADMIN.name().substring("ROLE_".length());
-
     @Value("${application.cors.allowed.origins:}")
     private String allowedOrigins;
 
@@ -115,9 +112,13 @@ public class ConnectorSecurityConfig {
 
     /**
      * Admin security filter chain covering {@code /api/**}, {@code /actuator/**} and {@code /env}.
-     * Requires {@code ROLE_SUPER_ADMIN} for {@code /api/v1/tenants/**}, {@code /api/v1/users/**},
-     * and {@code /api/v1/properties/**}; all other {@code /api/**} endpoints require
-     * {@code ROLE_ADMIN} or {@code ROLE_SUPER_ADMIN}. Disabled mode permits all requests.
+     * Requires {@code ROLE_SUPER_ADMIN} for {@code /api/v1/tenants/**},
+     * {@code /api/v1/properties/**}, and most {@code /api/v1/users/**} endpoints.
+     * {@code GET /api/v1/users/me}, {@code PUT /api/v1/users/*\/update}, and
+     * {@code PUT /api/v1/users/*\/password} are accessible to {@code ROLE_ADMIN} and
+     * {@code ROLE_SUPER_ADMIN} (self-service only — the service layer enforces ownership).
+     * All other {@code /api/**} endpoints require at minimum {@code ROLE_ADMIN}.
+     * Disabled mode permits all requests.
      *
      * <p>In BASIC mode, both {@link InternalServiceAuthenticationProvider} and
      * {@link DaoAuthenticationProvider} are registered so that internal machine-to-machine
@@ -148,10 +149,16 @@ public class ConnectorSecurityConfig {
                     .addFilterBefore(keycloakFilter.getObject(), UsernamePasswordAuthenticationFilter.class)
                     .addFilterAfter(apiTenantContextFilter.getObject(), UsernamePasswordAuthenticationFilter.class)
                     .authorizeHttpRequests(auth -> auth
-                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
+                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.GET,  ApiEndpoints.USERS_V1 + "/me")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/update")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/password")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .anyRequest().hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else {
             // BASIC: ApiTenantContextFilter must run AFTER BasicAuthenticationFilter so that
@@ -165,10 +172,16 @@ public class ConnectorSecurityConfig {
                             daoAuthenticationProvider.getObject()))
                     .addFilterAfter(apiTenantContextFilter.getObject(), BasicAuthenticationFilter.class)
                     .authorizeHttpRequests(auth -> auth
-                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
-                            .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
+                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.GET,  ApiEndpoints.USERS_V1 + "/me")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/update")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/password")
+                                .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+                            .anyRequest().hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         }
         return http.build();
@@ -208,18 +221,18 @@ public class ConnectorSecurityConfig {
                 http.addFilterBefore(dcp, UsernamePasswordAuthenticationFilter.class);
             }
             http.anonymous(AbstractHttpConfigurer::disable)
-                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(CONNECTOR_ROLE))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else if (authMode == AuthenticationMode.KEYCLOAK) {
             http.anonymous(AbstractHttpConfigurer::disable)
                     .addFilterBefore(keycloakFilter.getObject(), UsernamePasswordAuthenticationFilter.class)
-                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(CONNECTOR_ROLE))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else {
             // BASIC
             http.anonymous(AbstractHttpConfigurer::disable)
                     .httpBasic(basic -> basic.authenticationEntryPoint(authEntryPoint))
-                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(CONNECTOR_ROLE))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         }
         return http.build();

--- a/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
+++ b/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
@@ -38,6 +38,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import it.eng.connector.filter.ApiTenantContextFilter;
+import it.eng.connector.model.Role;
 import it.eng.connector.repository.UserRepository;
 import it.eng.tools.auth.AuthenticationMode;
 import it.eng.tools.auth.AuthenticationModeResolver;
@@ -73,8 +74,9 @@ import org.springframework.http.HttpHeaders;
 @EnableMethodSecurity
 public class ConnectorSecurityConfig {
 
-    private static final String ADMIN_ROLE = "ADMIN";
-    private static final String CONNECTOR_ROLE = "CONNECTOR";
+    private static final String ADMIN_ROLE = Role.ROLE_ADMIN.name().substring("ROLE_".length());
+    private static final String CONNECTOR_ROLE = Role.ROLE_CONNECTOR.name().substring("ROLE_".length());
+    private static final String SUPER_ADMIN_ROLE = Role.ROLE_SUPER_ADMIN.name().substring("ROLE_".length());
 
     @Value("${application.cors.allowed.origins:}")
     private String allowedOrigins;
@@ -113,7 +115,9 @@ public class ConnectorSecurityConfig {
 
     /**
      * Admin security filter chain covering {@code /api/**}, {@code /actuator/**} and {@code /env}.
-     * Requires {@code ROLE_ADMIN}. Disabled mode permits all requests.
+     * Requires {@code ROLE_SUPER_ADMIN} for {@code /api/v1/tenants/**}, {@code /api/v1/users/**},
+     * and {@code /api/v1/properties/**}; all other {@code /api/**} endpoints require
+     * {@code ROLE_ADMIN} or {@code ROLE_SUPER_ADMIN}. Disabled mode permits all requests.
      *
      * <p>In BASIC mode, both {@link InternalServiceAuthenticationProvider} and
      * {@link DaoAuthenticationProvider} are registered so that internal machine-to-machine
@@ -144,8 +148,10 @@ public class ConnectorSecurityConfig {
                     .addFilterBefore(keycloakFilter.getObject(), UsernamePasswordAuthenticationFilter.class)
                     .addFilterAfter(apiTenantContextFilter.getObject(), UsernamePasswordAuthenticationFilter.class)
                     .authorizeHttpRequests(auth -> auth
-                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole("SUPER_ADMIN")
-                            .anyRequest().hasAnyRole(ADMIN_ROLE, "SUPER_ADMIN"))
+                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else {
             // BASIC: ApiTenantContextFilter must run AFTER BasicAuthenticationFilter so that
@@ -159,8 +165,10 @@ public class ConnectorSecurityConfig {
                             daoAuthenticationProvider.getObject()))
                     .addFilterAfter(apiTenantContextFilter.getObject(), BasicAuthenticationFilter.class)
                     .authorizeHttpRequests(auth -> auth
-                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole("SUPER_ADMIN")
-                            .anyRequest().hasAnyRole(ADMIN_ROLE, "SUPER_ADMIN"))
+                            .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+                            .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         }
         return http.build();

--- a/connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java
+++ b/connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java
@@ -72,7 +72,7 @@ public class InternalServiceAuthenticationProvider implements AuthenticationProv
         }
         User syntheticUser = User.builder()
                 .email(INTERNAL_SERVICE_USERNAME)
-                .role(Role.ROLE_ADMIN)
+                .role(Role.ADMIN)
                 .enabled(true)
                 .build();
         log.debug("InternalServiceAuthenticationProvider: authenticated internal-service");

--- a/connector/src/main/java/it/eng/connector/model/Role.java
+++ b/connector/src/main/java/it/eng/connector/model/Role.java
@@ -1,5 +1,21 @@
 package it.eng.connector.model;
 
+/**
+ * Application roles assigned to connector users.
+ *
+ * <p>Use {@link #authorityName()} when constructing Spring Security authority strings
+ * (e.g. for {@code SimpleGrantedAuthority}) — it prepends the {@code ROLE_} prefix required
+ * by Spring Security's {@code hasRole()} / {@code hasAnyRole()} methods.
+ */
 public enum Role {
-	 ROLE_USER, ROLE_ADMIN, ROLE_CONNECTOR, ROLE_SUPER_ADMIN
+    USER, ADMIN, CONNECTOR, SUPER_ADMIN;
+
+    /**
+     * Returns the Spring Security authority string for this role (e.g. {@code "ROLE_ADMIN"}).
+     *
+     * @return the role name prefixed with {@code ROLE_}
+     */
+    public String authorityName() {
+        return "ROLE_" + name();
+    }
 }

--- a/connector/src/main/java/it/eng/connector/model/User.java
+++ b/connector/src/main/java/it/eng/connector/model/User.java
@@ -58,7 +58,7 @@ public class User implements UserDetails {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return List.of(new SimpleGrantedAuthority(role.name()));
+		return List.of(new SimpleGrantedAuthority(role.authorityName()));
 	}
 
 	@Override

--- a/connector/src/main/java/it/eng/connector/model/UserDTO.java
+++ b/connector/src/main/java/it/eng/connector/model/UserDTO.java
@@ -21,6 +21,6 @@ public class UserDTO {
 	private String password;
 	private String newPassword;
 	private Role role;
-	/** The tenant this user belongs to.  Optional only for ROLE_SUPER_ADMIN. */
+	/** The tenant this user belongs to.  Optional only for the {@code SUPER_ADMIN} role. */
 	private String tenantId;
 }

--- a/connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java
+++ b/connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java
@@ -78,10 +78,13 @@ public class TenantAPIController {
     }
 
     /**
-     * Updates the mutable settings of the tenant with the given ID.
+     * Updates the mutable settings of an existing tenant.
+     *
+     * <p>{@code participantId} is read-only after creation; any value supplied in the request
+     * body is silently ignored and the stored value is preserved.
      *
      * @param id      the tenant identifier
-     * @param updates the updated tenant settings
+     * @param updates the tenant body with the fields to update
      * @return 200 OK with the updated tenant
      */
     @PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
+++ b/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
@@ -19,6 +19,7 @@ import it.eng.connector.model.UserDTO;
 import it.eng.connector.service.UserService;
 import it.eng.tools.auth.condition.BasicOrDisabledAuthenticationModeCondition;
 import it.eng.tools.controller.ApiEndpoints;
+import it.eng.tools.exception.BadRequestException;
 import it.eng.tools.response.GenericApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -39,6 +40,26 @@ public class UserApiController {
 
 	public UserApiController(UserService userService) {
 		this.userService = userService;
+	}
+	
+	/**
+	 * Returns the currently authenticated user's own profile.
+	 *
+	 * <p>Returns {@code 400 Bad Request} when there is no authenticated principal (disabled-auth
+	 * mode), since there is no user identity to resolve.
+	 *
+	 * @param principal the authenticated principal injected by Spring Security
+	 * @return the current user as a {@link GenericApiResponse}
+	 */
+	@GetMapping(path = "/me")
+	public ResponseEntity<GenericApiResponse<JsonNode>> getCurrentUser(Principal principal) {
+		if (principal == null) {
+			throw new BadRequestException("No authenticated user in current context");
+		}
+		log.info("Fetching current user profile for principal '{}'", principal.getName());
+		JsonNode user = userService.findCurrentUser(principal.getName());
+		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+				.body(GenericApiResponse.success(user, "Current user"));
 	}
 	
 	/**

--- a/connector/src/main/java/it/eng/connector/service/KeycloakUserService.java
+++ b/connector/src/main/java/it/eng/connector/service/KeycloakUserService.java
@@ -174,7 +174,7 @@ public class KeycloakUserService {
             userRep.set("credentials", objectMapper.createArrayNode().add(credential));
         }
 
-        String roleName = userDTO.getRole() != null ? userDTO.getRole().name() : Role.ROLE_ADMIN.name();
+        String roleName = userDTO.getRole() != null ? userDTO.getRole().name() : Role.ADMIN.name();
         userRep.set("realmRoles", objectMapper.createArrayNode().add(roleName));
 
         return userRep;
@@ -185,7 +185,7 @@ public class KeycloakUserService {
         node.put("email", userDTO.getEmail());
         node.put("firstName", userDTO.getFirstName() != null ? userDTO.getFirstName() : "");
         node.put("lastName", userDTO.getLastName() != null ? userDTO.getLastName() : "");
-        node.put("role", userDTO.getRole() != null ? userDTO.getRole().name() : Role.ROLE_ADMIN.name());
+        node.put("role", userDTO.getRole() != null ? userDTO.getRole().name() : Role.ADMIN.name());
         if (userDTO.getTenantId() != null) {
             node.put("tenantId", userDTO.getTenantId());
         }

--- a/connector/src/main/java/it/eng/connector/service/UserService.java
+++ b/connector/src/main/java/it/eng/connector/service/UserService.java
@@ -76,6 +76,19 @@ public class UserService {
 	}
 
 	/**
+	 * Returns the authenticated user's own record by e-mail.
+	 *
+	 * @param email the e-mail of the authenticated principal
+	 * @return the user as a serialized JSON node
+	 * @throws BadRequestException if no user with the given e-mail exists
+	 */
+	public JsonNode findCurrentUser(String email) {
+		User user = userRepository.findByEmail(email)
+				.orElseThrow(() -> new BadRequestException("User not found"));
+		return ToolsSerializer.serializePlainJsonNode(user);
+	}
+
+	/**
 	 * Creates a new user.
 	 *
 	 * <p>For non-SUPER_ADMIN users the {@code tenantId} in {@code userDTO} must reference an

--- a/connector/src/main/java/it/eng/connector/service/UserService.java
+++ b/connector/src/main/java/it/eng/connector/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
 	 * existing, enabled tenant.  SUPER_ADMIN users are exempt from this check.
 	 *
 	 * @param userDTO the user data; {@code tenantId} is required unless the role is
-	 *                {@code ROLE_SUPER_ADMIN}
+	 *                {@code SUPER_ADMIN}
 	 * @return the created user as a serialized JSON node
 	 * @throws BadRequestException                            if the e-mail already exists or the password is invalid
 	 * @throws it.eng.tools.exception.TenantNotFoundException if the referenced tenant does not exist
@@ -96,7 +96,7 @@ public class UserService {
 		if (validationResult.isValid()) {
 			// SUPER_ADMIN users are not bound to a specific tenant.
 			if (StringUtils.isNotBlank(userDTO.getTenantId())
-					&& userDTO.getRole() != Role.ROLE_SUPER_ADMIN) {
+					&& userDTO.getRole() != Role.SUPER_ADMIN) {
 				tenantService.findEnabledTenantById(userDTO.getTenantId());
 			}
 			User user = new User(createNewPid(), userDTO.getFirstName(), userDTO.getLastName(),

--- a/connector/src/main/resources/initial_data-consumer.json
+++ b/connector/src/main/resources/initial_data-consumer.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "engineering"
     },
     {
@@ -23,7 +23,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "engineering"
     },
     {
@@ -36,7 +36,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     }
   ],
   "catalogs": [

--- a/connector/src/main/resources/initial_data-provider.json
+++ b/connector/src/main/resources/initial_data-provider.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "engineering-provider"
     },
     {
@@ -23,7 +23,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "engineering-provider"
     },
     {
@@ -36,7 +36,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     }
   ],
   "catalogs": [

--- a/connector/src/main/resources/initial_data-tck.json
+++ b/connector/src/main/resources/initial_data-tck.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN"
+      "role": "ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR"
+      "role": "CONNECTOR"
     }
   ],
   "catalogs": [

--- a/connector/src/main/resources/initial_data.json
+++ b/connector/src/main/resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "engineering"
     },
     {
@@ -35,7 +35,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "engineering"
     }
   ],

--- a/connector/src/test/java/it/eng/connector/configuration/KeycloakAuthenticationFilterTest.java
+++ b/connector/src/test/java/it/eng/connector/configuration/KeycloakAuthenticationFilterTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import it.eng.connector.model.Role;
+
 import java.util.List;
 import java.util.Set;
 
@@ -60,7 +62,7 @@ class KeycloakAuthenticationFilterTest {
                 .build();
         when(jwtDecoder.decode("token")).thenReturn(jwt);
 
-        Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority(Role.ADMIN.authorityName()));
         KeycloakAuthenticationFilter filter = new KeycloakAuthenticationFilter(jwtDecoder, ignored -> authorities);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer token");
@@ -71,7 +73,7 @@ class KeycloakAuthenticationFilterTest {
 
         assertTrue(SecurityContextHolder.getContext().getAuthentication().getAuthorities()
                 .stream()
-                .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
+                .anyMatch(auth -> auth.getAuthority().equals(Role.ADMIN.authorityName())));
         verify(jwtDecoder).decode("token");
     }
 }

--- a/connector/src/test/java/it/eng/connector/configuration/KeycloakRealmRoleConverterTest.java
+++ b/connector/src/test/java/it/eng/connector/configuration/KeycloakRealmRoleConverterTest.java
@@ -2,6 +2,8 @@ package it.eng.connector.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import it.eng.connector.model.Role;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +24,7 @@ class KeycloakRealmRoleConverterTest {
         KeycloakRealmRoleConverter converter = new KeycloakRealmRoleConverter();
         Collection<GrantedAuthority> authorities = converter.convert(jwt);
 
-        assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
-        assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_CONNECTOR")));
+        assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals(Role.ADMIN.authorityName())));
+        assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals(Role.CONNECTOR.authorityName())));
     }
 }

--- a/connector/src/test/java/it/eng/connector/filter/ApiTenantContextFilterTest.java
+++ b/connector/src/test/java/it/eng/connector/filter/ApiTenantContextFilterTest.java
@@ -49,7 +49,7 @@ class ApiTenantContextFilterTest {
         User user = User.builder()
                 .id("user-1")
                 .email("admin@mail.com")
-                .role(Role.ROLE_ADMIN)
+                .role(Role.ADMIN)
                 .tenantId("engineering")
                 .enabled(true)
                 .build();
@@ -71,7 +71,7 @@ class ApiTenantContextFilterTest {
         User superAdmin = User.builder()
                 .id("super-1")
                 .email("superadmin@mail.com")
-                .role(Role.ROLE_ADMIN)
+                .role(Role.ADMIN)
                 .tenantId(null)
                 .enabled(true)
                 .build();
@@ -97,7 +97,7 @@ class ApiTenantContextFilterTest {
         User user = User.builder()
                 .id("user-2")
                 .email("user@mail.com")
-                .role(Role.ROLE_ADMIN)
+                .role(Role.ADMIN)
                 .tenantId("engineering")
                 .enabled(true)
                 .build();
@@ -123,7 +123,7 @@ class ApiTenantContextFilterTest {
         User superAdmin = User.builder()
                 .id("super-2")
                 .email("superadmin@mail.com")
-                .role(Role.ROLE_ADMIN)
+                .role(Role.ADMIN)
                 .tenantId(null)
                 .enabled(true)
                 .build();

--- a/connector/src/test/java/it/eng/connector/integration/BaseKeycloakIntegrationTest.java
+++ b/connector/src/test/java/it/eng/connector/integration/BaseKeycloakIntegrationTest.java
@@ -34,6 +34,8 @@ public abstract class BaseKeycloakIntegrationTest extends BaseIntegrationTest {
     private static final String KEYCLOAK_ADMIN_PASSWORD = "admin123";
     private static final String KEYCLOAK_CONNECTOR_USERNAME = "connector@test.com";
     private static final String KEYCLOAK_CONNECTOR_PASSWORD = "connector123";
+    private static final String KEYCLOAK_SUPER_ADMIN_USERNAME = "superadmin@test.com";
+    private static final String KEYCLOAK_SUPER_ADMIN_PASSWORD = "password";
     private static final Duration KEYCLOAK_STARTUP_TIMEOUT = Duration.ofMinutes(3);
     private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
@@ -87,6 +89,16 @@ public abstract class BaseKeycloakIntegrationTest extends BaseIntegrationTest {
      */
     protected String connectorAccessToken() throws Exception {
         return accessToken(KEYCLOAK_CONNECTOR_USERNAME, KEYCLOAK_CONNECTOR_PASSWORD);
+    }
+
+    /**
+     * Returns a bearer token for the Keycloak super-admin test user.
+     *
+     * @return a valid bearer token with the super_admin realm role
+     * @throws Exception when the token cannot be obtained
+     */
+    protected String superAdminAccessToken() throws Exception {
+        return accessToken(KEYCLOAK_SUPER_ADMIN_USERNAME, KEYCLOAK_SUPER_ADMIN_PASSWORD);
     }
 
     /**

--- a/connector/src/test/java/it/eng/connector/integration/DisabledSecurityIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/DisabledSecurityIT.java
@@ -103,6 +103,15 @@ class DisabledSecurityIT extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /api/v1/tenants without authentication returns 200 in disabled mode")
+    void getTenantsWithoutAuthenticationReturnsOk() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.TENANTS_V1)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
     @DisplayName("GET /actuator/env without authentication returns 200 in disabled mode")
     void getActuatorEnvWithoutAuthenticationReturnsOk() throws Exception {
         mockMvc.perform(get("/actuator/env"))

--- a/connector/src/test/java/it/eng/connector/integration/KeycloakSecurityIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/KeycloakSecurityIT.java
@@ -105,24 +105,42 @@ class KeycloakSecurityIT extends BaseKeycloakIntegrationTest {
     }
 
     @Test
-    @DisplayName("GET /api/v1/properties with admin token returns 200 in Keycloak mode")
-    void getPropertiesWithAdminTokenReturnsOk() throws Exception {
+    @DisplayName("GET /api/v1/properties with admin token returns 403 in Keycloak mode (SUPER_ADMIN required)")
+    void getPropertiesWithAdminTokenReturnsForbidden() throws Exception {
         mockMvc.perform(get(ApiEndpoints.PROPERTIES_V1 + "/")
                         .header(HttpHeaders.AUTHORIZATION, bearerToken(adminAccessToken()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/properties with super-admin token returns 200 in Keycloak mode")
+    void getPropertiesWithSuperAdminTokenReturnsOk() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.PROPERTIES_V1 + "/")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(superAdminAccessToken()))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 
     @Test
-    @DisplayName("GET /api/v1/users with admin token reaches the Keycloak-mode endpoint (not blocked by Spring Security)")
-    void getUsersWithAdminTokenReturnsOk() throws Exception {
+    @DisplayName("GET /api/v1/users with admin token returns 403 in Keycloak mode (SUPER_ADMIN required)")
+    void getUsersWithAdminTokenReturnsForbidden() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.USERS_V1)
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(adminAccessToken()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/users with super-admin token reaches the Keycloak-mode endpoint (not blocked by Spring Security)")
+    void getUsersWithSuperAdminTokenReachesEndpoint() throws Exception {
         // In Keycloak mode, GET /api/v1/users is handled by KeycloakUserApiController.
-        // A valid admin bearer token must reach the endpoint (not be rejected with 401 or 403 by Spring Security).
+        // A valid super-admin bearer token must reach the endpoint (not be rejected by Spring Security).
         // The downstream Keycloak Admin API call may fail depending on service-account permissions,
         // which would return a 4xx, but that is an application-level concern, not a security-config concern.
         mockMvc.perform(get(ApiEndpoints.USERS_V1)
-                        .header(HttpHeaders.AUTHORIZATION, bearerToken(adminAccessToken()))
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken(superAdminAccessToken()))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(result -> {
                     int status = result.getResponse().getStatus();

--- a/connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java
@@ -78,7 +78,7 @@ class KeycloakUserRegistrationIT extends BaseKeycloakIntegrationTest {
         UserDTO userDTO = new UserDTO("First", "Last", "keycloak.user@test.com",
                 "TestPass123!", null, Role.ROLE_ADMIN, null);
 
-        String token = adminAccessToken();
+        String token = superAdminAccessToken();
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java
@@ -76,7 +76,7 @@ class KeycloakUserRegistrationIT extends BaseKeycloakIntegrationTest {
                 .willReturn(aResponse().withStatus(201)));
 
         UserDTO userDTO = new UserDTO("First", "Last", "keycloak.user@test.com",
-                "TestPass123!", null, Role.ROLE_ADMIN, null);
+                "TestPass123!", null, Role.ADMIN, null);
 
         String token = superAdminAccessToken();
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
@@ -99,7 +99,7 @@ class KeycloakUserRegistrationIT extends BaseKeycloakIntegrationTest {
                         .withBody("{\"errorMessage\":\"User exists with same username or email\"}")));
 
         UserDTO userDTO = new UserDTO("First", "Last", "existing.user@test.com",
-                "TestPass123!", null, Role.ROLE_ADMIN, null);
+                "TestPass123!", null, Role.ADMIN, null);
 
         String token = adminAccessToken();
         mockMvc.perform(post(ApiEndpoints.USERS_V1)

--- a/connector/src/test/java/it/eng/connector/integration/applicationproperties/ApplicationPropertyIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/applicationproperties/ApplicationPropertyIT.java
@@ -10,6 +10,7 @@ import it.eng.tools.repository.ApplicationPropertiesRepository;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.serializer.ToolsSerializer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -23,6 +24,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -43,11 +45,11 @@ public class ApplicationPropertyIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void getPropertiesSuccessfulTest() throws Exception {
         ResultActions result =
                 mockMvc.perform(
                         get(ApiEndpoints.PROPERTIES_V1 + "/")
+                                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .accept(MediaType.APPLICATION_JSON_VALUE));
 
@@ -65,6 +67,7 @@ public class ApplicationPropertyIT extends BaseIntegrationTest {
         result =
                 mockMvc.perform(
                         get(ApiEndpoints.PROPERTIES_V1 + "/?key_prefix=" + ApplicationPropertyKeys.PROTOCOL_AUTHENTICATION)
+                                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .accept(MediaType.APPLICATION_JSON_VALUE));
         result.andExpect(status().isOk())
@@ -79,7 +82,16 @@ public class ApplicationPropertyIT extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /api/v1/properties as ROLE_ADMIN returns 403")
     @WithUserDetails(TestUtil.ADMIN_USER)
+    public void getProperties_asAdmin_returns403() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.PROPERTIES_V1 + "/")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void putPropertySuccessfulTest() throws Exception {
         ApplicationProperty property = ApplicationProperty.Builder.newInstance()
                 .key(TEST_KEY)
@@ -99,6 +111,7 @@ public class ApplicationPropertyIT extends BaseIntegrationTest {
         final ResultActions result =
                 mockMvc.perform(
                         put("/api/v1/properties/")
+                                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(body)
                                 .accept(MediaType.APPLICATION_JSON_VALUE));
@@ -112,6 +125,22 @@ public class ApplicationPropertyIT extends BaseIntegrationTest {
         GenericApiResponse<List<ApplicationProperty>> apiResp = ToolsSerializer.deserializePlain(json, typeRef);
 
         assertNotNull(apiResp.getData());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/properties as ROLE_ADMIN returns 403")
+    @WithUserDetails(TestUtil.ADMIN_USER)
+    public void putProperty_asAdmin_returns403() throws Exception {
+        ApplicationProperty changedProperty = ApplicationProperty.Builder.newInstance()
+                .key(TEST_KEY)
+                .value("blocked")
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.PROPERTIES_V1 + "/")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(ToolsSerializer.serializePlain(Arrays.asList(changedProperty)).toString())
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isForbidden());
     }
 
 }

--- a/connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java
@@ -433,4 +433,29 @@ public class TenantAPIIT extends BaseIntegrationTest {
                         .with(user("admin").roles("ADMIN")))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with different participantId succeeds but preserves original")
+    public void updateTenant_participantIdIsIgnored_returnsOriginalValue() throws Exception {
+        Tenant original = buildNewTenant();
+        tenantRepository.save(original);
+        String originalParticipantId = original.getParticipantId();
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(original.getId())
+                .name("Updated Name")
+                .description("Updated description")
+                .participantId("urn:connector:changed")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + original.getId())
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(updates))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.participantId").value(originalParticipantId));
+    }
 }

--- a/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
@@ -316,8 +316,11 @@ public class UserIT extends BaseIntegrationTest {
     @Test
     @DisplayName("GET /api/v1/users/me as ROLE_SUPER_ADMIN returns 200 with own profile")
     public void getCurrentUser_asSuperAdmin_returns200() throws Exception {
+        // Use the permanent seed admin user (admin@mail.com) with SUPER_ADMIN role to verify
+        // the SUPER_ADMIN authority grants access to /me.  superadmin@mail.com is in the
+        // @AfterEach cleanup list and may be absent when this test runs.
         mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/me")
-                        .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
+                        .with(user(TestUtil.ADMIN_USER).roles("SUPER_ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));

--- a/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
@@ -108,7 +108,7 @@ public class UserIT extends BaseIntegrationTest {
 
     @Test
     public void createUser() throws Exception {
-        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
                 .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -132,7 +132,7 @@ public class UserIT extends BaseIntegrationTest {
 
     @Test
     public void createUser_weak_password() throws Exception {
-        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "pass", null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "pass", null, Role.ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
                 .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -148,10 +148,10 @@ public class UserIT extends BaseIntegrationTest {
     @Test
     public void createUser_already_exists() throws Exception {
         User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "email_test@mail.com", "password",
-                true, false, false, Role.ROLE_ADMIN);
+                true, false, false, Role.ADMIN);
         userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTest", "LastNameTest", "email_test@mail.com", "StrongPassword123!", null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTest", "LastNameTest", "email_test@mail.com", "StrongPassword123!", null, Role.ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
                 .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -167,12 +167,12 @@ public class UserIT extends BaseIntegrationTest {
     public void updateUser() throws Exception {
         // Create the user with SUPER_ADMIN email so the service email-ownership check passes.
         User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", TestUtil.SUPER_ADMIN_USER, "password",
-                true, false, false, Role.ROLE_SUPER_ADMIN);
+                true, false, false, Role.SUPER_ADMIN);
         userRepository.save(userObj);
         // Track ID for @AfterEach cleanup; can't delete by email safely as the seed may share it.
         savedTestSuperAdminDuplicateId = userObj.getId();
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ROLE_SUPER_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.SUPER_ADMIN, null);
 
         final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/update")
                 .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -190,10 +190,10 @@ public class UserIT extends BaseIntegrationTest {
     @Test
     public void updateUser_other_user() throws Exception {
         User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser@mail.com", "password",
-                true, false, false, Role.ROLE_ADMIN);
+                true, false, false, Role.ADMIN);
         userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ADMIN, null);
 
         final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/update")
                 .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -212,10 +212,10 @@ public class UserIT extends BaseIntegrationTest {
     @Test
     public void updatePassword() throws Exception {
         User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser1@mail.com",
-                passwordEncoder.encode("password"), true, false, false, Role.ROLE_SUPER_ADMIN);
+                passwordEncoder.encode("password"), true, false, false, Role.SUPER_ADMIN);
         userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "NewUpdPass123!", Role.ROLE_SUPER_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "NewUpdPass123!", Role.SUPER_ADMIN, null);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBasicAuth("otherUser1@mail.com", "password");
@@ -232,10 +232,10 @@ public class UserIT extends BaseIntegrationTest {
     @Test
     public void updatePassword_weak() throws Exception {
         User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser3@mail.com",
-                passwordEncoder.encode("password"), true, false, false, Role.ROLE_SUPER_ADMIN);
+                passwordEncoder.encode("password"), true, false, false, Role.SUPER_ADMIN);
         userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "weak123!", Role.ROLE_SUPER_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "weak123!", Role.SUPER_ADMIN, null);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBasicAuth("otherUser3@mail.com", "password");
@@ -253,7 +253,7 @@ public class UserIT extends BaseIntegrationTest {
     @DisplayName("POST /api/v1/users with valid tenantId links user to tenant and returns 200")
     public void createUser_withValidTenantId_returns200() throws Exception {
         UserDTO userDTO = new UserDTO("First", "Last", "tenant.user@mail.com", "StrongPassword1!", null,
-                Role.ROLE_ADMIN, KNOWN_TENANT_ID);
+                Role.ADMIN, KNOWN_TENANT_ID);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
                         .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -267,7 +267,7 @@ public class UserIT extends BaseIntegrationTest {
     @DisplayName("POST /api/v1/users with non-existent tenantId returns 4xx")
     public void createUser_withNonExistentTenantId_returns4xx() throws Exception {
         UserDTO userDTO = new UserDTO("First", "Last", "tenant.user@mail.com", "StrongPassword1!", null,
-                Role.ROLE_ADMIN, UNKNOWN_TENANT_ID);
+                Role.ADMIN, UNKNOWN_TENANT_ID);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
                         .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -281,7 +281,7 @@ public class UserIT extends BaseIntegrationTest {
     @DisplayName("POST /api/v1/users for SUPER_ADMIN without tenantId returns 200")
     public void createUser_superAdminWithoutTenantId_returns200() throws Exception {
         UserDTO userDTO = new UserDTO("SuperFirst", "SuperLast", "superadmin.user@mail.com", "StrongPassword1!", null,
-                Role.ROLE_SUPER_ADMIN, null);
+                Role.SUPER_ADMIN, null);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
                         .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
@@ -295,7 +295,7 @@ public class UserIT extends BaseIntegrationTest {
     @DisplayName("POST /api/v1/users as ROLE_ADMIN returns 403")
     @WithUserDetails(TestUtil.ADMIN_USER)
     public void createUser_asAdmin_returns403() throws Exception {
-        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ADMIN, null);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
                         .content(ToolsSerializer.serializePlain(userDTO))

--- a/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
@@ -9,6 +9,7 @@ import it.eng.connector.util.TestUtil;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.serializer.ToolsSerializer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -18,9 +19,9 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,14 +39,15 @@ public class UserIT extends BaseIntegrationTest {
             "otherUser3@mail.com",
             "otherUser4@mail.com",
             "tenant.user@mail.com",
-            "superadmin.user@mail.com"
+            "superadmin.user@mail.com",
+            TestUtil.SUPER_ADMIN_USER
     );
 
     private static final String KNOWN_TENANT_ID = "engineering";
     private static final String UNKNOWN_TENANT_ID = "non-existent-tenant-xyz";
 
-    // updateUser test creates a duplicate entry under the admin email; track by ID for safe cleanup.
-    private String savedTestAdminDuplicateId;
+    // updateUser test creates a duplicate entry under the super-admin email; track by ID for safe cleanup.
+    private String savedTestSuperAdminDuplicateId;
 
     @Autowired
     private UserRepository userRepository;
@@ -56,28 +58,30 @@ public class UserIT extends BaseIntegrationTest {
     public void cleanup() {
         TEST_USER_EMAILS.forEach(email ->
                 userRepository.findByEmail(email).ifPresent(userRepository::delete));
-        if (savedTestAdminDuplicateId != null) {
-            userRepository.deleteById(savedTestAdminDuplicateId);
-            savedTestAdminDuplicateId = null;
+        if (savedTestSuperAdminDuplicateId != null) {
+            userRepository.deleteById(savedTestSuperAdminDuplicateId);
+            savedTestSuperAdminDuplicateId = null;
         }
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void getUsers() throws Exception {
 
         ResultActions result = mockMvc.perform(get(ApiEndpoints.USERS_V1)
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .contentType(MediaType.APPLICATION_JSON));
         result.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         // TODO when user serialization is fixed, check if user is there
 
         result = mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/" + TestUtil.ADMIN_USER)
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .contentType(MediaType.APPLICATION_JSON));
         result.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
         result = mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/" + "not_found@user.com")
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .contentType(MediaType.APPLICATION_JSON));
         result.andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
@@ -85,11 +89,29 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /api/v1/users as ROLE_ADMIN returns 403")
     @WithUserDetails(TestUtil.ADMIN_USER)
+    public void getUsers_asAdmin_returns403() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.USERS_V1)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/users/{email} as ROLE_ADMIN returns 403")
+    @WithUserDetails(TestUtil.ADMIN_USER)
+    public void getUserByEmail_asAdmin_returns403() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/" + TestUtil.ADMIN_USER)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void createUser() throws Exception {
         UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ROLE_ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -109,11 +131,11 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void createUser_weak_password() throws Exception {
         UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "pass", null, Role.ROLE_ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -124,15 +146,15 @@ public class UserIT extends BaseIntegrationTest {
 
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void createUser_already_exists() throws Exception {
-        User user = new User(createNewId(), "FirstNameTest", "LastNameTest", "email_test@mail.com", "password",
+        User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "email_test@mail.com", "password",
                 true, false, false, Role.ROLE_ADMIN);
-        userRepository.save(user);
+        userRepository.save(userObj);
 
         UserDTO userDTO = new UserDTO("FirstNameTest", "LastNameTest", "email_test@mail.com", "StrongPassword123!", null, Role.ROLE_ADMIN, null);
 
         final ResultActions result = mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -142,38 +164,39 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void updateUser() throws Exception {
-        User user = new User(createNewId(), "FirstNameTest", "LastNameTest", TestUtil.ADMIN_USER, "password",
-                true, false, false, Role.ROLE_ADMIN);
-        userRepository.save(user);
-        // Track ID for @AfterEach cleanup; can't delete by email as it matches the seed admin user.
-        savedTestAdminDuplicateId = user.getId();
+        // Create the user with SUPER_ADMIN email so the service email-ownership check passes.
+        User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", TestUtil.SUPER_ADMIN_USER, "password",
+                true, false, false, Role.ROLE_SUPER_ADMIN);
+        userRepository.save(userObj);
+        // Track ID for @AfterEach cleanup; can't delete by email safely as the seed may share it.
+        savedTestSuperAdminDuplicateId = userObj.getId();
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ROLE_SUPER_ADMIN, null);
 
-        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + user.getId() + "/update")
+        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/update")
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 
         result.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
-        User userUpdated = userRepository.findById(user.getId()).get();
+        User userUpdated = userRepository.findById(userObj.getId()).get();
         assertEquals(userUpdated.getFirstName(), "FirstNameTestUpdate");
         assertEquals(userUpdated.getLastName(), "LastNameTestUpdate");
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
     public void updateUser_other_user() throws Exception {
-        User user = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser@mail.com", "password",
+        User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser@mail.com", "password",
                 true, false, false, Role.ROLE_ADMIN);
-        userRepository.save(user);
+        userRepository.save(userObj);
 
         UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, null, null, Role.ROLE_ADMIN, null);
 
-        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + user.getId() + "/update")
+        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/update")
+                .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -181,23 +204,23 @@ public class UserIT extends BaseIntegrationTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
         // did not update original values
-        User userUpdated = userRepository.findById(user.getId()).get();
+        User userUpdated = userRepository.findById(userObj.getId()).get();
         assertEquals(userUpdated.getFirstName(), "FirstNameTest");
         assertEquals(userUpdated.getLastName(), "LastNameTest");
     }
 
     @Test
     public void updatePassword() throws Exception {
-        User user = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser1@mail.com",
-                passwordEncoder.encode("password"), true, false, false, Role.ROLE_ADMIN);
-        userRepository.save(user);
+        User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser1@mail.com",
+                passwordEncoder.encode("password"), true, false, false, Role.ROLE_SUPER_ADMIN);
+        userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "NewUpdPass123!", Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "NewUpdPass123!", Role.ROLE_SUPER_ADMIN, null);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBasicAuth("otherUser1@mail.com", "password");
 
-        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + user.getId() + "/password")
+        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/password")
                 .headers(headers)
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
@@ -208,16 +231,16 @@ public class UserIT extends BaseIntegrationTest {
 
     @Test
     public void updatePassword_weak() throws Exception {
-        User user = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser3@mail.com",
-                passwordEncoder.encode("password"), true, false, false, Role.ROLE_ADMIN);
-        userRepository.save(user);
+        User userObj = new User(createNewId(), "FirstNameTest", "LastNameTest", "otherUser3@mail.com",
+                passwordEncoder.encode("password"), true, false, false, Role.ROLE_SUPER_ADMIN);
+        userRepository.save(userObj);
 
-        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "weak123!", Role.ROLE_ADMIN, null);
+        UserDTO userDTO = new UserDTO("FirstNameTestUpdate", "LastNameTestUpdate", null, "password", "weak123!", Role.ROLE_SUPER_ADMIN, null);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBasicAuth("otherUser3@mail.com", "password");
 
-        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + user.getId() + "/password")
+        final ResultActions result = mockMvc.perform(put(ApiEndpoints.USERS_V1 + "/" + userObj.getId() + "/password")
                 .headers(headers)
                 .content(ToolsSerializer.serializePlain(userDTO))
                 .contentType(MediaType.APPLICATION_JSON));
@@ -227,13 +250,13 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
-    @org.junit.jupiter.api.DisplayName("POST /api/v1/users with valid tenantId links user to tenant and returns 200")
+    @DisplayName("POST /api/v1/users with valid tenantId links user to tenant and returns 200")
     public void createUser_withValidTenantId_returns200() throws Exception {
         UserDTO userDTO = new UserDTO("First", "Last", "tenant.user@mail.com", "StrongPassword1!", null,
                 Role.ROLE_ADMIN, KNOWN_TENANT_ID);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                        .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                         .content(ToolsSerializer.serializePlain(userDTO))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -241,13 +264,13 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
-    @org.junit.jupiter.api.DisplayName("POST /api/v1/users with non-existent tenantId returns 4xx")
+    @DisplayName("POST /api/v1/users with non-existent tenantId returns 4xx")
     public void createUser_withNonExistentTenantId_returns4xx() throws Exception {
         UserDTO userDTO = new UserDTO("First", "Last", "tenant.user@mail.com", "StrongPassword1!", null,
                 Role.ROLE_ADMIN, UNKNOWN_TENANT_ID);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                        .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                         .content(ToolsSerializer.serializePlain(userDTO))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().is4xxClientError())
@@ -255,16 +278,28 @@ public class UserIT extends BaseIntegrationTest {
     }
 
     @Test
-    @WithUserDetails(TestUtil.ADMIN_USER)
-    @org.junit.jupiter.api.DisplayName("POST /api/v1/users for SUPER_ADMIN without tenantId returns 200")
+    @DisplayName("POST /api/v1/users for SUPER_ADMIN without tenantId returns 200")
     public void createUser_superAdminWithoutTenantId_returns200() throws Exception {
         UserDTO userDTO = new UserDTO("SuperFirst", "SuperLast", "superadmin.user@mail.com", "StrongPassword1!", null,
                 Role.ROLE_SUPER_ADMIN, null);
 
         mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                        .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
                         .content(ToolsSerializer.serializePlain(userDTO))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/users as ROLE_ADMIN returns 403")
+    @WithUserDetails(TestUtil.ADMIN_USER)
+    public void createUser_asAdmin_returns403() throws Exception {
+        UserDTO userDTO = new UserDTO("firstName", "lastName", "test@mail.com", "StrongPassword1!", null, Role.ROLE_ADMIN, null);
+
+        mockMvc.perform(post(ApiEndpoints.USERS_V1)
+                        .content(ToolsSerializer.serializePlain(userDTO))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
     }
 }

--- a/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/user/UserIT.java
@@ -302,4 +302,24 @@ public class UserIT extends BaseIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @DisplayName("GET /api/v1/users/me as ROLE_ADMIN returns 200 with own profile")
+    @WithUserDetails(TestUtil.ADMIN_USER)
+    public void getCurrentUser_asAdmin_returns200() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/users/me as ROLE_SUPER_ADMIN returns 200 with own profile")
+    public void getCurrentUser_asSuperAdmin_returns200() throws Exception {
+        mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/me")
+                        .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
 }

--- a/connector/src/test/java/it/eng/connector/model/UserDTOTest.java
+++ b/connector/src/test/java/it/eng/connector/model/UserDTOTest.java
@@ -14,7 +14,7 @@ class UserDTOTest {
 		userDTO.setEmail("test@mail.com");
 		userDTO.setFirstName("firstName");
 		userDTO.setLastName("lastName");
-		userDTO.setRole(Role.ROLE_ADMIN);
+		userDTO.setRole(Role.ADMIN);
 		userDTO.setPassword("password");
 		assertNotNull(ToolsSerializer.serializePlain(userDTO));
 	}

--- a/connector/src/test/java/it/eng/connector/service/UserServiceTest.java
+++ b/connector/src/test/java/it/eng/connector/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package it.eng.connector.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -77,6 +78,28 @@ class UserServiceTest {
 		// not found by email
 		when(userRepository.findByEmail("not found")).thenReturn(Optional.empty());
 		assertThrows(ResourceNotFoundException.class, () -> userService.findUsers("not found"));
+	}
+
+	@Test
+	@DisplayName("findCurrentUser returns user for known email")
+	void findCurrentUser_returnsUser() {
+		when(userRepository.findByEmail(TestUtil.USER.getEmail()))
+				.thenReturn(Optional.of(TestUtil.USER));
+
+		JsonNode result = userService.findCurrentUser(TestUtil.USER.getEmail());
+
+		assertNotNull(result);
+		assertEquals(TestUtil.USER.getEmail(), result.get("email").asText());
+		verify(userRepository).findByEmail(TestUtil.USER.getEmail());
+	}
+
+	@Test
+	@DisplayName("findCurrentUser throws BadRequestException for unknown email")
+	void findCurrentUser_notFound_throws() {
+		when(userRepository.findByEmail("unknown@mail.com")).thenReturn(Optional.empty());
+
+		assertThrows(BadRequestException.class,
+				() -> userService.findCurrentUser("unknown@mail.com"));
 	}
 
 	@Test

--- a/connector/src/test/java/it/eng/connector/service/UserServiceTest.java
+++ b/connector/src/test/java/it/eng/connector/service/UserServiceTest.java
@@ -83,7 +83,7 @@ class UserServiceTest {
 	@DisplayName("Create user with valid tenantId - user saved with tenantId set")
 	void createUser_withValidTenantId() {
 		when(userDTO.getEmail()).thenReturn(USER);
-		when(userDTO.getRole()).thenReturn(Role.ROLE_ADMIN);
+		when(userDTO.getRole()).thenReturn(Role.ADMIN);
 		when(userDTO.getTenantId()).thenReturn(TENANT_ID);
 		when(userRepository.findByEmail(userDTO.getEmail())).thenReturn(Optional.empty());
 		when(passwordValidator.isValid(userDTO.getPassword())).thenReturn(passwordValidationResult);
@@ -103,7 +103,7 @@ class UserServiceTest {
 	@DisplayName("Create user with non-existent tenantId - TenantNotFoundException thrown")
 	void createUser_withNonExistentTenantId() {
 		when(userDTO.getEmail()).thenReturn(USER);
-		when(userDTO.getRole()).thenReturn(Role.ROLE_ADMIN);
+		when(userDTO.getRole()).thenReturn(Role.ADMIN);
 		when(userDTO.getTenantId()).thenReturn("non-existent-tenant");
 		when(userRepository.findByEmail(userDTO.getEmail())).thenReturn(Optional.empty());
 		when(passwordValidator.isValid(userDTO.getPassword())).thenReturn(passwordValidationResult);
@@ -120,7 +120,7 @@ class UserServiceTest {
 	@DisplayName("Create ROLE_SUPER_ADMIN user without tenantId - succeeds without tenant lookup")
 	void createUser_superAdmin_noTenantId() {
 		when(userDTO.getEmail()).thenReturn(USER);
-		when(userDTO.getRole()).thenReturn(Role.ROLE_SUPER_ADMIN);
+		when(userDTO.getRole()).thenReturn(Role.SUPER_ADMIN);
 		when(userDTO.getTenantId()).thenReturn(null);
 		when(userRepository.findByEmail(userDTO.getEmail())).thenReturn(Optional.empty());
 		when(passwordValidator.isValid(userDTO.getPassword())).thenReturn(passwordValidationResult);

--- a/connector/src/test/java/it/eng/connector/util/TestUtil.java
+++ b/connector/src/test/java/it/eng/connector/util/TestUtil.java
@@ -14,6 +14,6 @@ public class TestUtil {
 	public static final String CONSUMER_PID = "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833";
 	public static final String USER_ID = "urn:uuid:fdc45798-a123-4955-8baf-ab7fd66ac4d5";
 	
-	public static User USER = new User(USER_ID, "first name", "last name", "test@mail.com", "secret", true, false, false, Role.ROLE_ADMIN);
+	public static User USER = new User(USER_ID, "first name", "last name", "test@mail.com", "secret", true, false, false, Role.ADMIN);
 
 }

--- a/connector/src/test/java/it/eng/connector/util/TestUtil.java
+++ b/connector/src/test/java/it/eng/connector/util/TestUtil.java
@@ -7,6 +7,7 @@ public class TestUtil {
 	//all values in this class are from the initial_data.json
 	public static final String CONNECTOR_USER = "connector@mail.com";
 	public static final String ADMIN_USER = "admin@mail.com";
+	public static final String SUPER_ADMIN_USER = "superadmin@mail.com";
 	public static final String API_USER = "admin@mail.com";
 	public static final String DATASET_ID = "urn:uuid:fdc45798-a222-4955-8baf-ab7fd66ac4d5";
 	public static final String PROVIDER_PID = "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab";

--- a/connector/src/test/resources/initial_data-tck.json
+++ b/connector/src/test/resources/initial_data-tck.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN"
+      "role": "ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR"
+      "role": "CONNECTOR"
     }
   ],
   "catalogs": [

--- a/connector/src/test/resources/initial_data-tck.json
+++ b/connector/src/test/resources/initial_data-tck.json
@@ -2,6 +2,18 @@
   "users": [
     {
       "_class": "it.eng.connector.model.User",
+      "_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "firstName": "Super",
+      "lastName": "Admin",
+      "email": "superadmin@mail.com",
+      "password": "$2a$10$wQgl7stAxkVI1oxaynYU2uj.1IxzQ/ETygs32RoveH.rkgAfXAk5q",
+      "enabled": true,
+      "expired": false,
+      "locked": false,
+      "role": "SUPER_ADMIN"
+    },
+    {
+      "_class": "it.eng.connector.model.User",
       "_id": "59d54e6d-a3f3-4a03-a093-d276e3068eef",
       "firstName": "Admin",
       "lastName": "Role",
@@ -2385,7 +2397,8 @@
       "enabled": true,
       "automaticNegotiation": false,
       "automaticTransfer": false,
-      "version": 0
+      "version": 0,
+      "participantId": "urn:connector:engineering"
     }
   ]
 }

--- a/connector/src/test/resources/initial_data-unittest.json
+++ b/connector/src/test/resources/initial_data-unittest.json
@@ -23,7 +23,8 @@
       "enabled": true,
       "automaticNegotiation": false,
       "automaticTransfer": false,
-      "version": 0
+      "version": 0,
+      "participantId": "urn:connector:engineering"
     }
   ]
 }

--- a/connector/src/test/resources/initial_data.json
+++ b/connector/src/test/resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN"
+      "role": "ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR"
+      "role": "CONNECTOR"
     }
   ],
   "application_properties": [

--- a/connector/src/test/resources/initial_data.json
+++ b/connector/src/test/resources/initial_data.json
@@ -2,6 +2,18 @@
   "users": [
     {
       "_class": "it.eng.connector.model.User",
+      "_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "firstName": "Super",
+      "lastName": "Admin",
+      "email": "superadmin@mail.com",
+      "password": "$2a$10$wQgl7stAxkVI1oxaynYU2uj.1IxzQ/ETygs32RoveH.rkgAfXAk5q",
+      "enabled": true,
+      "expired": false,
+      "locked": false,
+      "role": "SUPER_ADMIN"
+    },
+    {
+      "_class": "it.eng.connector.model.User",
       "_id": "59d54e6d-a3f3-4a03-a093-d276e3068eef",
       "firstName": "Admin",
       "lastName": "Role",
@@ -115,7 +127,8 @@
       "enabled": true,
       "automaticNegotiation": false,
       "automaticTransfer": false,
-      "version": 0
+      "version": 0,
+      "participantId": "urn:connector:engineering"
     }
   ]
 }

--- a/doc/security.md
+++ b/doc/security.md
@@ -61,10 +61,10 @@ application.auth.provider=KEYCLOAK
 
 | `auth.provider` | `dcp.enabled` | `/api/**` `/actuator/**` | Protocol endpoints¹ |
 |-----------------|---------------|--------------------------|----------------------|
-| `KEYCLOAK`      | `false`       | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | Keycloak JWT → `ROLE_CONNECTOR` |
-| `KEYCLOAK`      | `true`        | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | DCP → `ROLE_CONNECTOR` |
-| `BASIC`         | `false`       | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | HTTP Basic → `ROLE_CONNECTOR` |
-| `BASIC`         | `true`        | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | DCP → `ROLE_CONNECTOR` |
+| `KEYCLOAK`      | `false`       | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, most `/users/**`, `/properties/**`; `ROLE_ADMIN` may call `/users/me` and own-account PUT endpoints | Keycloak JWT → `ROLE_CONNECTOR` |
+| `KEYCLOAK`      | `true`        | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, most `/users/**`, `/properties/**`; `ROLE_ADMIN` may call `/users/me` and own-account PUT endpoints | DCP → `ROLE_CONNECTOR` |
+| `BASIC`         | `false`       | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, most `/users/**`, `/properties/**`; `ROLE_ADMIN` may call `/users/me` and own-account PUT endpoints | HTTP Basic → `ROLE_CONNECTOR` |
+| `BASIC`         | `true`        | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, most `/users/**`, `/properties/**`; `ROLE_ADMIN` may call `/users/me` and own-account PUT endpoints | DCP → `ROLE_CONNECTOR` |
 | `DISABLED`      | `false`       | `permitAll()` — all management endpoints open, not for production | `permitAll()` |
 | `DISABLED`      | `true`        | ❌ startup error | ❌ startup error |
 
@@ -180,17 +180,20 @@ application.auth.provider=BASIC
 
 ### Management Endpoint Access Control
 
-The following endpoints are restricted to `ROLE_SUPER_ADMIN` in both `BASIC` and `KEYCLOAK` modes:
+The following endpoints are restricted to `ROLE_SUPER_ADMIN` in both `BASIC` and `KEYCLOAK` modes, with self-service exceptions for `ROLE_ADMIN`:
 
-| Endpoint prefix | Required role |
-|-----------------|---------------|
+| Endpoint | Required role |
+|----------|---------------|
+| `GET /api/v1/users/me` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` — self-service profile retrieval |
+| `PUT /api/v1/users/*/update` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` — own account update (service layer enforces ownership) |
+| `PUT /api/v1/users/*/password` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` — own password change (service layer enforces ownership) |
+| `* /api/v1/users/**` (all other) | `ROLE_SUPER_ADMIN` |
 | `/api/v1/tenants/**` | `ROLE_SUPER_ADMIN` |
-| `/api/v1/users/**` | `ROLE_SUPER_ADMIN` |
 | `/api/v1/properties/**` | `ROLE_SUPER_ADMIN` |
 
 All other `/api/**` endpoints require at minimum `ROLE_ADMIN`.
 
-**Convention**: All role names in `ConnectorSecurityConfig` must be derived from the `it.eng.connector.model.Role` enum using private constants (e.g., `Role.ROLE_SUPER_ADMIN.name().substring("ROLE_".length())`). Hardcoded role strings like `"SUPER_ADMIN"` must not be used directly.
+**Convention**: All role names in `ConnectorSecurityConfig` must be derived from the `it.eng.connector.model.Role` enum directly (e.g., `Role.SUPER_ADMIN.name()`, `Role.ADMIN.authorityName()`). Hardcoded role strings are not used.
 
 **DISABLED mode**: The `DISABLED` authentication mode permits all requests including management endpoints. It is intended only for local development and must **not** be used in production.
 
@@ -201,7 +204,7 @@ Three distinct user roles are used in `initial_data.json` and at runtime:
 | Role | Email | `tenantId` | Purpose |
 |------|-------|-----------|---------|
 | `ROLE_SUPER_ADMIN` | `superadmin@mail.com` | `null` | Manages tenants and cross-tenant operations. No data scope restriction — all tenant data is visible. |
-| `ROLE_ADMIN` | `admin@mail.com` | per-tenant (e.g., `engineering`) | Per-tenant admin. Manages catalog, dataset, negotiation, and transfer data for their assigned tenant only. |
+| `ROLE_ADMIN` | `admin@mail.com` | per-tenant (e.g., `engineering`) | Per-tenant admin. Manages catalog, dataset, negotiation, and transfer data for their assigned tenant only. May also call `GET /api/v1/users/me`, `PUT /api/v1/users/{id}/update`, and `PUT /api/v1/users/{id}/password` for their own account. |
 | `ROLE_CONNECTOR` | `connector@mail.com` | per-tenant (e.g., `engineering`) | Per-tenant connector user. Authenticates DSP protocol calls (connector-to-connector). |
 
 Each tenant should have its own `ROLE_ADMIN` and `ROLE_CONNECTOR` users with `tenantId` set to that tenant's ID. Multiple tenants cannot share the same email address.

--- a/doc/security.md
+++ b/doc/security.md
@@ -61,11 +61,11 @@ application.auth.provider=KEYCLOAK
 
 | `auth.provider` | `dcp.enabled` | `/api/**` `/actuator/**` | Protocol endpoints¹ |
 |-----------------|---------------|--------------------------|----------------------|
-| `KEYCLOAK`      | `false`       | Keycloak JWT → `ROLE_ADMIN` | Keycloak JWT → `ROLE_CONNECTOR` |
-| `KEYCLOAK`      | `true`        | Keycloak JWT → `ROLE_ADMIN` | DCP → `ROLE_CONNECTOR` |
-| `BASIC`         | `false`       | HTTP Basic → `ROLE_ADMIN` | HTTP Basic → `ROLE_CONNECTOR` |
-| `BASIC`         | `true`        | HTTP Basic → `ROLE_ADMIN` | DCP → `ROLE_CONNECTOR` |
-| `DISABLED`      | `false`       | `permitAll()` | `permitAll()` |
+| `KEYCLOAK`      | `false`       | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | Keycloak JWT → `ROLE_CONNECTOR` |
+| `KEYCLOAK`      | `true`        | Keycloak JWT → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | DCP → `ROLE_CONNECTOR` |
+| `BASIC`         | `false`       | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | HTTP Basic → `ROLE_CONNECTOR` |
+| `BASIC`         | `true`        | HTTP Basic → `ROLE_ADMIN` or `ROLE_SUPER_ADMIN`; `ROLE_SUPER_ADMIN` required for `/tenants/**`, `/users/**`, `/properties/**` | DCP → `ROLE_CONNECTOR` |
+| `DISABLED`      | `false`       | `permitAll()` — all management endpoints open, not for production | `permitAll()` |
 | `DISABLED`      | `true`        | ❌ startup error | ❌ startup error |
 
 ¹ Protocol endpoints: `/connector/**`, `/catalog/**`, `/negotiations/**`, `/transfers/**`
@@ -177,6 +177,22 @@ application.auth.provider=BASIC
 - `/api/v1/users` endpoints are **active** — users created here are valid credentials
 - Initial users and data are seeded from `initial_data.json` on startup
 - On authentication failure at protocol endpoints, returns a DSP-compliant error JSON
+
+### Management Endpoint Access Control
+
+The following endpoints are restricted to `ROLE_SUPER_ADMIN` in both `BASIC` and `KEYCLOAK` modes:
+
+| Endpoint prefix | Required role |
+|-----------------|---------------|
+| `/api/v1/tenants/**` | `ROLE_SUPER_ADMIN` |
+| `/api/v1/users/**` | `ROLE_SUPER_ADMIN` |
+| `/api/v1/properties/**` | `ROLE_SUPER_ADMIN` |
+
+All other `/api/**` endpoints require at minimum `ROLE_ADMIN`.
+
+**Convention**: All role names in `ConnectorSecurityConfig` must be derived from the `it.eng.connector.model.Role` enum using private constants (e.g., `Role.ROLE_SUPER_ADMIN.name().substring("ROLE_".length())`). Hardcoded role strings like `"SUPER_ADMIN"` must not be used directly.
+
+**DISABLED mode**: The `DISABLED` authentication mode permits all requests including management endpoints. It is intended only for local development and must **not** be used in production.
 
 ### User Model (Basic Mode)
 

--- a/docs/superpowers/plans/2026-06-30-user-role-tenant-improvements.md
+++ b/docs/superpowers/plans/2026-06-30-user-role-tenant-improvements.md
@@ -1,0 +1,1112 @@
+# User Self-Service, Role Enum Cleanup, and Tenant participantId Immutability
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow ROLE_ADMIN users to manage their own account, rename the Role enum to remove redundant `ROLE_` prefixes, make Tenant.participantId immutable after creation, and update all related documentation.
+
+**Architecture:** The Role enum is renamed (ROLE_ADMIN → ADMIN etc.) and gains an `authorityName()` helper that produces the Spring Security `"ROLE_"` prefix needed by `User.getAuthorities()`. ConnectorSecurityConfig is updated to add per-endpoint matchers that open the three user self-service endpoints to ADMIN in addition to SUPER_ADMIN, while all other user management remains SUPER_ADMIN-only. TenantService.updateTenant() is fixed to always use the existing participantId, ignoring any value in the request body.
+
+**Tech Stack:** Java 17, Spring Boot 3.5.x, Spring Security 6.x, MongoDB / Spring Data MongoDB, JUnit 5, MockMvc, Testcontainers (MongoDB + MinIO), Mockito.
+
+---
+
+## File Map
+
+| Action | File |
+|---|---|
+| Modify | `connector/src/main/java/it/eng/connector/model/Role.java` |
+| Modify | `connector/src/main/java/it/eng/connector/model/User.java` |
+| Modify | `connector/src/main/java/it/eng/connector/model/UserDTO.java` |
+| Modify | `connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java` |
+| Modify | `connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java` |
+| Modify | `connector/src/main/java/it/eng/connector/service/UserService.java` |
+| Modify | `connector/src/main/java/it/eng/connector/service/KeycloakUserService.java` |
+| Modify | `connector/src/main/java/it/eng/connector/rest/api/UserApiController.java` |
+| Modify | `connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java` |
+| Modify | `tools/src/main/java/it/eng/tools/service/TenantService.java` |
+| Modify | `connector/src/test/java/it/eng/connector/util/TestUtil.java` |
+| Modify | `connector/src/test/java/it/eng/connector/filter/ApiTenantContextFilterTest.java` |
+| Modify | `connector/src/test/java/it/eng/connector/configuration/KeycloakAuthenticationFilterTest.java` |
+| Modify | `connector/src/test/java/it/eng/connector/configuration/KeycloakRealmRoleConverterTest.java` |
+| Modify | `connector/src/test/java/it/eng/connector/model/UserDTOTest.java` |
+| Modify | `connector/src/test/java/it/eng/connector/service/UserServiceTest.java` |
+| Modify | `connector/src/test/java/it/eng/connector/integration/user/UserIT.java` |
+| Modify | `connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java` |
+| Modify | `connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java` |
+| Modify | `tools/src/test/java/it/eng/tools/service/TenantServiceTest.java` |
+| Modify | `connector/src/test/resources/initial_data.json` |
+| Modify | `connector/src/test/resources/initial_data-tck.json` |
+| Modify | `connector/src/main/resources/initial_data.json` |
+| Modify | `connector/src/main/resources/initial_data-consumer.json` |
+| Modify | `connector/src/main/resources/initial_data-provider.json` |
+| Modify | `connector/src/main/resources/initial_data-tck.json` |
+| Modify | `ci/docker/connector_a_resources/initial_data.json` |
+| Modify | `ci/docker/connector_b_resources/initial_data.json` |
+| Modify | `ci/tck/connector_tck_resources/initial_data-tck.json` |
+| Modify | `doc/security.md` |
+| Modify | `CHANGELOG.md` |
+
+---
+
+## Task 1: Rename Role enum values and fix User.getAuthorities()
+
+**Files:**
+- Modify: `connector/src/main/java/it/eng/connector/model/Role.java`
+- Modify: `connector/src/main/java/it/eng/connector/model/User.java`
+
+This task renames the enum constants and adds `authorityName()`. It will cause compile errors in callers — fix those in Task 2.
+
+- [ ] **Step 1: Replace Role.java entirely**
+
+```java
+package it.eng.connector.model;
+
+/**
+ * Application roles assigned to connector users.
+ *
+ * <p>Use {@link #authorityName()} when constructing Spring Security authority strings
+ * (e.g. for {@code SimpleGrantedAuthority}) — it prepends the {@code ROLE_} prefix required
+ * by Spring Security's {@code hasRole()} / {@code hasAnyRole()} methods.
+ */
+public enum Role {
+    USER, ADMIN, CONNECTOR, SUPER_ADMIN;
+
+    /**
+     * Returns the Spring Security authority string for this role (e.g. {@code "ROLE_ADMIN"}).
+     *
+     * @return the role name prefixed with {@code ROLE_}
+     */
+    public String authorityName() {
+        return "ROLE_" + name();
+    }
+}
+```
+
+- [ ] **Step 2: Fix User.getAuthorities() to use authorityName()**
+
+In `connector/src/main/java/it/eng/connector/model/User.java`, change line 61:
+
+Old:
+```java
+return List.of(new SimpleGrantedAuthority(role.name()));
+```
+
+New:
+```java
+return List.of(new SimpleGrantedAuthority(role.authorityName()));
+```
+
+- [ ] **Step 3: Attempt compile to see all call sites that need updating**
+
+```bash
+cd /path/to/repo && mvn -pl connector -am compile -q 2>&1 | grep "error:" | grep -v "cannot find symbol" | head -20
+mvn -pl connector -am compile -q 2>&1 | grep "cannot find symbol" -A 2 | head -60
+```
+
+Expected: compile errors listing every file that references `Role.ROLE_*`.
+
+- [ ] **Step 4: Commit Role.java and User.java only (compilation will be restored in Task 2)**
+
+```bash
+git add connector/src/main/java/it/eng/connector/model/Role.java \
+        connector/src/main/java/it/eng/connector/model/User.java
+git commit -m "refactor: rename Role enum values (ROLE_ADMIN→ADMIN etc.), add authorityName()"
+```
+
+---
+
+## Task 2: Fix all production code callers of old Role enum names
+
+**Files:**
+- Modify: `connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java`
+- Modify: `connector/src/main/java/it/eng/connector/service/UserService.java`
+- Modify: `connector/src/main/java/it/eng/connector/service/KeycloakUserService.java`
+- Modify: `connector/src/main/java/it/eng/connector/model/UserDTO.java`
+
+- [ ] **Step 1: Fix InternalServiceAuthenticationProvider — line 75**
+
+Old:
+```java
+.role(Role.ROLE_ADMIN)
+```
+
+New:
+```java
+.role(Role.ADMIN)
+```
+
+- [ ] **Step 2: Fix UserService — line 99**
+
+Old:
+```java
+&& userDTO.getRole() != Role.ROLE_SUPER_ADMIN) {
+```
+
+New:
+```java
+&& userDTO.getRole() != Role.SUPER_ADMIN) {
+```
+
+Also update the Javadoc on `createUser()` — change `{@code ROLE_SUPER_ADMIN}` to `{@code SUPER_ADMIN}`:
+
+Old Javadoc (lines 81–86):
+```java
+/**
+ * Creates a new user.
+ *
+ * <p>For non-SUPER_ADMIN users the {@code tenantId} in {@code userDTO} must reference an
+ * existing, enabled tenant.  SUPER_ADMIN users are exempt from this check.
+ *
+ * @param userDTO the user data; {@code tenantId} is required unless the role is
+ *                {@code ROLE_SUPER_ADMIN}
+```
+
+New Javadoc:
+```java
+/**
+ * Creates a new user.
+ *
+ * <p>For non-SUPER_ADMIN users the {@code tenantId} in {@code userDTO} must reference an
+ * existing, enabled tenant.  SUPER_ADMIN users are exempt from this check.
+ *
+ * @param userDTO the user data; {@code tenantId} is required unless the role is
+ *                {@code SUPER_ADMIN}
+```
+
+- [ ] **Step 3: Fix KeycloakUserService — two occurrences (lines 177 and 188)**
+
+Old (line 177 in `buildUserRepresentation`):
+```java
+String roleName = userDTO.getRole() != null ? userDTO.getRole().name() : Role.ROLE_ADMIN.name();
+```
+
+New:
+```java
+String roleName = userDTO.getRole() != null ? userDTO.getRole().name() : Role.ADMIN.name();
+```
+
+Old (line 188 in `buildCreatedUserResponse`):
+```java
+node.put("role", userDTO.getRole() != null ? userDTO.getRole().name() : Role.ROLE_ADMIN.name());
+```
+
+New:
+```java
+node.put("role", userDTO.getRole() != null ? userDTO.getRole().name() : Role.ADMIN.name());
+```
+
+- [ ] **Step 4: Fix UserDTO Javadoc**
+
+In `connector/src/main/java/it/eng/connector/model/UserDTO.java`, update the field comment:
+
+Old:
+```java
+/** The tenant this user belongs to.  Optional only for ROLE_SUPER_ADMIN. */
+private String tenantId;
+```
+
+New:
+```java
+/** The tenant this user belongs to.  Optional only for {@link Role#SUPER_ADMIN}. */
+private String tenantId;
+```
+
+Also add `import it.eng.connector.model.Role;` if not already present (check first — it may not be imported).
+
+Note: `UserDTO` does not import `Role` currently. Only the Javadoc references it. Use the simple name `{@link Role#SUPER_ADMIN}` which requires the import, OR change to plain text `"SUPER_ADMIN role"`. Use plain text to avoid adding an unnecessary import:
+
+```java
+/** The tenant this user belongs to.  Optional only for the {@code SUPER_ADMIN} role. */
+private String tenantId;
+```
+
+Also update the class Javadoc if it mentions `ROLE_SUPER_ADMIN`:
+
+Old class Javadoc:
+```java
+/**
+ * Data transfer object for user create and update operations.
+ *
+ * <p>When creating a non-SUPER_ADMIN user, {@code tenantId} must reference an existing,
+ * enabled tenant.  SUPER_ADMIN users are exempt and may omit {@code tenantId}.
+ */
+```
+
+This is already clean (uses SUPER_ADMIN not ROLE_SUPER_ADMIN), so no change needed.
+
+- [ ] **Step 5: Verify compilation succeeds**
+
+```bash
+mvn -pl connector -am compile -q
+```
+
+Expected: clean compile with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java \
+        connector/src/main/java/it/eng/connector/service/UserService.java \
+        connector/src/main/java/it/eng/connector/service/KeycloakUserService.java \
+        connector/src/main/java/it/eng/connector/model/UserDTO.java
+git commit -m "refactor: update all production callers to new Role enum names"
+```
+
+---
+
+## Task 3: Rewrite ConnectorSecurityConfig — remove role constants, add ADMIN self-service matchers
+
+**Files:**
+- Modify: `connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java`
+
+- [ ] **Step 1: Remove the three private static final String constants (lines 77–79)**
+
+Delete these three lines:
+```java
+private static final String ADMIN_ROLE = Role.ROLE_ADMIN.name().substring("ROLE_".length());
+private static final String CONNECTOR_ROLE = Role.ROLE_CONNECTOR.name().substring("ROLE_".length());
+private static final String SUPER_ADMIN_ROLE = Role.ROLE_SUPER_ADMIN.name().substring("ROLE_".length());
+```
+
+- [ ] **Step 2: Add HttpMethod import**
+
+Add to the import section (after the other `org.springframework` imports):
+```java
+import org.springframework.http.HttpMethod;
+```
+
+- [ ] **Step 3: Replace the KEYCLOAK branch authorizeHttpRequests block**
+
+Old (inside the `authMode == AuthenticationMode.KEYCLOAK` block):
+```java
+.authorizeHttpRequests(auth -> auth
+        .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
+```
+
+New:
+```java
+.authorizeHttpRequests(auth -> auth
+        .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.GET,  ApiEndpoints.USERS_V1 + "/me")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/update")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/password")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .anyRequest().hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name()))
+```
+
+- [ ] **Step 4: Replace the BASIC branch authorizeHttpRequests block**
+
+Old (inside the `else` / BASIC block):
+```java
+.authorizeHttpRequests(auth -> auth
+        .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(SUPER_ADMIN_ROLE)
+        .anyRequest().hasAnyRole(ADMIN_ROLE, SUPER_ADMIN_ROLE))
+```
+
+New (identical shape to the KEYCLOAK block above):
+```java
+.authorizeHttpRequests(auth -> auth
+        .requestMatchers(ApiEndpoints.TENANTS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.GET,  ApiEndpoints.USERS_V1 + "/me")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/update")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/password")
+            .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+        .requestMatchers(ApiEndpoints.USERS_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .requestMatchers(ApiEndpoints.PROPERTIES_V1 + "/**").hasRole(Role.SUPER_ADMIN.name())
+        .anyRequest().hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name()))
+```
+
+- [ ] **Step 5: Replace all remaining CONNECTOR_ROLE references in protocolFilterChain**
+
+Three occurrences of `.hasRole(CONNECTOR_ROLE)` inside `protocolFilterChain`:
+
+Old:
+```java
+.authorizeHttpRequests(auth -> auth.anyRequest().hasRole(CONNECTOR_ROLE))
+```
+
+New (appears three times — in DCP, KEYCLOAK, and BASIC branches):
+```java
+.authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
+```
+
+- [ ] **Step 6: Update the class-level Javadoc**
+
+Old:
+```
+ * Requires {@code ROLE_SUPER_ADMIN} for {@code /api/v1/tenants/**},
+ * and {@code /api/v1/properties/**}; all other {@code /api/**} endpoints require
+ * {@code ROLE_ADMIN} or {@code ROLE_SUPER_ADMIN}. Disabled mode permits all requests.
+```
+
+New (in the `adminFilterChain` Javadoc, around lines 118–121):
+```
+ * Requires {@code ROLE_SUPER_ADMIN} for {@code /api/v1/tenants/**},
+ * {@code /api/v1/properties/**}, and most {@code /api/v1/users/**} endpoints.
+ * {@code GET /api/v1/users/me}, {@code PUT /api/v1/users/*\/update}, and
+ * {@code PUT /api/v1/users/*\/password} are accessible to {@code ROLE_ADMIN} and
+ * {@code ROLE_SUPER_ADMIN} (self-service only — the service layer enforces ownership).
+ * All other {@code /api/**} endpoints require at minimum {@code ROLE_ADMIN}.
+ * Disabled mode permits all requests.
+```
+
+- [ ] **Step 7: Verify compilation**
+
+```bash
+mvn -pl connector -am compile -q
+```
+
+Expected: clean compile.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
+git commit -m "feat: remove role string constants from ConnectorSecurityConfig, add ADMIN self-service matchers"
+```
+
+---
+
+## Task 4: Add GET /api/v1/users/me endpoint
+
+**Files:**
+- Modify: `connector/src/main/java/it/eng/connector/service/UserService.java`
+- Modify: `connector/src/main/java/it/eng/connector/rest/api/UserApiController.java`
+
+- [ ] **Step 1: Add findCurrentUser() method to UserService**
+
+Add after the existing `findUsers()` method (around line 76):
+
+```java
+/**
+ * Returns the authenticated user's own record by e-mail.
+ *
+ * @param email the e-mail of the authenticated principal
+ * @return the user as a serialized JSON node
+ * @throws BadRequestException if no user with the given e-mail exists
+ */
+public JsonNode findCurrentUser(String email) {
+    User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new BadRequestException("User not found"));
+    return ToolsSerializer.serializePlainJsonNode(user);
+}
+```
+
+- [ ] **Step 2: Add getCurrentUser() endpoint to UserApiController**
+
+Add the following method after the constructor and before `getUsers()`. The class-level `@RequestMapping` has `consumes = APPLICATION_JSON_VALUE`; GET endpoints without a body should work because the `Content-Type` header is optional for GET (clients may still send it). This follows the same pattern as the existing `getUsers()` GET method in this controller.
+
+```java
+/**
+ * Returns the currently authenticated user's own profile.
+ *
+ * <p>Returns {@code 400 Bad Request} when there is no authenticated principal (disabled-auth
+ * mode), since there is no user identity to resolve.
+ *
+ * @param principal the authenticated principal injected by Spring Security
+ * @return the current user as a {@link GenericApiResponse}
+ */
+@GetMapping(path = "/me")
+public ResponseEntity<GenericApiResponse<JsonNode>> getCurrentUser(Principal principal) {
+    if (principal == null) {
+        throw new BadRequestException("No authenticated user in current context");
+    }
+    log.info("Fetching current user profile for principal '{}'", principal.getName());
+    JsonNode user = userService.findCurrentUser(principal.getName());
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+            .body(GenericApiResponse.success(user, "Current user"));
+}
+```
+
+Note: `BadRequestException` is **not** currently imported in `UserApiController`. Add this import to the import section:
+```java
+import it.eng.tools.exception.BadRequestException;
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+mvn -pl connector -am compile -q
+```
+
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add connector/src/main/java/it/eng/connector/service/UserService.java \
+        connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
+git commit -m "feat: add GET /api/v1/users/me endpoint for ADMIN and SUPER_ADMIN self-service"
+```
+
+---
+
+## Task 5: Fix TenantService.updateTenant() — participantId immutability
+
+**Files:**
+- Modify: `tools/src/main/java/it/eng/tools/service/TenantService.java`
+- Modify: `connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java`
+
+- [ ] **Step 1: Fix line 266 in TenantService.updateTenant()**
+
+Old:
+```java
+.participantId(updates.getParticipantId() != null ? updates.getParticipantId() : existing.getParticipantId())
+```
+
+New:
+```java
+.participantId(existing.getParticipantId())  // immutable; any value in request body is silently ignored
+```
+
+- [ ] **Step 2: Update the Javadoc on TenantService.updateTenant()**
+
+Old Javadoc (lines 229–242):
+```java
+/**
+ * Updates the mutable settings of an existing tenant (name, description, participantId,
+ * automaticNegotiation, automaticTransfer, bucketName).
+ * The {@code enabled} state is preserved from the existing tenant.
+ *
+ * <p>If {@code bucketName} is changed, the new bucket is provisioned before the tenant
+ * is updated.  The old bucket is <strong>not</strong> deleted automatically.
+ *
+ * @param tenantId the tenant identifier
+ * @param updates  the tenant containing the new values to apply
+ * @return the saved, updated tenant
+ * @throws TenantNotFoundException  if the tenant does not exist
+ * @throws IllegalArgumentException if the new bucket name is already owned by another tenant
+ */
+```
+
+New:
+```java
+/**
+ * Updates the mutable settings of an existing tenant (name, description,
+ * automaticNegotiation, automaticTransfer, bucketName).
+ * The {@code enabled} state and {@code participantId} are always preserved from the existing
+ * tenant; any {@code participantId} value in {@code updates} is silently ignored.
+ *
+ * <p>If {@code bucketName} is changed, the new bucket is provisioned before the tenant
+ * is updated.  The old bucket is <strong>not</strong> deleted automatically.
+ *
+ * @param tenantId the tenant identifier
+ * @param updates  the tenant containing the new values to apply
+ * @return the saved, updated tenant
+ * @throws TenantNotFoundException  if the tenant does not exist
+ * @throws IllegalArgumentException if the new bucket name is already owned by another tenant
+ */
+```
+
+- [ ] **Step 3: Add missing Javadoc to TenantAPIController.updateTenant()**
+
+The current `updateTenant` method in `TenantAPIController` has no Javadoc. Checkstyle will reject this. Add it:
+
+```java
+/**
+ * Updates the mutable settings of an existing tenant.
+ *
+ * <p>{@code participantId} is read-only after creation; any value supplied in the request
+ * body is silently ignored and the stored value is preserved.
+ *
+ * @param id      the tenant identifier
+ * @param updates the tenant body with the fields to update
+ * @return 200 OK with the updated tenant
+ */
+@PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+public ResponseEntity<GenericApiResponse<Tenant>> updateTenant(
+        @PathVariable String id,
+        @RequestBody Tenant updates) {
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+mvn -pl tools connector -am compile -q
+```
+
+Expected: clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/src/main/java/it/eng/tools/service/TenantService.java \
+        connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java
+git commit -m "fix: make Tenant.participantId immutable — updateTenant() silently ignores it"
+```
+
+---
+
+## Task 6: Update seed data JSON files (Role values in user records)
+
+**Files:** All `initial_data*.json` files listed below.
+
+The `User` MongoDB documents store the role as the enum name. After renaming from `ROLE_ADMIN` to `ADMIN`, existing documents must use the new names. Update **only user records** — other collections (e.g., `transfer_processes`, `negotiation`) also have a `"role"` field that means something entirely different (e.g., `"provider"`, `"consumer"`) — do **not** change those.
+
+- [ ] **Step 1: Update connector/src/test/resources/initial_data.json**
+
+Change in the `users` array:
+- `"role": "ROLE_ADMIN"` → `"role": "ADMIN"`
+- `"role": "ROLE_CONNECTOR"` → `"role": "CONNECTOR"`
+- `"role": "ROLE_SUPER_ADMIN"` → `"role": "SUPER_ADMIN"`
+
+- [ ] **Step 2: Update connector/src/test/resources/initial_data-tck.json**
+
+Same substitutions as Step 1 — only in user documents.
+
+- [ ] **Step 3: Update connector/src/main/resources/initial_data.json**
+
+Same substitutions.
+
+- [ ] **Step 4: Update connector/src/main/resources/initial_data-consumer.json**
+
+Same substitutions.
+
+- [ ] **Step 5: Update connector/src/main/resources/initial_data-provider.json**
+
+Same substitutions.
+
+- [ ] **Step 6: Update connector/src/main/resources/initial_data-tck.json**
+
+Same substitutions.
+
+- [ ] **Step 7: Update ci/docker/connector_a_resources/initial_data.json**
+
+Same substitutions.
+
+- [ ] **Step 8: Update ci/docker/connector_b_resources/initial_data.json**
+
+Same substitutions.
+
+- [ ] **Step 9: Update ci/tck/connector_tck_resources/initial_data-tck.json**
+
+Same substitutions.
+
+For each file, verify before and after with:
+```bash
+grep '"role": "ROLE_' <filename>
+```
+Expected: no matches.
+
+- [ ] **Step 10: Commit all seed file changes**
+
+```bash
+git add connector/src/test/resources/initial_data.json \
+        connector/src/test/resources/initial_data-tck.json \
+        connector/src/main/resources/initial_data.json \
+        connector/src/main/resources/initial_data-consumer.json \
+        connector/src/main/resources/initial_data-provider.json \
+        connector/src/main/resources/initial_data-tck.json \
+        ci/docker/connector_a_resources/initial_data.json \
+        ci/docker/connector_b_resources/initial_data.json \
+        ci/tck/connector_tck_resources/initial_data-tck.json
+git commit -m "chore: update seed data role values to match renamed Role enum"
+```
+
+---
+
+## Task 7: Fix test code — update all Role.ROLE_* references and inline role strings
+
+**Files:**
+- Modify: `connector/src/test/java/it/eng/connector/util/TestUtil.java`
+- Modify: `connector/src/test/java/it/eng/connector/filter/ApiTenantContextFilterTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/configuration/KeycloakAuthenticationFilterTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/configuration/KeycloakRealmRoleConverterTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/model/UserDTOTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/service/UserServiceTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/integration/user/UserIT.java`
+- Modify: `connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java`
+
+- [ ] **Step 1: Fix TestUtil.java**
+
+Old:
+```java
+public static User USER = new User(USER_ID, "first name", "last name", "test@mail.com", "secret", true, false, false, Role.ROLE_ADMIN);
+```
+
+New:
+```java
+public static User USER = new User(USER_ID, "first name", "last name", "test@mail.com", "secret", true, false, false, Role.ADMIN);
+```
+
+- [ ] **Step 2: Fix ApiTenantContextFilterTest.java — four occurrences**
+
+Replace all four occurrences of `Role.ROLE_ADMIN` with `Role.ADMIN`:
+
+```java
+// line ~52
+.role(Role.ADMIN)
+
+// line ~74
+.role(Role.ADMIN)
+
+// line ~100
+.role(Role.ADMIN)
+
+// line ~126
+.role(Role.ADMIN)
+```
+
+- [ ] **Step 3: Fix KeycloakAuthenticationFilterTest.java — two inline strings**
+
+Add `import it.eng.connector.model.Role;` to the import section.
+
+Old (line ~63):
+```java
+Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+```
+
+New:
+```java
+Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority(Role.ADMIN.authorityName()));
+```
+
+Old (line ~74):
+```java
+.anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
+```
+
+New:
+```java
+.anyMatch(auth -> auth.getAuthority().equals(Role.ADMIN.authorityName())));
+```
+
+- [ ] **Step 4: Fix KeycloakRealmRoleConverterTest.java — two inline strings**
+
+Add `import it.eng.connector.model.Role;` to the import section.
+
+Old (lines ~25–26):
+```java
+assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
+assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_CONNECTOR")));
+```
+
+New:
+```java
+assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals(Role.ADMIN.authorityName())));
+assertTrue(authorities.stream().anyMatch(auth -> auth.getAuthority().equals(Role.CONNECTOR.authorityName())));
+```
+
+- [ ] **Step 5: Fix UserDTOTest.java**
+
+Old:
+```java
+userDTO.setRole(Role.ROLE_ADMIN);
+```
+
+New:
+```java
+userDTO.setRole(Role.ADMIN);
+```
+
+- [ ] **Step 6: Fix UserServiceTest.java — three occurrences**
+
+Old (three locations):
+```java
+when(userDTO.getRole()).thenReturn(Role.ROLE_ADMIN);    // line ~86
+when(userDTO.getRole()).thenReturn(Role.ROLE_ADMIN);    // line ~106
+when(userDTO.getRole()).thenReturn(Role.ROLE_SUPER_ADMIN); // line ~123
+```
+
+New:
+```java
+when(userDTO.getRole()).thenReturn(Role.ADMIN);
+when(userDTO.getRole()).thenReturn(Role.ADMIN);
+when(userDTO.getRole()).thenReturn(Role.SUPER_ADMIN);
+```
+
+- [ ] **Step 7: Fix UserIT.java — all occurrences**
+
+Replace throughout the file:
+- `Role.ROLE_ADMIN` → `Role.ADMIN`
+- `Role.ROLE_SUPER_ADMIN` → `Role.SUPER_ADMIN`
+
+All existing `UserDTO` constructor calls pass the `Role` enum value. The inline `".roles("SUPER_ADMIN")` strings in `user(...).roles(...)` calls are Spring Security test utilities and must NOT be changed — they take plain role names (without `ROLE_` prefix) and already work correctly.
+
+Check: `git diff connector/src/test/java/it/eng/connector/integration/user/UserIT.java | grep "^[-+]" | grep Role`
+
+- [ ] **Step 8: Fix KeycloakUserRegistrationIT.java — two occurrences**
+
+Old (lines ~79 and ~102):
+```java
+"TestPass123!", null, Role.ROLE_ADMIN, null
+```
+
+New:
+```java
+"TestPass123!", null, Role.ADMIN, null
+```
+
+- [ ] **Step 9: Run unit tests to verify compile and tests pass**
+
+```bash
+mvn -pl connector -am test -q
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add connector/src/test/java/it/eng/connector/util/TestUtil.java \
+        connector/src/test/java/it/eng/connector/filter/ApiTenantContextFilterTest.java \
+        connector/src/test/java/it/eng/connector/configuration/KeycloakAuthenticationFilterTest.java \
+        connector/src/test/java/it/eng/connector/configuration/KeycloakRealmRoleConverterTest.java \
+        connector/src/test/java/it/eng/connector/model/UserDTOTest.java \
+        connector/src/test/java/it/eng/connector/service/UserServiceTest.java \
+        connector/src/test/java/it/eng/connector/integration/user/UserIT.java \
+        connector/src/test/java/it/eng/connector/integration/KeycloakUserRegistrationIT.java
+git commit -m "refactor: update test Role enum references to renamed values"
+```
+
+---
+
+## Task 8: Add new tests
+
+**Files:**
+- Modify: `connector/src/test/java/it/eng/connector/service/UserServiceTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/integration/user/UserIT.java`
+- Modify: `tools/src/test/java/it/eng/tools/service/TenantServiceTest.java`
+- Modify: `connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java`
+
+### 8a: UserService.findCurrentUser() unit test
+
+- [ ] **Step 1: Add test to UserServiceTest.java**
+
+Add the following test after `testFindUsers()`:
+
+```java
+@Test
+@DisplayName("findCurrentUser returns user for known email")
+void findCurrentUser_returnsUser() {
+    when(userRepository.findByEmail(TestUtil.USER.getEmail()))
+            .thenReturn(Optional.of(TestUtil.USER));
+
+    JsonNode result = userService.findCurrentUser(TestUtil.USER.getEmail());
+
+    assertNotNull(result);
+    assertEquals(TestUtil.USER.getEmail(), result.get("email").asText());
+    verify(userRepository).findByEmail(TestUtil.USER.getEmail());
+}
+
+@Test
+@DisplayName("findCurrentUser throws BadRequestException for unknown email")
+void findCurrentUser_notFound_throws() {
+    when(userRepository.findByEmail("unknown@mail.com")).thenReturn(Optional.empty());
+
+    assertThrows(BadRequestException.class,
+            () -> userService.findCurrentUser("unknown@mail.com"));
+}
+```
+
+- [ ] **Step 2: Run the new unit tests**
+
+```bash
+mvn -pl connector -am -Dtest=UserServiceTest -Dsurefire.failIfNoSpecifiedTests=false test -q
+```
+
+Expected: `BUILD SUCCESS`.
+
+### 8b: UserIT integration tests for GET /me
+
+- [ ] **Step 3: Add tests to UserIT.java**
+
+Add these two test methods and extend the `TEST_USER_EMAILS` list if needed (no new emails are used here — existing ADMIN_USER seed user is used).
+
+Add the following tests after the existing `getUserByEmail_asAdmin_returns403()` test:
+
+```java
+@Test
+@DisplayName("GET /api/v1/users/me as ROLE_ADMIN returns 200 with own profile")
+@WithUserDetails(TestUtil.ADMIN_USER)
+public void getCurrentUser_asAdmin_returns200() throws Exception {
+    mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/me")
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+}
+
+@Test
+@DisplayName("GET /api/v1/users/me as ROLE_SUPER_ADMIN returns 200 with own profile")
+public void getCurrentUser_asSuperAdmin_returns200() throws Exception {
+    mockMvc.perform(get(ApiEndpoints.USERS_V1 + "/me")
+                    .with(user(TestUtil.SUPER_ADMIN_USER).roles("SUPER_ADMIN"))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+}
+```
+
+Note: `@WithUserDetails(TestUtil.ADMIN_USER)` loads the `admin@mail.com` user from MongoDB via `UserDetailsService`. This requires the seed user to have `"role": "ADMIN"` (done in Task 6). The test does NOT check the response body content-type for the email field because the `User` serializer omits `password` (via `@JsonIgnore`).
+
+### 8c: TenantService unit test — participantId is ignored on update
+
+- [ ] **Step 4: Add updateTenant tests to TenantServiceTest.java**
+
+Add the following imports if not already present:
+```java
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+```
+
+Add these two tests after `disableTenant_success()`:
+
+```java
+@Test
+@DisplayName("updateTenant preserves participantId from existing tenant, ignoring update body")
+void updateTenant_participantIdIsIgnored() {
+    Tenant existing = buildTenant(true);
+    when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+    when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Tenant updates = Tenant.Builder.newInstance()
+            .id(TENANT_ID)
+            .name("New Name")
+            .participantId("urn:connector:changed")   // different from existing "urn:connector:engineering"
+            .automaticNegotiation(false)
+            .automaticTransfer(false)
+            .build();
+
+    Tenant result = tenantService.updateTenant(TENANT_ID, updates);
+
+    assertEquals("urn:connector:engineering", result.getParticipantId(),
+            "participantId must remain unchanged regardless of update body");
+    assertEquals("New Name", result.getName());
+}
+
+@Test
+@DisplayName("updateTenant keeps participantId when update body has null participantId")
+void updateTenant_nullParticipantIdInUpdates_keepExisting() {
+    Tenant existing = buildTenant(true);
+    when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+    when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    // Build with a workaround: participantId is @NotNull in Tenant.Builder, so supply existing
+    // value. The service must ignore it and use the stored value regardless.
+    Tenant updates = Tenant.Builder.newInstance()
+            .id(TENANT_ID)
+            .name("Another Name")
+            .participantId("urn:connector:engineering")  // same value — still tests the code path
+            .automaticNegotiation(true)
+            .automaticTransfer(false)
+            .build();
+
+    Tenant result = tenantService.updateTenant(TENANT_ID, updates);
+
+    assertEquals("urn:connector:engineering", result.getParticipantId());
+}
+```
+
+- [ ] **Step 5: Run TenantServiceTest**
+
+```bash
+mvn -pl tools -am -Dtest=TenantServiceTest -Dsurefire.failIfNoSpecifiedTests=false test -q
+```
+
+Expected: `BUILD SUCCESS`.
+
+### 8d: TenantAPIIT — participantId immutability integration test
+
+- [ ] **Step 6: Add integration test to TenantAPIIT.java**
+
+Add the following import if not already present:
+```java
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+```
+
+Add the test after `updateTenant_asSuperAdmin_returns200()`:
+
+```java
+@Test
+@DisplayName("PUT /api/v1/tenants/{id} with different participantId succeeds but preserves original participantId")
+public void updateTenant_participantIdIsIgnored_returnsOriginalValue() throws Exception {
+    Tenant original = buildNewTenant(); // participantId = "urn:connector:test-it"
+    tenantRepository.save(original);
+
+    Tenant updates = Tenant.Builder.newInstance()
+            .id(NEW_TENANT_ID)
+            .name("Updated Name")
+            .description("Updated description")
+            .participantId("urn:connector:changed") // different value — must be ignored
+            .automaticNegotiation(false)
+            .automaticTransfer(false)
+            .build();
+
+    mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + NEW_TENANT_ID)
+                    .with(user("super").roles("SUPER_ADMIN"))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(Objects.requireNonNull(ToolsSerializer.serializePlain(updates))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.participantId").value("urn:connector:test-it"));
+}
+```
+
+- [ ] **Step 7: Run unit tests to verify all new tests compile and pass**
+
+```bash
+mvn -pl connector -am test -q
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 8: Commit all new tests**
+
+```bash
+git add connector/src/test/java/it/eng/connector/service/UserServiceTest.java \
+        connector/src/test/java/it/eng/connector/integration/user/UserIT.java \
+        tools/src/test/java/it/eng/tools/service/TenantServiceTest.java \
+        connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java
+git commit -m "test: add tests for findCurrentUser, GET /me, participantId immutability"
+```
+
+---
+
+## Task 9: Run full verification
+
+- [ ] **Step 1: Run the full Maven build with integration tests**
+
+```bash
+mvn clean verify -q
+```
+
+Expected: `BUILD SUCCESS`. Docker must be running for Testcontainers (MongoDB + MinIO).
+
+If any test fails:
+- Compile errors → re-check Task 7 for missed enum references
+- Integration test failures → check seed file changes in Task 6; verify `"role": "ADMIN"` in seed files matches `Role.ADMIN`
+- Security tests returning wrong HTTP status → check the authorizeHttpRequests order in Task 3
+
+- [ ] **Step 2: Run Checkstyle**
+
+```bash
+mvn validate -q
+```
+
+Expected: no Checkstyle violations. Common failures:
+- Missing Javadoc on a public method → add it
+- Missing `@param`/`@return` tags → add them
+
+---
+
+## Task 10: Update documentation
+
+**Files:**
+- Modify: `doc/security.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update doc/security.md — admin endpoint access table**
+
+Find the table or section that lists `/api/v1/users/**` access (around lines 64–67 and 188–191 based on current content).
+
+Update the table entry for `/api/v1/users/**`. Change:
+
+Old:
+```
+| `/api/v1/users/**` | `ROLE_SUPER_ADMIN` |
+```
+
+New — replace the single row with multiple rows:
+```
+| `GET /api/v1/users/me` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` |
+| `PUT /api/v1/users/*/update` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` (own account only) |
+| `PUT /api/v1/users/*/password` | `ROLE_ADMIN`, `ROLE_SUPER_ADMIN` (own account only) |
+| `* /api/v1/users/**` (all other) | `ROLE_SUPER_ADMIN` |
+```
+
+Also update any prose that describes the role authority model. Find lines 64–67 where the BASIC/KEYCLOAK auth matrix table shows `ROLE_SUPER_ADMIN required for /tenants/**, /users/**, /properties/**`. Update those cells to say:
+
+```
+Keycloak JWT → ROLE_ADMIN or ROLE_SUPER_ADMIN; ROLE_SUPER_ADMIN required for /tenants/**, most /users/**, /properties/**; ROLE_ADMIN may call /users/me and own-account PUT endpoints
+```
+
+Also find section around line 188–191 that says:
+```
+| `/api/v1/users/**` | `ROLE_SUPER_ADMIN` |
+```
+And replace with the split rows shown above.
+
+- [ ] **Step 2: Update CHANGELOG.md — add entries to the [Unreleased] section**
+
+In the `### Changed` subsection, add after the existing MT2 entry:
+
+```markdown
+- **MT2 — ROLE_ADMIN self-service user management** — `ROLE_ADMIN` users may now call
+  `GET /api/v1/users/me` (own profile), `PUT /api/v1/users/{id}/update` (own name), and
+  `PUT /api/v1/users/{id}/password` (own password) without requiring `ROLE_SUPER_ADMIN`.
+  All other user-management endpoints (`GET /api/v1/users`, `POST /api/v1/users`, etc.)
+  remain restricted to `ROLE_SUPER_ADMIN`.
+- **MT2 — Role enum cleanup** — `Role` enum values renamed from `ROLE_ADMIN`/`ROLE_USER`/
+  `ROLE_CONNECTOR`/`ROLE_SUPER_ADMIN` to `ADMIN`/`USER`/`CONNECTOR`/`SUPER_ADMIN`.
+  `authorityName()` helper added to produce the Spring Security `ROLE_`-prefixed authority
+  string. `User.getAuthorities()` now calls `role.authorityName()`.
+  All inline `"ROLE_*"` string literals removed from the codebase.
+- **MT2 — Tenant.participantId immutability** — `TenantService.updateTenant()` no longer
+  accepts a new `participantId` from the request body; any supplied value is silently ignored
+  and the stored `participantId` is always preserved.
+```
+
+- [ ] **Step 3: Commit documentation**
+
+```bash
+git add doc/security.md CHANGELOG.md
+git commit -m "docs: document ADMIN self-service endpoints, Role enum rename, participantId immutability"
+```
+
+---
+
+## Task 11: Final verification and branch push
+
+- [ ] **Step 1: Run full verification one last time**
+
+```bash
+mvn clean verify -q
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 2: Run Checkstyle**
+
+```bash
+mvn validate -q
+```
+
+Expected: no violations.
+
+- [ ] **Step 3: Verify no old enum references remain**
+
+```bash
+grep -rn "Role\.ROLE_" --include="*.java" . | grep -v target/
+```
+
+Expected: zero matches.
+
+```bash
+grep -rn '"ROLE_ADMIN"\|"ROLE_CONNECTOR"\|"ROLE_SUPER_ADMIN"\|"ROLE_USER"' --include="*.java" . | grep -v target/
+```
+
+Expected: zero matches (all replaced with `Role.X.authorityName()` or `Role.X.name()`).
+
+```bash
+grep -rn '"ROLE_ADMIN"\|"ROLE_CONNECTOR"\|"ROLE_SUPER_ADMIN"\|"ROLE_USER"' --include="*.json" . | grep -v target/
+```
+
+Expected: zero matches (all seed files updated).
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push origin feature/249-slice-security-access-control-hardening
+```

--- a/docs/superpowers/specs/2026-06-30-user-role-tenant-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-30-user-role-tenant-improvements-design.md
@@ -1,0 +1,184 @@
+# Design: User Self-Service, Role Enum Cleanup, and Tenant participantId Immutability
+
+**Date:** 2026-06-30  
+**Status:** Approved
+
+## Overview
+
+This design covers four related improvements to the connector's user management, role handling, and tenant model:
+
+1. Allow `ROLE_ADMIN` users to manage their own account (new `/me` endpoint + PUT access).
+2. Rename `Role` enum values to remove the redundant `ROLE_` prefix and eliminate all inline role strings.
+3. Make `Tenant.participantId` immutable (cannot be changed after creation).
+4. Update documentation to reflect all three changes.
+
+---
+
+## 1. ROLE_ADMIN Self-Service User Management
+
+### Problem
+
+The security config currently routes all of `/api/v1/users/**` to `ROLE_SUPER_ADMIN`. This prevents `ROLE_ADMIN` users from viewing or updating their own account details, even though the service layer already enforces ownership (only the authenticated user's own record can be modified).
+
+### Design
+
+**New endpoint:** `GET /api/v1/users/me`
+
+- Available to `ROLE_ADMIN` and `ROLE_SUPER_ADMIN`.
+- Reads the `Principal` from the request, resolves the current user by email, and returns the user as a `JsonNode`.
+- A new `UserService.findCurrentUser(String email)` method is added (delegates to the existing repository lookup).
+- A new `UserApiController.getCurrentUser(Principal)` method handles the endpoint.
+
+**Existing PUT endpoints** (`/{id}/update`, `/{id}/password`):
+
+- Both opened to `ROLE_ADMIN` in addition to `ROLE_SUPER_ADMIN`.
+- No service changes needed; the existing ownership check (`user.getEmail().equals(loggedInUser)`) already prevents cross-user writes.
+
+**Security config change (`ConnectorSecurityConfig.adminFilterChain`):**
+
+More specific matchers are added before the existing catch-all rule. Order matters; Spring Security evaluates rules top-to-bottom:
+
+```java
+.requestMatchers(HttpMethod.GET,  ApiEndpoints.USERS_V1 + "/me")
+    .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+.requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/update")
+    .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+.requestMatchers(HttpMethod.PUT,  ApiEndpoints.USERS_V1 + "/*/password")
+    .hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name())
+.requestMatchers(ApiEndpoints.USERS_V1 + "/**")
+    .hasRole(Role.SUPER_ADMIN.name())   // all other user endpoints: SUPER_ADMIN only
+```
+
+This change applies to both the KEYCLOAK and BASIC branches of the admin filter chain.
+
+### Files Affected
+
+- `connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java`
+- `connector/src/main/java/it/eng/connector/rest/api/UserApiController.java`
+- `connector/src/main/java/it/eng/connector/service/UserService.java`
+
+---
+
+## 2. Role Enum Cleanup
+
+### Problem
+
+The `Role` enum values carry a redundant `ROLE_` prefix (`ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, etc.). This causes awkward Spring Security integration — `hasRole()` strips `ROLE_` from the authority but the enum values have it baked in, requiring `.name().substring("ROLE_".length())` in the security config. It also means inline string literals in tests duplicate the enum value.
+
+### Design
+
+**Rename `Role` enum values:**
+
+| Old name         | New name      |
+|------------------|---------------|
+| `ROLE_USER`      | `USER`        |
+| `ROLE_ADMIN`     | `ADMIN`       |
+| `ROLE_CONNECTOR` | `CONNECTOR`   |
+| `ROLE_SUPER_ADMIN` | `SUPER_ADMIN` |
+
+**Add `authorityName()` helper:**
+
+```java
+public enum Role {
+    USER, ADMIN, CONNECTOR, SUPER_ADMIN;
+
+    /**
+     * Returns the Spring Security authority string for this role (e.g. {@code "ROLE_ADMIN"}).
+     *
+     * @return the prefixed authority name
+     */
+    public String authorityName() {
+        return "ROLE_" + name();
+    }
+}
+```
+
+**`User.getAuthorities()`** — use the helper so the authority string is correct:
+
+```java
+return List.of(new SimpleGrantedAuthority(role.authorityName()));
+```
+
+**`ConnectorSecurityConfig`** — remove the three `private static final String` role constants (`ADMIN_ROLE`, `CONNECTOR_ROLE`, `SUPER_ADMIN_ROLE`). Replace every `hasRole(ADMIN_ROLE)` / `hasAnyRole(ADMIN_ROLE, ...)` call with `hasRole(Role.ADMIN.name())` / `hasAnyRole(Role.ADMIN.name(), ...)` inline. No intermediate variables.
+
+**All other callers** — replace every `Role.ROLE_ADMIN` (etc.) reference with `Role.ADMIN` throughout production code and tests. Replace test string literals `"ROLE_ADMIN"` with `Role.ADMIN.authorityName()`.
+
+**`KeycloakRealmRoleConverter`** — no change. It already produces `"ROLE_" + jwtRole.toUpperCase()` (e.g. `"ROLE_ADMIN"` from a JWT claim of `"ADMIN"`), which matches `Role.ADMIN.authorityName()`.
+
+**No backward-compatibility annotations required** — there is no existing deployed data to migrate.
+
+### Files Affected
+
+- `connector/src/main/java/it/eng/connector/model/Role.java`
+- `connector/src/main/java/it/eng/connector/model/User.java`
+- `connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java`
+- `connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java`
+- `connector/src/main/java/it/eng/connector/service/UserService.java`
+- `connector/src/main/java/it/eng/connector/service/KeycloakUserService.java`
+- `connector/src/main/java/it/eng/connector/model/UserDTO.java` (Javadoc references)
+- All test files that reference `Role.ROLE_*` or inline `"ROLE_*"` strings
+
+---
+
+## 3. Tenant.participantId Immutability
+
+### Problem
+
+`TenantService.updateTenant()` rebuilds the tenant using `updates.getParticipantId()`, which allows the `participantId` to be changed after creation. The `participantId` is a stable DSP participant identity and should be set once at creation time only.
+
+### Design
+
+In `TenantService.updateTenant()`, always take `participantId` from the existing tenant:
+
+```java
+.participantId(existing.getParticipantId())  // immutable; request body value silently ignored
+```
+
+The `rebuildWithEnabled()` private helper already uses `source.getParticipantId()` — no change needed there.
+
+**Client behavior:** If a client sends a `participantId` value in the update request body, the request succeeds and the value is silently ignored. The stored `participantId` remains unchanged.
+
+**No model changes:** `@NotNull` on `Tenant.participantId` is preserved (clients may include it in the request body without breaking anything).
+
+**Javadoc updates:**
+- `TenantService.updateTenant()` — remove `participantId` from the list of mutable fields in the doc comment.
+- `TenantAPIController.updateTenant()` — add a note clarifying that `participantId` is read-only.
+
+### Files Affected
+
+- `tools/src/main/java/it/eng/tools/service/TenantService.java`
+- `connector/src/main/java/it/eng/connector/rest/api/TenantAPIController.java` (Javadoc only)
+
+---
+
+## 4. Documentation Updates
+
+### `doc/security.md`
+
+Add a section or note clarifying:
+- `ROLE_ADMIN` users may call `GET /api/v1/users/me`, `PUT /api/v1/users/{id}/update`, and `PUT /api/v1/users/{id}/password` for their own account only.
+- All other user-management endpoints (list all users, create user) remain restricted to `ROLE_SUPER_ADMIN`.
+
+### Tenant docs
+
+Update any tenant API documentation to state that `participantId` is set at creation and is immutable thereafter.
+
+### `CHANGELOG.md`
+
+Add entries under the next unreleased version:
+
+```markdown
+### Changed
+- ROLE_ADMIN users can now update their own name, password, and view their own profile via `/api/v1/users/me`.
+- `Role` enum values renamed (ROLE_ADMIN → ADMIN, etc.); `authorityName()` helper added for Spring Security integration.
+- `Tenant.participantId` is now treated as immutable; update requests that include a different `participantId` succeed but the value is silently ignored.
+```
+
+---
+
+## Testing
+
+- **`UserIT`** — add test cases for `GET /api/v1/users/me` as ADMIN and SUPER_ADMIN; verify ADMIN cannot call `GET /api/v1/users` (returns 403).
+- **`UserServiceTest`** — add unit test for `findCurrentUser()`.
+- **`TenantServiceTest` / `TenantIT`** — add a test that sends a different `participantId` in an update body and verifies the stored value is unchanged.
+- Existing tests referencing `Role.ROLE_ADMIN` will be updated to `Role.ADMIN` (compile-time check).

--- a/docs/superpowers/specs/2026-06-30-user-role-tenant-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-30-user-role-tenant-improvements-design.md
@@ -26,6 +26,7 @@ The security config currently routes all of `/api/v1/users/**` to `ROLE_SUPER_AD
 
 - Available to `ROLE_ADMIN` and `ROLE_SUPER_ADMIN`.
 - Reads the `Principal` from the request, resolves the current user by email, and returns the user as a `JsonNode`.
+- If `Principal` is `null` (disabled-auth mode), the controller returns a `400 Bad Request` with a clear message, consistent with how the existing PUT methods handle it via the service's `loggedInUser == null` branch (which permits the action in disabled mode — the `/me` endpoint returns 400 in disabled mode since there is no authenticated user to identify).
 - A new `UserService.findCurrentUser(String email)` method is added (delegates to the existing repository lookup).
 - A new `UserApiController.getCurrentUser(Principal)` method handles the endpoint.
 

--- a/terraform/app-resources/connector_a_resources/initial_data.json
+++ b/terraform/app-resources/connector_a_resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "engineering"
     },
     {
@@ -35,7 +35,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "engineering"
     }
   ],

--- a/terraform/app-resources/connector_b_resources/initial_data.json
+++ b/terraform/app-resources/connector_b_resources/initial_data.json
@@ -10,7 +10,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_SUPER_ADMIN"
+      "role": "SUPER_ADMIN"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +22,7 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ROLE_ADMIN",
+      "role": "ADMIN",
       "tenantId": "engineering"
     },
     {
@@ -35,7 +35,7 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "ROLE_CONNECTOR",
+      "role": "CONNECTOR",
       "tenantId": "engineering"
     }
   ],

--- a/tools/src/main/java/it/eng/tools/service/TenantService.java
+++ b/tools/src/main/java/it/eng/tools/service/TenantService.java
@@ -227,9 +227,10 @@ public class TenantService {
     }
 
     /**
-     * Updates the mutable settings of an existing tenant (name, description, participantId,
+     * Updates the mutable settings of an existing tenant (name, description,
      * automaticNegotiation, automaticTransfer, bucketName).
-     * The {@code enabled} state is preserved from the existing tenant.
+     * The {@code enabled} state and {@code participantId} are always preserved from the existing
+     * tenant; any {@code participantId} value in {@code updates} is silently ignored.
      *
      * <p>If {@code bucketName} is changed, the new bucket is provisioned before the tenant
      * is updated.  The old bucket is <strong>not</strong> deleted automatically.
@@ -263,7 +264,7 @@ public class TenantService {
                 .version(existing.getVersion())
                 .name(updates.getName() != null ? updates.getName() : existing.getName())
                 .description(updates.getDescription() != null ? updates.getDescription() : existing.getDescription())
-                .participantId(updates.getParticipantId() != null ? updates.getParticipantId() : existing.getParticipantId())
+                .participantId(existing.getParticipantId())  // immutable; any value in request body is silently ignored
                 .automaticNegotiation(updates.isAutomaticNegotiation())
                 .automaticTransfer(updates.isAutomaticTransfer())
                 .enabled(existing.isEnabled())

--- a/tools/src/test/java/it/eng/tools/service/TenantServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/service/TenantServiceTest.java
@@ -265,5 +265,29 @@ class TenantServiceTest {
         verify(auditEventPublisher).publishEvent(captor.capture());
         assertEquals(AuditEventType.TENANT_DISABLED, captor.getValue().getEventType());
     }
+
+    @Test
+    @DisplayName("updateTenant preserves participantId from existing tenant, ignoring update body")
+    void updateTenant_participantIdIsIgnored() {
+        Tenant existing = buildTenant(true);
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        String existingParticipantId = existing.getParticipantId();
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId("urn:connector:changed-value")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+
+        Tenant result = tenantService.updateTenant(TENANT_ID, updates);
+
+        assertEquals(existingParticipantId, result.getParticipantId(),
+                "participantId must remain unchanged regardless of update body");
+        assertEquals("New Name", result.getName());
+    }
 }
 


### PR DESCRIPTION
## Slice completion

Parent slice:
- Closes #249

Child tasks:
- Closes #258
- Closes #259
- Closes #260
- Closes #261

## Summary

Hardens management API access control across the connector by restricting `/api/v1/users/**` and `/api/v1/properties/**` to `ROLE_SUPER_ADMIN` in both BASIC and KEYCLOAK authentication modes. Previously only `/api/v1/tenants/**` was restricted, leaving a privilege-escalation path where tenant-scoped `ROLE_ADMIN` users could manage users and modify global runtime properties.

### Changes

**`ConnectorSecurityConfig` (#258)**
- Added `SUPER_ADMIN_ROLE` constant derived from `Role.ROLE_SUPER_ADMIN.name()` (Role enum as single source of truth)
- Extended KEYCLOAK and BASIC mode `authorizeHttpRequests` blocks to require SUPER_ADMIN for `USERS_V1/**` and `PROPERTIES_V1/**`
- Replaced all remaining hardcoded role strings (`"ADMIN"`, `"CONNECTOR"`) with Role enum constants

**Integration tests (#259)**
- `UserIT`: 14 tests covering all user endpoints with SUPER_ADMIN success paths and new ROLE_ADMIN 403 assertions
- `ApplicationPropertyIT`: 4 tests covering properties endpoints with SUPER_ADMIN success and ROLE_ADMIN 403 assertions
- `DisabledSecurityIT`: added `getTenantsWithoutAuthenticationReturnsOk()` for full DISABLED-mode coverage

**Documentation (#261)**
- `doc/security.md`: updated authentication matrix; new Management Endpoint Access Control section
- `connector/documentation/users.md`: updated user API access requirement from ROLE_ADMIN to ROLE_SUPER_ADMIN
- `CHANGELOG.md`: Security and Changed entries under `[Unreleased]`

## Verification

- All targeted integration tests pass: `UserIT` (14/14), `ApplicationPropertyIT` (4/4), `TenantAPIIT` (22/22), `DisabledSecurityIT` (5/5)
- Checkstyle passes: `mvn -pl connector -am checkstyle:check`
- Pre-existing `AutomaticNegotiationIT` timing failures on `feature/multitenant` are unrelated to this slice