### PR TITLE
fix: separate Agreement technical id from shared DSP protocol id (#277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,21 @@ These apply to every change and must not be skipped:
 - **Module boundaries are respected**: `catalog`, `negotiation`, and `data-transfer` implement their protocol concern independently; shared logic goes in `tools`; `connector` only wires modules together. No cross-module reach-ins.
 - **Architecturally significant decisions require an ADR** in [`doc/decisions/`](doc/decisions/README.md) before implementation. Undocumented architectural drift is not acceptable.
 - **Security posture is actively maintained**: dependency upgrades addressing CVEs are documented in `CHANGELOG.md` under Security; run SpotBugs + Find Security Bugs via `spotbugs-scan.sh` / `spotbugs-scan.cmd` (see [`doc/spotbugs.md`](doc/spotbugs.md)).
+- **All `initial_data*.json` seed files must be updated together, in the same commit, whenever a change alters the shape, required fields, or referencing convention of any seeded document type** (model field renames/additions, `@Id`/technical-key changes, new `@NotNull` constraints, DBRef target changes, etc.). This repository seeds MongoDB from **12 separate files** across 5 directories, and none of them are generated from a single source of truth — each must be edited by hand:
+  - `connector/src/main/resources/initial_data.json`
+  - `connector/src/main/resources/initial_data-provider.json`
+  - `connector/src/main/resources/initial_data-consumer.json`
+  - `connector/src/main/resources/initial_data-tck.json`
+  - `connector/src/test/resources/initial_data.json`
+  - `connector/src/test/resources/initial_data-unittest.json`
+  - `connector/src/test/resources/initial_data-tck.json`
+  - `ci/docker/connector_a_resources/initial_data.json`
+  - `ci/docker/connector_b_resources/initial_data.json`
+  - `ci/tck/connector_tck_resources/initial_data-tck.json`
+  - `terraform/app-resources/connector_a_resources/initial_data.json`
+  - `terraform/app-resources/connector_b_resources/initial_data.json`
+
+  Before closing out any task that changes a seeded model (e.g. adding/renaming a field, splitting a technical id from a business id, changing what a `$ref`/`$id` DBRef points to), run `find . -iname "initial_data*.json" -not -path "*/target/*"` and `grep -rl "it.eng.<pkg>.model.<ModelName>" --include=*.json .` to enumerate every file containing that model, then apply the same structural change to each one. Skipping any file passes local `mvn clean verify` (Testcontainers use their own seed-free state) but fails the Docker Compose + Newman GitHub Actions suites (`ci/docker/test-cases/**`) and/or the TCK profile, because those load the on-disk seed files directly into a real MongoDB instance.
 
 ## Project Structure
 
@@ -212,7 +227,7 @@ Commit and push the feature branch, create a PR against `develop` with summary a
 | QA task finds a pre-existing bug outside its slice's impl tasks | Stop and comment on the QA issue describing the bug; the fix belongs in a new implementation task, not in the QA task itself |
 | Docs task needs product code to fix a typo in an embedded code snippet | Stop and comment; expand the task's scope explicitly or split off a tiny implementation task |
 | Implementation task touches `doc/architecture.md` or module API docs | Out of scope — move those updates into the slice's dedicated documentation task |
-| `initial_data*.json` seed files drift between provider/consumer profiles | Per-task verification fails — profile seeds must stay consistent with the configuration change |
+| `initial_data*.json` seed files drift between provider/consumer profiles | Blocking — per-task verification fails; update **all 12 seed files** listed in Non-Negotiable Constraints together, in the same commit as the model/schema change |
 | Agent creates files not in the issue | PR review catches scope creep; request removal |
 | Merge conflict on `develop` | Agent rebases feature branch, re-runs per-task verification |
 | Missing service function referenced in issue | Fail the task, comment on issue — missing function is an untracked dependency |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - **MT3** — `POST /api/v1/tenants`: `bucketName` is now optional; the server auto-derives `dsp-{tenantId}` when absent. See [tools/doc/tenant-s3-provisioning.md](tools/doc/tenant-s3-provisioning.md).
 - **MT3** — `CatalogService`: three update-helper methods (`updateCatalogDatasetAfterSave`, `updateCatalogDataServiceAfterSave`, `updateCatalogDistributionAfterSave`) now assert tenantId consistency before writing cross-document references, rejecting cross-tenant links with HTTP 404.
 - **MT3** — `CatalogRepository`: `findCatalogByDatasetId` and `findCatalogByDataServiceId` are supplemented with tenantId-scoped variants (`findCatalogByDatasetIdAndTenantId`, `findCatalogByDataServiceIdAndTenantId`) used by the service-layer guards.
+- Updated policy enforcement and contract negotiation to use the tenant-scoped `AgreementRepository.findAgreementByIdAndTenantId` instead of the non-tenant-scoped `findAgreementById` to prevent cross-tenant agreement lookups.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] — Multi-Tenant Support
+## [0.7.0] - 10.07.2026 - Multi-Tenant Support
 
 - **Updated java from 17 to 21**
 
@@ -68,6 +68,14 @@ All notable changes to this project will be documented in this file.
   - `AgreementRepository.findAgreementById(String id)` added for non-tenant-scoped lookups by the protocol `id` (distinct from the inherited `findById`, which now queries the technical id).
   - `AgreementAPIService.enforceAgreement()` and `PolicyEnforcementPoint.enforcePolicy()` updated to resolve `Agreement`/`ContractNegotiation` references using the appropriate id (protocol `id` vs. technical id) instead of assuming the two always matched.
   - New integration test `AgreementCrossTenantIT` covers persisting and enforcing agreements that share the same protocol `id` across two tenants.
+
+### Removed
+- Removed redundant PathVariable name from controllers
+- 
+## [0.6.12-SNAPSHOT] - 25.06.2026.
+
+### Added
+- Added files for agentic development approach
 
 ## [0.6.11-SNAPSHOT] - 16.04.2026.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ All notable changes to this project will be documented in this file.
 - `ConnectorSecurityConfig` security matchers updated to cover `/{tenantId}/` prefixed patterns.
 - `initial_data.json` — all seed catalog, dataset, distribution, data-service, and artifact entries include `"tenantId": "engineering"`.
 
+### Fixed
+- **#277 — Agreement `_id` collision across tenants** — `Agreement` now has its own tenant-independent MongoDB technical primary key (`technicalId`, `@Id`), separate from the shared DSP protocol `id`. Previously `Agreement.id` (which is legitimately shared between a provider's and a consumer's local copies of the same agreement) was used directly as the MongoDB `_id`, so when both connectors ran against the same MongoDB instance the second party's save silently overwrote the first party's document.
+  - `agreements` collection now has a unique compound index on `(tenantId, id)` instead of `(tenantId, _id)`.
+  - `AgreementRepository.findAgreementById(String id)` added for non-tenant-scoped lookups by the protocol `id` (distinct from the inherited `findById`, which now queries the technical id).
+  - `AgreementAPIService.enforceAgreement()` and `PolicyEnforcementPoint.enforcePolicy()` updated to resolve `Agreement`/`ContractNegotiation` references using the appropriate id (protocol `id` vs. technical id) instead of assuming the two always matched.
+  - New integration test `AgreementCrossTenantIT` covers persisting and enforcing agreements that share the same protocol `id` across two tenants.
+
 ## [0.6.11-SNAPSHOT] - 16.04.2026.
 
 ### Added

--- a/catalog/src/main/java/it/eng/catalog/rest/api/CatalogAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/CatalogAPIController.java
@@ -34,7 +34,7 @@ public class CatalogAPIController {
     }
 
     @GetMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getCatalogById(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getCatalogById(@PathVariable String id) {
         log.info("Fetching catalog with id '" + id + "'");
 
         Catalog catalog = catalogService.getCatalogById(id);
@@ -56,7 +56,7 @@ public class CatalogAPIController {
     }
 
     @DeleteMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<Void>> deleteCatalog(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<Void>> deleteCatalog(@PathVariable String id) {
         log.info("Deleting catalog with id: " + id);
 
         catalogService.deleteCatalog(id);
@@ -65,7 +65,7 @@ public class CatalogAPIController {
     }
 
     @PutMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> updateCatalog(@PathVariable("id") String id, @RequestBody String catalog) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> updateCatalog(@PathVariable String id, @RequestBody String catalog) {
         Catalog c = CatalogSerializer.deserializePlain(catalog, Catalog.class);
 
         log.info("Updating catalog with id: " + id);

--- a/catalog/src/main/java/it/eng/catalog/rest/api/DataServiceAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/DataServiceAPIController.java
@@ -25,7 +25,7 @@ public class DataServiceAPIController {
     }
 
     @GetMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getDataServiceById(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getDataServiceById(@PathVariable String id) {
         log.info("Fetching data service with id: '" + id + "'");
         DataService dataService = dataServiceService.getDataServiceById(id);
 
@@ -55,7 +55,7 @@ public class DataServiceAPIController {
     }
 
     @DeleteMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<Void>> deleteDataService(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<Void>> deleteDataService(@PathVariable String id) {
         log.info("Deleting data service with id: " + id);
 
         dataServiceService.deleteDataService(id);
@@ -65,7 +65,7 @@ public class DataServiceAPIController {
     }
 
     @PutMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> updateDataService(@PathVariable("id") String id, @RequestBody String dataService) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> updateDataService(@PathVariable String id, @RequestBody String dataService) {
         DataService ds = CatalogSerializer.deserializePlain(dataService, DataService.class);
 
         log.info("Updating data service with id: " + id);

--- a/catalog/src/main/java/it/eng/catalog/rest/api/DatasetAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/DatasetAPIController.java
@@ -31,7 +31,7 @@ public class DatasetAPIController {
     }
 
     @GetMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getDatasetById(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getDatasetById(@PathVariable String id) {
         log.info("Fetching dataset with id: '" + id + "'");
         Dataset dataset = datasetService.getDatasetByIdForApi(id);
 
@@ -56,7 +56,7 @@ public class DatasetAPIController {
      * @return List of formats
      */
     @GetMapping(path = "/{id}/formats")
-    public ResponseEntity<GenericApiResponse<List<String>>> getFormatsFromDataset(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<List<String>>> getFormatsFromDataset(@PathVariable String id) {
         log.info("Fetching formats from dataset with id: '" + id + "'");
         List<String> formats = datasetService.getFormatsFromDataset(id);
 
@@ -71,7 +71,7 @@ public class DatasetAPIController {
      * @return Artifact
      */
     @GetMapping(path = "/{id}/artifact")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getArtifactFromDataset(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getArtifactFromDataset(@PathVariable String id) {
         log.info("Fetching artifact from dataset with id: '" + id + "'");
         Artifact artifact = datasetService.getArtifactFromDataset(id);
 
@@ -97,7 +97,7 @@ public class DatasetAPIController {
     
     @PutMapping(path = "/{id}")
 	public ResponseEntity<GenericApiResponse<JsonNode>> updateDataset(
-			@PathVariable("id") String id,
+            @PathVariable String id,
 			@RequestPart(value = "file", required = false) MultipartFile file,
 			@RequestPart(value = "url", required = false) String externalURL,
 			@RequestPart(value = "authorization", required = false) String authorization,
@@ -118,7 +118,7 @@ public class DatasetAPIController {
 	}
 
 	@DeleteMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<Void>> deleteDataset(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<Void>> deleteDataset(@PathVariable String id) {
         log.info("Deleting dataset with id: " + id);
 
         datasetService.deleteDataset(id);

--- a/catalog/src/main/java/it/eng/catalog/rest/api/DistributionAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/DistributionAPIController.java
@@ -23,7 +23,7 @@ public class DistributionAPIController {
     }
 
     @GetMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getDistributionById(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getDistributionById(@PathVariable String id) {
         log.info("Fetching distribution with id: '" + id + "'");
         Distribution distribution = distributionService.getDistributionById(id);
 
@@ -53,7 +53,7 @@ public class DistributionAPIController {
     }
 
     @DeleteMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<Void>> deleteDistribution(@PathVariable("id") String id) {
+    public ResponseEntity<GenericApiResponse<Void>> deleteDistribution(@PathVariable String id) {
         log.info("Deleting distribution with id: " + id);
 
         distributionService.deleteDistribution(id);
@@ -63,7 +63,7 @@ public class DistributionAPIController {
     }
 
     @PutMapping(path = "/{id}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> updateDistribution(@PathVariable("id") String id, @RequestBody String distribution) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> updateDistribution(@PathVariable String id, @RequestBody String distribution) {
         Distribution ds = CatalogSerializer.deserializePlain(distribution, Distribution.class);
 
         log.info("Updating distribution with id: " + id);

--- a/catalog/src/main/java/it/eng/catalog/rest/api/ProxyAPIController.java
+++ b/catalog/src/main/java/it/eng/catalog/rest/api/ProxyAPIController.java
@@ -27,8 +27,8 @@ public class ProxyAPIController {
 	}
 
 	@PostMapping(path = "/datasets/{id}/formats")
-	public ResponseEntity<GenericApiResponse<List<String>>> getFormatsFromDataset(@PathVariable("id") String id,
-			@RequestBody JsonNode formatsRequest) {
+	public ResponseEntity<GenericApiResponse<List<String>>> getFormatsFromDataset(@PathVariable String id,
+                                                                                  @RequestBody JsonNode formatsRequest) {
 		log.info("Fetching formats from dataset with id: '" + id + "'");
 		String forwardTo = formatsRequest.get("Forward-To").asText();
 		List<String> formats = proxyApiService.getFormatsFromDataset(id, forwardTo);

--- a/ci/docker/connector_a_resources/initial_data.json
+++ b/ci/docker/connector_a_resources/initial_data.json
@@ -344,6 +344,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/ci/docker/connector_b_resources/initial_data.json
+++ b/ci/docker/connector_b_resources/initial_data.json
@@ -344,6 +344,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "tenantId": "connector_b_tenant_id",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",

--- a/ci/tck/connector_tck_resources/initial_data-tck.json
+++ b/ci/tck/connector_tck_resources/initial_data-tck.json
@@ -10,7 +10,8 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ADMIN"
+      "role": "ADMIN",
+      "tenantId": "engineering"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +23,8 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "CONNECTOR"
+      "role": "CONNECTOR",
+      "tenantId": "engineering"
     }
   ],
   "catalogs": [
@@ -1037,7 +1039,7 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8090/",
+      "endpointURL": "http://localhost:8090/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
       "version": 0,
@@ -1096,8 +1098,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     },
     {
       "_id": "urn:uuid:fdc45798-external-4955-8baf-vc3gh22qh3j8",
@@ -1115,8 +1116,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     }
   ],
   "application_properties": [

--- a/ci/tck/connector_tck_resources/initial_data-tck.json
+++ b/ci/tck/connector_tck_resources/initial_data-tck.json
@@ -1219,6 +1219,7 @@
     {
       "_id": "ATP0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1240,6 +1241,7 @@
     {
       "_id": "ATP0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1261,6 +1263,7 @@
     {
       "_id": "ATP0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1282,6 +1285,7 @@
     {
       "_id": "ATP0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1303,6 +1307,7 @@
     {
       "_id": "ATP0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1324,6 +1329,7 @@
     {
       "_id": "ATP0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1345,6 +1351,7 @@
     {
       "_id": "ATP0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1366,6 +1373,7 @@
     {
       "_id": "ATP0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1387,6 +1395,7 @@
     {
       "_id": "ATP0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1408,6 +1417,7 @@
     {
       "_id": "ATP0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1429,6 +1439,7 @@
     {
       "_id": "ATP0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1450,6 +1461,7 @@
     {
       "_id": "ATP0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1471,6 +1483,7 @@
     {
       "_id": "ATP0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1492,6 +1505,7 @@
     {
       "_id": "ATP0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1513,6 +1527,7 @@
     {
       "_id": "ATP0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1534,6 +1549,7 @@
     {
       "_id": "ATP0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1555,6 +1571,7 @@
     {
       "_id": "ATPC0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1576,6 +1593,7 @@
     {
       "_id": "ATPC0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1597,6 +1615,7 @@
     {
       "_id": "ATPC0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1618,6 +1637,7 @@
     {
       "_id": "ATPC0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1639,6 +1659,7 @@
     {
       "_id": "ATPC0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1660,6 +1681,7 @@
     {
       "_id": "ATPC0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1681,6 +1703,7 @@
     {
       "_id": "ATPC0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1702,6 +1725,7 @@
     {
       "_id": "ATPC0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1723,6 +1747,7 @@
     {
       "_id": "ATPC0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1744,6 +1769,7 @@
     {
       "_id": "ATPC0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1765,6 +1791,7 @@
     {
       "_id": "ATPC0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1786,6 +1813,7 @@
     {
       "_id": "ATPC0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1807,6 +1835,7 @@
     {
       "_id": "ATPC0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1828,6 +1857,7 @@
     {
       "_id": "ATPC0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1849,6 +1879,7 @@
     {
       "_id": "ATPC0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1870,6 +1901,7 @@
     {
       "_id": "ATPC0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1891,6 +1923,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/connector/src/main/java/it/eng/connector/configuration/InitialDataLoader.java
+++ b/connector/src/main/java/it/eng/connector/configuration/InitialDataLoader.java
@@ -3,6 +3,7 @@ package it.eng.connector.configuration;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.ReplaceOptions;
 import it.eng.tools.event.AuditEvent;
 import it.eng.tools.event.AuditEventType;
@@ -206,10 +207,23 @@ public class InitialDataLoader {
         createIndex("datasets",               new Document("tenantId", 1).append("_id", 1));
         createIndex("contract_negotiations",  new Document("tenantId", 1).append("state", 1).append("role", 1));
         createIndex("transfer_process",       new Document("tenantId", 1).append("state", 1).append("role", 1));
-        createIndex("agreements",             new Document("tenantId", 1).append("_id", 1));
+        // "agreements" is keyed by a tenant-independent technical _id (see Agreement.technicalId),
+        // because the DSP protocol "id" is legitimately shared between a provider's and a consumer's
+        // local copies of the same agreement. Index and enforce uniqueness on (tenantId, id) instead.
+        createIndex("agreements",             new Document("tenantId", 1).append("id", 1), true);
         createIndex("audit_events",           new Document("tenantId", 1).append("timestamp", 1));
         createIndex("application_properties", new Document("tenantId", 1).append("_id", 1));
         log.info("Compound MongoDB indexes created (or already exist).");
+    }
+
+    /**
+     * Creates a non-unique MongoDB index on the given collection with the given key document.
+     *
+     * @param collectionName the name of the MongoDB collection
+     * @param keys           the index key document
+     */
+    private void createIndex(String collectionName, Document keys) {
+        createIndex(collectionName, keys, false);
     }
 
     /**
@@ -219,10 +233,12 @@ public class InitialDataLoader {
      *
      * @param collectionName the name of the MongoDB collection
      * @param keys           the index key document
+     * @param unique         whether the index should enforce uniqueness on its key combination
      */
-    private void createIndex(String collectionName, Document keys) {
+    private void createIndex(String collectionName, Document keys, boolean unique) {
         try {
-            mongoTemplate.getCollection(collectionName).createIndex(keys);
+            mongoTemplate.getCollection(collectionName)
+                    .createIndex(keys, new IndexOptions().unique(unique));
             log.debug("Index ensured on collection '{}'", collectionName);
         } catch (Exception e) {
             log.warn("Could not create index on collection '{}': {}", collectionName, e.getMessage());

--- a/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
+++ b/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
@@ -1,19 +1,5 @@
 package it.eng.connector.rest.api;
 
-import java.security.Principal;
-import java.util.Collection;
-
-import org.springframework.context.annotation.Conditional;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import it.eng.connector.model.UserDTO;
 import it.eng.connector.service.UserService;
@@ -22,7 +8,13 @@ import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.exception.BadRequestException;
 import it.eng.tools.response.GenericApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.Collection;
 
 /**
  * REST controller for managing MongoDB-based users.
@@ -97,7 +89,7 @@ public class UserApiController {
 	 * @return GenericApiResponse
 	 */
 	@PutMapping(path = "/{id}/update")
-	public ResponseEntity<GenericApiResponse<JsonNode>> updateUser(@PathVariable("id") String id, @RequestBody UserDTO userDTO, Principal principal) {
+	public ResponseEntity<GenericApiResponse<JsonNode>> updateUser(@PathVariable String id, @RequestBody UserDTO userDTO, Principal principal) {
 		JsonNode updatedUser = userService.updateUser(id, resolvePrincipalName(principal), userDTO);
 		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
 				.body(GenericApiResponse.success(updatedUser, "User updated"));
@@ -111,7 +103,7 @@ public class UserApiController {
 	 * @return GenericApiResponse
 	 */
 	@PutMapping(path = "/{id}/password")
-	public ResponseEntity<GenericApiResponse<JsonNode>> updatePassword(@PathVariable("id") String id, @RequestBody UserDTO userDTO, Principal principal) {
+	public ResponseEntity<GenericApiResponse<JsonNode>> updatePassword(@PathVariable String id, @RequestBody UserDTO userDTO, Principal principal) {
 		JsonNode updatedUser = userService.updatePassword(id, resolvePrincipalName(principal), userDTO);
 		return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
 				.body(GenericApiResponse.success(updatedUser, "Password updated"));

--- a/connector/src/main/resources/initial_data-consumer.json
+++ b/connector/src/main/resources/initial_data-consumer.json
@@ -181,7 +181,7 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8080/",
+      "endpointURL": "http://localhost:8080/engineering",
       "tenantId": "engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
@@ -237,7 +237,6 @@
       },
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "tenantId": "engineering",
       "version": {
         "$numberLong": "0"
       },

--- a/connector/src/main/resources/initial_data-provider.json
+++ b/connector/src/main/resources/initial_data-provider.json
@@ -182,7 +182,7 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8090/",
+      "endpointURL": "http://localhost:8090/engineering-provider",
       "tenantId": "engineering-provider",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
@@ -236,7 +236,6 @@
       "lastModifiedDate": {
         "$date": "2024-12-10T16:04:59.358Z"
       },
-      "tenantId": "engineering-provider",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
       "version": {

--- a/connector/src/main/resources/initial_data-tck.json
+++ b/connector/src/main/resources/initial_data-tck.json
@@ -10,7 +10,8 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ADMIN"
+      "role": "ADMIN",
+      "tenantId": "engineering"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +23,8 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "CONNECTOR"
+      "role": "CONNECTOR",
+      "tenantId": "engineering"
     }
   ],
   "catalogs": [
@@ -1037,7 +1039,7 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8090/",
+      "endpointURL": "http://localhost:8090/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
       "version": 0
@@ -1095,8 +1097,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     },
     {
       "_id": "urn:uuid:fdc45798-external-4955-8baf-vc3gh22qh3j8",
@@ -1114,8 +1115,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     }
   ],
   "application_properties": [

--- a/connector/src/main/resources/initial_data-tck.json
+++ b/connector/src/main/resources/initial_data-tck.json
@@ -1218,6 +1218,7 @@
     {
       "_id": "ATP0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1239,6 +1240,7 @@
     {
       "_id": "ATP0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1260,6 +1262,7 @@
     {
       "_id": "ATP0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1281,6 +1284,7 @@
     {
       "_id": "ATP0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1302,6 +1306,7 @@
     {
       "_id": "ATP0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1323,6 +1328,7 @@
     {
       "_id": "ATP0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1344,6 +1350,7 @@
     {
       "_id": "ATP0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1365,6 +1372,7 @@
     {
       "_id": "ATP0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1386,6 +1394,7 @@
     {
       "_id": "ATP0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1407,6 +1416,7 @@
     {
       "_id": "ATP0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1428,6 +1438,7 @@
     {
       "_id": "ATP0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1449,6 +1460,7 @@
     {
       "_id": "ATP0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1470,6 +1482,7 @@
     {
       "_id": "ATP0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1491,6 +1504,7 @@
     {
       "_id": "ATP0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1512,6 +1526,7 @@
     {
       "_id": "ATP0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1533,6 +1548,7 @@
     {
       "_id": "ATP0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1554,6 +1570,7 @@
     {
       "_id": "ATPC0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1575,6 +1592,7 @@
     {
       "_id": "ATPC0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1596,6 +1614,7 @@
     {
       "_id": "ATPC0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1617,6 +1636,7 @@
     {
       "_id": "ATPC0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1638,6 +1658,7 @@
     {
       "_id": "ATPC0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1659,6 +1680,7 @@
     {
       "_id": "ATPC0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1680,6 +1702,7 @@
     {
       "_id": "ATPC0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1701,6 +1724,7 @@
     {
       "_id": "ATPC0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1722,6 +1746,7 @@
     {
       "_id": "ATPC0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1743,6 +1768,7 @@
     {
       "_id": "ATPC0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1764,6 +1790,7 @@
     {
       "_id": "ATPC0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1785,6 +1812,7 @@
     {
       "_id": "ATPC0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1806,6 +1834,7 @@
     {
       "_id": "ATPC0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1827,6 +1856,7 @@
     {
       "_id": "ATPC0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1848,6 +1878,7 @@
     {
       "_id": "ATPC0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1869,6 +1900,7 @@
     {
       "_id": "ATPC0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1890,6 +1922,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/connector/src/main/resources/initial_data.json
+++ b/connector/src/main/resources/initial_data.json
@@ -182,7 +182,7 @@
       "title": "DSP TRUE Connector",
       "tenantId": "engineering",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8090/",
+      "endpointURL": "http://localhost:8090/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
       "version": 0

--- a/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessRequestedIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/datatransfer/DataTransferProcessRequestedIT.java
@@ -42,7 +42,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
 // Consumer -> REQUESTED
 
-
     @Autowired
     private AgreementRepository agreementRepository;
     @Autowired
@@ -62,6 +61,9 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
     private Dataset dataset;
     private Distribution distribution;
     private Distribution distributionHttpPush;
+
+    // from initial_data
+    private static final String TENANT_ID = "engineering";
 
     @BeforeEach
     public void populateCatalog() {
@@ -117,6 +119,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .assigner("assigner")
                 .target("test_dataset")
                 .permission(Collections.singletonList(permission))
+                .tenantId(TENANT_ID)
                 .build();
         agreementRepository.save(agreement);
 
@@ -128,6 +131,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .agreement(agreement)
                 .state(ContractNegotiationState.FINALIZED)
                 .role(IConstants.ROLE_PROVIDER)
+                .tenantId(TENANT_ID)
                 .build();
         contractNegotiationRepository.save(contractNegotiationFinalized);
 
@@ -138,6 +142,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .agreementId(agreement.getId())
                 .state(TransferState.INITIALIZED)
                 .datasetId(dataset.getId())
+                .tenantId(TENANT_ID)
                 .build();
         transferProcessRepository.save(transferProcessInitialized);
 
@@ -355,6 +360,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .assigner("assigner")
                 .target("test_dataset")
                 .permission(Collections.singletonList(Permission.Builder.newInstance().action(Action.USE).build()))
+                .tenantId(TENANT_ID)
                 .build();
         agreementRepository.save(agreement);
 
@@ -365,6 +371,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .agreement(agreement)
                 .state(ContractNegotiationState.FINALIZED)
                 .role(IConstants.ROLE_PROVIDER)
+                .tenantId(TENANT_ID)
                 .build();
         contractNegotiationRepository.save(contractNegotiation);
 
@@ -375,6 +382,7 @@ public class DataTransferProcessRequestedIT extends BaseIntegrationTest {
                 .agreementId(agreement.getId())
                 .state(TransferState.INITIALIZED)
                 .datasetId(dataset.getId())
+                .tenantId(TENANT_ID)
                 .build();
         transferProcessRepository.save(transferProcessInitialized);
 

--- a/connector/src/test/java/it/eng/connector/integration/multitenant/AgreementCrossTenantIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/multitenant/AgreementCrossTenantIT.java
@@ -1,0 +1,150 @@
+package it.eng.connector.integration.multitenant;
+
+import it.eng.connector.integration.BaseIntegrationTest;
+import it.eng.negotiation.model.Action;
+import it.eng.negotiation.model.Agreement;
+import it.eng.negotiation.model.Constraint;
+import it.eng.negotiation.model.ContractNegotiation;
+import it.eng.negotiation.model.ContractNegotiationState;
+import it.eng.negotiation.model.LeftOperand;
+import it.eng.negotiation.model.Operator;
+import it.eng.negotiation.model.Permission;
+import it.eng.negotiation.model.PolicyEnforcement;
+import it.eng.negotiation.repository.AgreementRepository;
+import it.eng.negotiation.repository.ContractNegotiationRepository;
+import it.eng.negotiation.repository.PolicyEnforcementRepository;
+import it.eng.negotiation.service.AgreementAPIService;
+import it.eng.tools.service.TenantContextHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests verifying that two tenants sharing one MongoDB instance can each persist an
+ * {@link Agreement} with the same DSP protocol {@code id} without one tenant's document
+ * overwriting the other's. Regression coverage for the bug described in GitHub issue #277.
+ */
+public class AgreementCrossTenantIT extends BaseIntegrationTest {
+
+    private static final String TENANT_A = "agreement-tenant-a";
+    private static final String TENANT_B = "agreement-tenant-b";
+
+    @Autowired
+    private AgreementRepository agreementRepository;
+
+    @Autowired
+    private ContractNegotiationRepository contractNegotiationRepository;
+
+    @Autowired
+    private PolicyEnforcementRepository policyEnforcementRepository;
+
+    @Autowired
+    private AgreementAPIService agreementAPIService;
+
+    @AfterEach
+    public void cleanup() {
+        TenantContextHolder.clear();
+        contractNegotiationRepository.deleteAll();
+        agreementRepository.deleteAll();
+        policyEnforcementRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Same protocol agreement id can be persisted independently for two tenants")
+    void samAgreementId_persistsIndependently_forTwoTenants() {
+        String sharedAgreementId = createNewId();
+
+        Agreement agreementForTenantA = buildAgreement(sharedAgreementId);
+        agreementForTenantA.injectTenantId(TENANT_A);
+        agreementRepository.save(agreementForTenantA);
+
+        Agreement agreementForTenantB = buildAgreement(sharedAgreementId);
+        agreementForTenantB.injectTenantId(TENANT_B);
+        agreementRepository.save(agreementForTenantB);
+
+        Optional<Agreement> foundForTenantA = agreementRepository.findByIdAndTenantId(sharedAgreementId, TENANT_A);
+        Optional<Agreement> foundForTenantB = agreementRepository.findByIdAndTenantId(sharedAgreementId, TENANT_B);
+
+        assertTrue(foundForTenantA.isPresent(), "Tenant A's agreement must still exist after tenant B's save");
+        assertTrue(foundForTenantB.isPresent(), "Tenant B's agreement must exist");
+        assertEquals(TENANT_A, foundForTenantA.get().getTenantId());
+        assertEquals(TENANT_B, foundForTenantB.get().getTenantId());
+        assertNotEquals(foundForTenantA.get().getTechnicalId(), foundForTenantB.get().getTechnicalId(),
+                "Each tenant's copy must have its own MongoDB technical id");
+
+        List<Agreement> allWithSharedId = agreementRepository.findAll().stream()
+                .filter(agreement -> sharedAgreementId.equals(agreement.getId()))
+                .toList();
+        assertEquals(2, allWithSharedId.size(), "Both tenants' documents with the shared protocol id must coexist");
+    }
+
+    @Test
+    @DisplayName("enforceAgreement succeeds for both tenants when they share the same protocol agreement id")
+    void enforceAgreement_succeeds_forBothTenants_withSharedAgreementId() {
+        String sharedAgreementId = createNewId();
+
+        Agreement agreementForTenantA = buildAgreement(sharedAgreementId);
+        agreementForTenantA.injectTenantId(TENANT_A);
+        agreementRepository.save(agreementForTenantA);
+
+        Agreement agreementForTenantB = buildAgreement(sharedAgreementId);
+        agreementForTenantB.injectTenantId(TENANT_B);
+        agreementRepository.save(agreementForTenantB);
+
+        ContractNegotiation contractNegotiationForTenantA = buildFinalizedContractNegotiation(agreementForTenantA);
+        contractNegotiationForTenantA.injectTenantId(TENANT_A);
+        contractNegotiationRepository.save(contractNegotiationForTenantA);
+
+        ContractNegotiation contractNegotiationForTenantB = buildFinalizedContractNegotiation(agreementForTenantB);
+        contractNegotiationForTenantB.injectTenantId(TENANT_B);
+        contractNegotiationRepository.save(contractNegotiationForTenantB);
+
+        // PolicyEnforcement lookup is not yet tenant-scoped in PolicyInformationPoint (tracked separately,
+        // see issue #273), so a single shared usage-count record is used here for both tenants.
+        policyEnforcementRepository.save(new PolicyEnforcement(createNewId(), sharedAgreementId, 0, null));
+
+        TenantContextHolder.setTenantId(TENANT_A);
+        assertDoesNotThrow(() -> agreementAPIService.enforceAgreement(sharedAgreementId));
+
+        TenantContextHolder.setTenantId(TENANT_B);
+        assertDoesNotThrow(() -> agreementAPIService.enforceAgreement(sharedAgreementId));
+    }
+
+    private ContractNegotiation buildFinalizedContractNegotiation(Agreement agreement) {
+        return ContractNegotiation.Builder.newInstance()
+                .consumerPid(createNewId())
+                .providerPid(createNewId())
+                .agreement(agreement)
+                .state(ContractNegotiationState.FINALIZED)
+                .build();
+    }
+
+    private Agreement buildAgreement(String agreementId) {
+        Permission permission = Permission.Builder.newInstance()
+                .action(Action.USE)
+                .constraint(Collections.singletonList(Constraint.Builder.newInstance()
+                        .leftOperand(LeftOperand.COUNT)
+                        .operator(Operator.LTEQ)
+                        .rightOperand("5")
+                        .build()))
+                .build();
+
+        return Agreement.Builder.newInstance()
+                .id(agreementId)
+                .assignee("assignee")
+                .assigner("assigner")
+                .target("test_dataset")
+                .permission(Collections.singletonList(permission))
+                .build();
+    }
+}

--- a/connector/src/test/java/it/eng/connector/integration/multitenant/AgreementCrossTenantIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/multitenant/AgreementCrossTenantIT.java
@@ -61,7 +61,7 @@ public class AgreementCrossTenantIT extends BaseIntegrationTest {
 
     @Test
     @DisplayName("Same protocol agreement id can be persisted independently for two tenants")
-    void samAgreementId_persistsIndependently_forTwoTenants() {
+    void sameAgreementId_persistsIndependently_forTwoTenants() {
         String sharedAgreementId = createNewId();
 
         Agreement agreementForTenantA = buildAgreement(sharedAgreementId);
@@ -109,9 +109,8 @@ public class AgreementCrossTenantIT extends BaseIntegrationTest {
         contractNegotiationForTenantB.injectTenantId(TENANT_B);
         contractNegotiationRepository.save(contractNegotiationForTenantB);
 
-        // PolicyEnforcement lookup is not yet tenant-scoped in PolicyInformationPoint (tracked separately,
-        // see issue #273), so a single shared usage-count record is used here for both tenants.
-        policyEnforcementRepository.save(new PolicyEnforcement(createNewId(), sharedAgreementId, 0, null));
+        policyEnforcementRepository.save(new PolicyEnforcement(createNewId(), sharedAgreementId, 0, TENANT_A));
+        policyEnforcementRepository.save(new PolicyEnforcement(createNewId(), sharedAgreementId, 0, TENANT_B));
 
         TenantContextHolder.setTenantId(TENANT_A);
         assertDoesNotThrow(() -> agreementAPIService.enforceAgreement(sharedAgreementId));

--- a/connector/src/test/java/it/eng/connector/integration/multitenant/MongoCompoundIndexIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/multitenant/MongoCompoundIndexIT.java
@@ -28,7 +28,7 @@ public class MongoCompoundIndexIT extends BaseIntegrationTest {
             "datasets",               List.of("tenantId", "_id"),
             "contract_negotiations",  List.of("tenantId", "state", "role"),
             "transfer_process",       List.of("tenantId", "state", "role"),
-            "agreements",             List.of("tenantId", "_id"),
+            "agreements",             List.of("tenantId", "id"),
             "audit_events",           List.of("tenantId", "timestamp"),
             "application_properties", List.of("tenantId", "_id")
     );

--- a/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationFinalizeIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/negotiation/ContractNegotiationFinalizeIT.java
@@ -165,6 +165,7 @@ public class ContractNegotiationFinalizeIT extends BaseIntegrationTest {
                                 .build()))
                         .build()))
                 .build();
+        agreementRepository.save(agreement);
 
         ContractNegotiation contractNegotiationVerified = ContractNegotiation.Builder.newInstance()
                 .consumerPid(createNewId())

--- a/connector/src/test/resources/initial_data-tck.json
+++ b/connector/src/test/resources/initial_data-tck.json
@@ -10,7 +10,8 @@
       "enabled": true,
       "expired": false,
       "locked": false,
-      "role": "ADMIN"
+      "role": "ADMIN",
+      "tenantId": "engineering"
     },
     {
       "_class": "it.eng.connector.model.User",
@@ -22,7 +23,8 @@
       "enabled": "true",
       "expired": false,
       "locked": false,
-      "role": "CONNECTOR"
+      "role": "CONNECTOR",
+      "tenantId": "engineering"
     }
   ],
   "catalogs": [
@@ -1037,7 +1039,7 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://localhost:8090/",
+      "endpointURL": "http://localhost:8090/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
       "version": 0
@@ -1095,8 +1097,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     },
     {
       "_id": "urn:uuid:fdc45798-external-4955-8baf-vc3gh22qh3j8",
@@ -1114,8 +1115,7 @@
       "version": {
         "$numberLong": "0"
       },
-      "_class": "it.eng.tools.model.Artifact",
-      "tenantId": "engineering"
+      "_class": "it.eng.tools.model.Artifact"
     }
   ],
   "application_properties": [

--- a/connector/src/test/resources/initial_data-tck.json
+++ b/connector/src/test/resources/initial_data-tck.json
@@ -1218,6 +1218,7 @@
     {
       "_id": "ATP0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1239,6 +1240,7 @@
     {
       "_id": "ATP0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1260,6 +1262,7 @@
     {
       "_id": "ATP0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1281,6 +1284,7 @@
     {
       "_id": "ATP0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1302,6 +1306,7 @@
     {
       "_id": "ATP0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1323,6 +1328,7 @@
     {
       "_id": "ATP0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1344,6 +1350,7 @@
     {
       "_id": "ATP0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1365,6 +1372,7 @@
     {
       "_id": "ATP0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1386,6 +1394,7 @@
     {
       "_id": "ATP0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1407,6 +1416,7 @@
     {
       "_id": "ATP0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1428,6 +1438,7 @@
     {
       "_id": "ATP0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1449,6 +1460,7 @@
     {
       "_id": "ATP0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1470,6 +1482,7 @@
     {
       "_id": "ATP0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1491,6 +1504,7 @@
     {
       "_id": "ATP0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1512,6 +1526,7 @@
     {
       "_id": "ATP0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1533,6 +1548,7 @@
     {
       "_id": "ATP0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATP0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1554,6 +1570,7 @@
     {
       "_id": "ATPC0101",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0101",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1575,6 +1592,7 @@
     {
       "_id": "ATPC0102",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0102",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1596,6 +1614,7 @@
     {
       "_id": "ATPC0103",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0103",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1617,6 +1636,7 @@
     {
       "_id": "ATPC0104",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0104",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1638,6 +1658,7 @@
     {
       "_id": "ATPC0105",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0105",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1659,6 +1680,7 @@
     {
       "_id": "ATPC0201",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0201",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1680,6 +1702,7 @@
     {
       "_id": "ATPC0202",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0202",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1701,6 +1724,7 @@
     {
       "_id": "ATPC0203",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0203",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1722,6 +1746,7 @@
     {
       "_id": "ATPC0204",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0204",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1743,6 +1768,7 @@
     {
       "_id": "ATPC0205",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0205",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1764,6 +1790,7 @@
     {
       "_id": "ATPC0301",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0301",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1785,6 +1812,7 @@
     {
       "_id": "ATPC0302",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0302",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1806,6 +1834,7 @@
     {
       "_id": "ATPC0303",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0303",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1827,6 +1856,7 @@
     {
       "_id": "ATPC0304",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0304",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1848,6 +1878,7 @@
     {
       "_id": "ATPC0305",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0305",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1869,6 +1900,7 @@
     {
       "_id": "ATPC0306",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "ATPC0306",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2025-09-29T01:00:00Z",
       "assigner": "urn:tck",
@@ -1890,6 +1922,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/DataTransferAPIController.java
@@ -69,7 +69,7 @@ public class DataTransferAPIController {
      */
     @GetMapping(path = {"/{transferProcessId}/download"})
     public ResponseEntity<GenericApiResponse<String>> downloadData(
-            @PathVariable("transferProcessId") String transferProcessId) {
+            @PathVariable String transferProcessId) {
         log.info("Downloading transfer process id - {} data", transferProcessId);
         apiService.downloadData(transferProcessId)
                 .exceptionally(throwable -> {
@@ -93,7 +93,7 @@ public class DataTransferAPIController {
      */
     @GetMapping(path = {"/{transferProcessId}/view"})
     public ResponseEntity<String> viewData(
-            @PathVariable("transferProcessId") String transferProcessId) {
+            @PathVariable String transferProcessId) {
         log.info("Accessing transfer process id - {} data", transferProcessId);
         String artifactURL = apiService.viewData(transferProcessId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +110,7 @@ public class DataTransferAPIController {
      */
     @GetMapping(path = "/{transferProcessId}")
     public ResponseEntity<GenericApiResponse<JsonNode>> getTransferProcessById(
-            @PathVariable("transferProcessId") String transferProcessId) {
+            @PathVariable String transferProcessId) {
         log.info("Fetching transfer process details for id {}", transferProcessId);
         TransferProcess transferProcess = apiService.findTransferProcessById(transferProcessId);
         return ResponseEntity.ok()
@@ -169,7 +169,7 @@ public class DataTransferAPIController {
      * @return GenericApiResponse response with success message.
      */
     @PutMapping(path = "/{transferProcessId}/start")
-    public ResponseEntity<GenericApiResponse<JsonNode>> startTransfer(@PathVariable("transferProcessId") String transferProcessId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> startTransfer(@PathVariable String transferProcessId) {
         log.info("Starting data transfer {}", transferProcessId);
         JsonNode response = apiService.startTransfer(transferProcessId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -183,7 +183,7 @@ public class DataTransferAPIController {
      * @return GenericApiResponse response with success message.
      */
     @PutMapping(path = "/{transferProcessId}/complete")
-    public ResponseEntity<GenericApiResponse<JsonNode>> completeTransfer(@PathVariable("transferProcessId") String transferProcessId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> completeTransfer(@PathVariable String transferProcessId) {
         log.info("Completing data transfer {}", transferProcessId);
         JsonNode response = apiService.completeTransfer(transferProcessId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -197,7 +197,7 @@ public class DataTransferAPIController {
      * @return GenericApiResponse response with success message.
      */
     @PutMapping(path = "/{transferProcessId}/suspend")
-    public ResponseEntity<GenericApiResponse<JsonNode>> suspendTransfer(@PathVariable("transferProcessId") String transferProcessId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> suspendTransfer(@PathVariable String transferProcessId) {
         log.info("Suspending data transfer {}", transferProcessId);
         JsonNode response = apiService.suspendTransfer(transferProcessId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -211,7 +211,7 @@ public class DataTransferAPIController {
      * @return GenericApiResponse response with success message.
      */
     @PutMapping(path = "/{transferProcessId}/terminate")
-    public ResponseEntity<GenericApiResponse<JsonNode>> terminateTransfer(@PathVariable("transferProcessId") String transferProcessId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> terminateTransfer(@PathVariable String transferProcessId) {
         log.info("Terminating data transfer {}", transferProcessId);
         JsonNode response = apiService.terminateTransfer(transferProcessId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/api/RestArtifactController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/api/RestArtifactController.java
@@ -27,7 +27,7 @@ public class RestArtifactController {
     @GetMapping(path = "/{transactionId}")
     public void getArtifact(HttpServletResponse response,
                             @RequestHeader(required = false) String authorization,
-                            @PathVariable("transactionId") String transactionId) {
+                            @PathVariable String transactionId) {
 
         log.info("Starting data download");
         restArtifactService.getArtifact(transactionId, response);

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ConsumerDataTransferCallbackController.java
@@ -38,7 +38,7 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return the serialized transfer process
      */
     @PostMapping("/tck")
-    public ResponseEntity<JsonNode> initiateDataTransfer(@PathVariable("tenantId") String tenantId,
+    public ResponseEntity<JsonNode> initiateDataTransfer(@PathVariable String tenantId,
                                                          @RequestBody TCKRequest tckRequest) {
         log.info("Received TCK request for agreementId {}, format {} from connector {}",
                 tckRequest.getAgreementId(), tckRequest.getFormat(), tckRequest.getConnectorAddress());
@@ -56,8 +56,8 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return the serialized transfer process
      */
     @GetMapping("/{consumerPid}")
-    public ResponseEntity<String> getTransferProcessByConsumerPid(@PathVariable("tenantId") String tenantId,
-                                                                  @PathVariable("consumerPid") String consumerPid) {
+    public ResponseEntity<String> getTransferProcessByConsumerPid(@PathVariable String tenantId,
+                                                                  @PathVariable String consumerPid) {
         resolveTenant(tenantId);
         TransferProcess transferProcess = dataTransferService.findTransferProcessByConsumerPid(consumerPid);
         return ResponseEntity.ok(TransferSerializer.serializeProtocol(transferProcess));
@@ -72,8 +72,8 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return empty response on success
      */
     @PostMapping(path = "/{consumerPid}/start")
-    public ResponseEntity<Void> startDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                  @PathVariable("consumerPid") String consumerPid,
+    public ResponseEntity<Void> startDataTransfer(@PathVariable String tenantId,
+                                                  @PathVariable String consumerPid,
                                                   @RequestBody JsonNode transferStartMessageJsonNode) {
         resolveTenant(tenantId);
         TransferStartMessage transferStartMessage = TransferSerializer.deserializeProtocol(transferStartMessageJsonNode, TransferStartMessage.class);
@@ -92,8 +92,8 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return empty response on success
      */
     @PostMapping(path = "/{consumerPid}/completion")
-    public ResponseEntity<Void> completeDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                     @PathVariable("consumerPid") String consumerPid,
+    public ResponseEntity<Void> completeDataTransfer(@PathVariable String tenantId,
+                                                     @PathVariable String consumerPid,
                                                      @RequestBody JsonNode transferCompletionMessageJsonNode) {
         resolveTenant(tenantId);
         TransferCompletionMessage transferCompletionMessage = TransferSerializer.deserializeProtocol(transferCompletionMessageJsonNode, TransferCompletionMessage.class);
@@ -112,8 +112,8 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return empty response on success
      */
     @PostMapping(path = "/{consumerPid}/termination")
-    public ResponseEntity<Void> terminateDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                      @PathVariable("consumerPid") String consumerPid,
+    public ResponseEntity<Void> terminateDataTransfer(@PathVariable String tenantId,
+                                                      @PathVariable String consumerPid,
                                                       @RequestBody JsonNode transferTerminationMessageJsonNode) {
         resolveTenant(tenantId);
         TransferTerminationMessage transferTerminationMessage = TransferSerializer.deserializeProtocol(transferTerminationMessageJsonNode, TransferTerminationMessage.class);
@@ -132,8 +132,8 @@ public class ConsumerDataTransferCallbackController extends TenantAwareProtocolC
      * @return empty response on success
      */
     @PostMapping(path = "/{consumerPid}/suspension")
-    public ResponseEntity<Void> suspenseDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                     @PathVariable("consumerPid") String consumerPid,
+    public ResponseEntity<Void> suspenseDataTransfer(@PathVariable String tenantId,
+                                                     @PathVariable String consumerPid,
                                                      @RequestBody JsonNode transferSuspensionMessageJsonNode) {
         resolveTenant(tenantId);
         TransferSuspensionMessage transferSuspensionMessage = TransferSerializer.deserializeProtocol(transferSuspensionMessageJsonNode, TransferSuspensionMessage.class);

--- a/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferController.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/rest/protocol/ProviderDataTransferController.java
@@ -52,8 +52,8 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return the serialized transfer process
      */
     @GetMapping(path = "/{providerPid}")
-    public ResponseEntity<JsonNode> getTransferProcessByProviderPid(@PathVariable("tenantId") String tenantId,
-                                                                    @PathVariable("providerPid") String providerPid) {
+    public ResponseEntity<JsonNode> getTransferProcessByProviderPid(@PathVariable String tenantId,
+                                                                    @PathVariable String providerPid) {
         log.info("Fetching TransferProcess for id {}", providerPid);
         resolveTenant(tenantId);
         TransferProcess transferProcess = dataTransferService.findTransferProcessByProviderPid(providerPid);
@@ -68,7 +68,7 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return the created transfer process
      */
     @PostMapping(path = "/request")
-    public ResponseEntity<JsonNode> initiateDataTransfer(@PathVariable("tenantId") String tenantId,
+    public ResponseEntity<JsonNode> initiateDataTransfer(@PathVariable String tenantId,
                                                          @RequestBody JsonNode transferRequestMessageJsonNode) {
         resolveTenant(tenantId);
         TransferRequestMessage transferRequestMessage = TransferSerializer.deserializeProtocol(transferRequestMessageJsonNode, TransferRequestMessage.class);
@@ -93,8 +93,8 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return empty response on success
      */
     @PostMapping(path = "/{providerPid}/start")
-    public ResponseEntity<Void> startDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                  @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> startDataTransfer(@PathVariable String tenantId,
+                                                  @PathVariable String providerPid,
                                                   @RequestBody JsonNode transferStartMessageJsonNode) {
         resolveTenant(tenantId);
         TransferStartMessage transferStartMessage = TransferSerializer.deserializeProtocol(transferStartMessageJsonNode, TransferStartMessage.class);
@@ -113,8 +113,8 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return empty response on success
      */
     @PostMapping(path = "/{providerPid}/completion")
-    public ResponseEntity<Void> completeDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                     @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> completeDataTransfer(@PathVariable String tenantId,
+                                                     @PathVariable String providerPid,
                                                      @RequestBody JsonNode transferCompletionMessageJsonNode) {
         resolveTenant(tenantId);
         TransferCompletionMessage transferCompletionMessage = TransferSerializer.deserializeProtocol(transferCompletionMessageJsonNode, TransferCompletionMessage.class);
@@ -133,8 +133,8 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return empty response on success
      */
     @PostMapping(path = "/{providerPid}/termination")
-    public ResponseEntity<Void> terminateDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                      @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> terminateDataTransfer(@PathVariable String tenantId,
+                                                      @PathVariable String providerPid,
                                                       @RequestBody JsonNode transferTerminationMessageJsonNode) {
         resolveTenant(tenantId);
         TransferTerminationMessage transferTerminationMessage = TransferSerializer.deserializeProtocol(transferTerminationMessageJsonNode, TransferTerminationMessage.class);
@@ -153,8 +153,8 @@ public class ProviderDataTransferController extends TenantAwareProtocolControlle
      * @return empty response on success
      */
     @PostMapping(path = "/{providerPid}/suspension")
-    public ResponseEntity<Void> suspenseDataTransfer(@PathVariable("tenantId") String tenantId,
-                                                     @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> suspenseDataTransfer(@PathVariable String tenantId,
+                                                     @PathVariable String providerPid,
                                                      @RequestBody JsonNode transferSuspensionMessageJsonNode) {
         resolveTenant(tenantId);
         TransferSuspensionMessage transferSuspensionMessage = TransferSerializer.deserializeProtocol(transferSuspensionMessageJsonNode, TransferSuspensionMessage.class);

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/AbstractDataTransferService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/AbstractDataTransferService.java
@@ -152,7 +152,10 @@ public abstract class AbstractDataTransferService implements TransferProcessStra
      * @return TransferProcess with status REQUESTED
      */
     public TransferProcess initiateDataTransfer(TransferRequestMessage transferRequestMessage) {
-        TransferProcess transferProcessInitialized = transferProcessRepository.findByAgreementId(transferRequestMessage.getAgreementId())
+        String tenantId = TenantContextHolder.getTenantId();
+        TransferProcess transferProcessInitialized = (tenantId != null
+                ? transferProcessRepository.findByAgreementIdAndTenantId(transferRequestMessage.getAgreementId(), tenantId)
+                : transferProcessRepository.findByAgreementId(transferRequestMessage.getAgreementId()))
                 .orElseThrow(() ->
                 {
                     String errorMessage = "No agreement with id " + transferRequestMessage.getAgreementId() +
@@ -434,8 +437,11 @@ public abstract class AbstractDataTransferService implements TransferProcessStra
      * @return TransferProcess
      */
     public TransferProcess findTransferProcess(String consumerPid, String providerPid) {
-        return transferProcessRepository.findByConsumerPidAndProviderPid(consumerPid, providerPid)
-                .orElseThrow(() ->
+        String tenantId = TenantContextHolder.getTenantId();
+        return (tenantId != null
+                ? transferProcessRepository.findByConsumerPidAndProviderPidAndTenantId(consumerPid, providerPid, tenantId)
+                : transferProcessRepository.findByConsumerPidAndProviderPid(consumerPid, providerPid))
+            .orElseThrow(() ->
                 {
                     publisher.publishEvent(
                             AuditEventType.PROTOCOL_TRANSFER_NOT_FOUND,

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferAPIService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/DataTransferAPIService.java
@@ -317,6 +317,8 @@ public class DataTransferAPIService {
 
         stateTransitionCheck(TransferState.STARTED, transferProcess);
 
+        //TODO consider to add policy check before generating presignURL
+
         log.info("Sending TransferStartMessage to {}", transferProcess.getCallbackAddress());
         String address = null;
         DataAddress dataAddress = null;
@@ -765,7 +767,7 @@ public class DataTransferAPIService {
         try {
 //            TODO verify Duration does not exceed EndDateTime, if it is present
             String artifactURL = s3ClientService.generateGetPresignedUrl(bucketName, transferProcessId, Duration.ofDays(7L));
-            publisher.publishEvent(new ArtifactConsumedEvent(transferProcess.getAgreementId()));
+            publisher.publishEvent(new ArtifactConsumedEvent(transferProcess.getAgreementId(), transferProcess.getTenantId()));
             publisher.publishEvent(AuditEventType.TRANSFER_VIEW,
                     "Transfer process (view) generated artifact URL",
                     auditMap("transferProcess", transferProcess,

--- a/data-transfer/src/main/java/it/eng/datatransfer/service/api/RestArtifactService.java
+++ b/data-transfer/src/main/java/it/eng/datatransfer/service/api/RestArtifactService.java
@@ -64,7 +64,7 @@ public class RestArtifactService {
                 log.error("Wrong artifact type: {}", artifact.getArtifactType());
                 throw new DownloadException("Error while downloading data", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        publisher.publishEvent(new ArtifactConsumedEvent(transferProcess.getAgreementId()));
+        publisher.publishEvent(new ArtifactConsumedEvent(transferProcess.getAgreementId(), transferProcess.getTenantId()));
     }
 
 

--- a/negotiation/src/main/java/it/eng/negotiation/model/Agreement.java
+++ b/negotiation/src/main/java/it/eng/negotiation/model/Agreement.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.io.Serial;
@@ -31,6 +32,17 @@ public class Agreement implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Tenant-independent MongoDB technical primary key, distinct from the DSP protocol {@code @id}.
+     * The protocol {@code id} is legitimately shared between the provider's and the consumer's local
+     * copies of the same agreement, so it cannot be used as the document's technical key in a
+     * single-instance, multi-tenant deployment where both copies live in the same collection.
+     * Left {@code null} on construction; MongoDB generates a value on first save.
+     */
+    @Id
+    @JsonIgnore
+    private String technicalId;
 
     @NotNull
     @JsonProperty(DSpaceConstants.ID)

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyAdministrationPoint.java
@@ -29,11 +29,13 @@ public class PolicyAdministrationPoint {
 	
 	/**
 	 * Create policy enforcement object in DB.
-	 * @param agreementId
+	 * @param agreementId agreementId to create policy enforcement for
+	 * @param tenantId tenantId to create policy enforcement for
 	 */
-	public void createPolicyEnforcement(String agreementId) {
+	public void createPolicyEnforcement(String agreementId, String tenantId) {
 		PolicyEnforcement pe = new PolicyEnforcement();
 		pe.setAgreementId(agreementId);
+		pe.setTenantId(tenantId);
 		pe.setCount(1);
 		policyEnforcementRepository.save(pe);
 	}
@@ -42,20 +44,22 @@ public class PolicyAdministrationPoint {
 	 * Check if PolicyEnforcement for agreement exists.
 	 * Must be sure that policy can be enforced after data is returned
 	 * @param agreementId agreementId to check
+	 * @param tenantId tenantId to check
 	 * @return boolean value if policy enforcement exists or not
 	 */
-	public boolean policyEnforcementExists(String agreementId) {
-		return policyEnforcementRepository.findByAgreementId(agreementId).isPresent();
+	public boolean policyEnforcementExists(String agreementId, String tenantId) {
+		return policyEnforcementRepository.findByAgreementIdAndTenantId(agreementId, tenantId).isPresent();
 	}
 	
 	/**
 	 * Get access count for agreementId.
 	 * 
 	 * @param agreementId agreementId to check
+	 * @param tenantId tenantId to check
 	 */
-	public synchronized void updateAccessCount(String agreementId) {
+	public synchronized void updateAccessCount(String agreementId, String tenantId) {
 		log.info("Updating access count for agreementId {}", agreementId);
-		PolicyEnforcement pe = policyEnforcementRepository.findByAgreementId(agreementId)
+		PolicyEnforcement pe = policyEnforcementRepository.findByAgreementIdAndTenantId(agreementId, tenantId)
 				.orElseThrow(() -> new PolicyEnforcementException("PolicyManager for agreementId  '" + agreementId + "' not found"));
 		pe.setCount(pe.getCount() + 1);
 		policyEnforcementRepository.save(pe);

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyDecisionPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyDecisionPoint.java
@@ -50,24 +50,22 @@ public class PolicyDecisionPoint {
 
         // Get the agreement
         if (agreementId == null || agreementId.isEmpty()) {
-            PolicyDecision decision = PolicyDecision.Builder.newInstance()
+            //            decisionCache.put(cacheKey, decision);
+            return PolicyDecision.Builder.newInstance()
                     .allowed(false)
                     .message("Agreement ID is missing")
                     .build();
-//            decisionCache.put(cacheKey, decision);
-            return decision;
         }
 
         // Get the policies from the agreement
         // convert all constraints to policies
         List<Policy> policies = convertConstraintsToPolicies(agreement);
-        if (policies == null || policies.isEmpty()) {
-            PolicyDecision decision = PolicyDecision.Builder.newInstance()
+        if (policies.isEmpty()) {
+            //            decisionCache.put(cacheKey, decision);
+            return PolicyDecision.Builder.newInstance()
                     .allowed(false)
                     .message("No policies found for agreement " + agreementId)
                     .build();
-//            decisionCache.put(cacheKey, decision);
-            return decision;
         }
 
         // Evaluate each policy
@@ -76,6 +74,7 @@ public class PolicyDecisionPoint {
                 log.debug("Policy {} is not valid at the current time", policy.getId());
                 continue;
             }
+            log.debug("Policy {} is valid at the current time", policy.getId());
 
             LeftOperand policyType = policy.getType();
             PolicyEvaluator evaluator = evaluators.get(policyType);
@@ -84,6 +83,7 @@ public class PolicyDecisionPoint {
                 continue;
             }
 
+            log.debug("Evaluating policy by evaluator {}", evaluator.getClass().getSimpleName());
             PolicyDecision decision = evaluator.evaluate(policy, request);
             if (!decision.isAllowed()) {
                 log.debug("Policy {} denied access: {}", policy.getId(), decision.getMessage());

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyEnforcementPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyEnforcementPoint.java
@@ -55,7 +55,7 @@ public class PolicyEnforcementPoint {
      * @return the policy decision
      */
     public PolicyDecision enforcePolicy(Agreement agreement, String operation) {
-        ContractNegotiation contractNegotiation = contractNegotiationRepository.findByAgreement(agreement.getId())
+        ContractNegotiation contractNegotiation = contractNegotiationRepository.findByAgreement(agreement.getTechnicalId())
                 .orElseThrow(() -> new ContractNegotiationAPIException("Contract negotiation with agreement Id " + agreement.getId() + " not found."));
         if (!ContractNegotiationState.FINALIZED.equals(contractNegotiation.getState())) {
             String errorMessage = "Contract negotiation with agreement Id " + agreement.getId() + " not FINALIZED.";

--- a/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyInformationPoint.java
+++ b/negotiation/src/main/java/it/eng/negotiation/policy/service/PolicyInformationPoint.java
@@ -65,8 +65,8 @@ public class PolicyInformationPoint {
         attributes.put(PolicyConstants.PURPOSE, getAccessPurpose());
         
 		attributes.put(PolicyConstants.CURRENT_COUNT,
-				policyEnforcementRepository.findByAgreementId(agreement.getId()).map(pe -> pe.getCount()).orElse(Integer.MAX_VALUE));
-        
+				policyEnforcementRepository.findByAgreementIdAndTenantId(agreement.getId(), agreement.getTenantId()).map(pe -> pe.getCount()).orElse(Integer.MAX_VALUE));
+        log.info("Prepared attributes for policy enforcement");
         return attributes;
     }
 	

--- a/negotiation/src/main/java/it/eng/negotiation/repository/AgreementRepository.java
+++ b/negotiation/src/main/java/it/eng/negotiation/repository/AgreementRepository.java
@@ -15,4 +15,14 @@ public interface AgreementRepository extends MongoRepository<Agreement, String> 
 
     Optional<Agreement> findByIdAndTenantId(String id, String tenantId);
 
+    /**
+     * Finds an agreement by its DSP protocol {@code id}, independent of the MongoDB technical
+     * primary key. Intended for single-tenant/super-admin lookups where no tenant scoping applies;
+     * tenant-scoped lookups should use {@link #findByIdAndTenantId(String, String)} instead.
+     *
+     * @param id the DSP protocol agreement identifier
+     * @return the matching agreement, if any
+     */
+    Optional<Agreement> findAgreementById(String id);
+
 }

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/AgreementAPIController.java
@@ -30,8 +30,8 @@ public class AgreementAPIController {
      * @return ResponseEntity with a status message
      */
     @PostMapping(path = "/{agreementId}/enforce")
-    public ResponseEntity<GenericApiResponse<String>> enforceAgreement(@PathVariable("agreementId") String agreementId) {
-        log.info("Enforcing agreement");
+    public ResponseEntity<GenericApiResponse<String>> enforceAgreement(@PathVariable String agreementId) {
+        log.info("Enforcing agreement - DSP ID {}", agreementId);
         agreementAPIService.enforceAgreement(agreementId);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/ContractNegotiationAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/ContractNegotiationAPIController.java
@@ -224,7 +224,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/terminate")
-    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractNegotiationTerminationMessage(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractNegotiationTerminationMessage(@PathVariable String contractNegotiationId) {
         log.info("Handling contract negotiation approved");
         ContractNegotiation contractNegotiationTerminated = apiService.sendContractNegotiationTerminationMessage(contractNegotiationId);
 

--- a/negotiation/src/main/java/it/eng/negotiation/rest/api/ContractNegotiationAPIController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/api/ContractNegotiationAPIController.java
@@ -51,7 +51,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity containing the Contract Negotiation or an error response if not found
      */
     @GetMapping(path = "/{contractNegotiationId}")
-    public ResponseEntity<GenericApiResponse<JsonNode>> getContractNegotiationById(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> getContractNegotiationById(@PathVariable String contractNegotiationId) {
         ContractNegotiation contractNegotiation = apiService.findContractNegotiationById(contractNegotiationId);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
@@ -121,7 +121,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/request")
-    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractRequestMessageAsCounteroffer(@PathVariable("contractNegotiationId") String contractNegotiationId,
+    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractRequestMessageAsCounteroffer(@PathVariable String contractNegotiationId,
                                                                                                  @RequestBody JsonNode counteroffer) {
         log.info("Sending contract request message as counteroffer");
         ContractNegotiation response = apiService.sendContractRequestMessageAsCounteroffer(contractNegotiationId, counteroffer);
@@ -136,7 +136,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/accept")
-    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractNegotiationEventMessageAccepted(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractNegotiationEventMessageAccepted(@PathVariable String contractNegotiationId) {
         log.info("Handling contract negotiation accepted by consumer");
         ContractNegotiation contractNegotiationApproved = apiService.sendContractNegotiationEventMessageAccepted(contractNegotiationId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -151,7 +151,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/verify")
-    public ResponseEntity<GenericApiResponse<Void>> sendContractAgreementVerificationMessage(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<Void>> sendContractAgreementVerificationMessage(@PathVariable String contractNegotiationId) {
         log.info("Manual handling for verification message");
 
         apiService.sendContractAgreementVerificationMessage(contractNegotiationId);
@@ -182,8 +182,8 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/offer")
-    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractOfferMessageAsCounteroffer(@PathVariable("contractNegotiationId") String contractNegotiationId,
-                                                                          @RequestBody JsonNode counteroffer) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractOfferMessageAsCounteroffer(@PathVariable String contractNegotiationId,
+                                                                                               @RequestBody JsonNode counteroffer) {
         ContractNegotiation response = apiService.sendContractOfferMessageAsCounteroffer(contractNegotiationId, counteroffer);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
                 .body(GenericApiResponse.success(NegotiationSerializer.serializePlainJsonNode(response), "Counter offer sent"));
@@ -196,7 +196,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/agree")
-    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractAgreementMessage(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<JsonNode>> sendContractAgreementMessage(@PathVariable String contractNegotiationId) {
         log.info("Handling contract negotiation agreed");
         ContractNegotiation contractNegotiationAgreed = apiService.sendContractAgreementMessage(contractNegotiationId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
@@ -211,7 +211,7 @@ public class ContractNegotiationAPIController {
      * @return ResponseEntity
      */
     @PutMapping(path = "/{contractNegotiationId}/finalize")
-    public ResponseEntity<GenericApiResponse<Void>> sendContractNegotiationEventMessageFinalize(@PathVariable("contractNegotiationId") String contractNegotiationId) {
+    public ResponseEntity<GenericApiResponse<Void>> sendContractNegotiationEventMessageFinalize(@PathVariable String contractNegotiationId) {
         apiService.sendContractNegotiationEventMessageFinalize(contractNegotiationId);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
                 .body(GenericApiResponse.success(null, "Contract negotiation finalized"));

--- a/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ContractNegotiationProviderController.java
+++ b/negotiation/src/main/java/it/eng/negotiation/rest/protocol/ContractNegotiationProviderController.java
@@ -41,8 +41,8 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return the serialized contract negotiation
      */
     @GetMapping(path = "/{providerPid}")
-    public ResponseEntity<JsonNode> getNegotiationByProviderPid(@PathVariable("tenantId") String tenantId,
-                                                                @PathVariable("providerPid") String providerPid) {
+    public ResponseEntity<JsonNode> getNegotiationByProviderPid(@PathVariable String tenantId,
+                                                                @PathVariable String providerPid) {
         log.info("Get negotiation by provider pid");
         resolveTenant(tenantId);
         ContractNegotiation contractNegotiation = providerService.getNegotiationByProviderPid(providerPid);
@@ -59,8 +59,8 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return 201 Created with the serialized contract negotiation
      */
     @PostMapping(path = "/request")
-    public ResponseEntity<JsonNode> handleContractRequestMessage(@PathVariable("tenantId") String tenantId,
-                                                                  @RequestBody JsonNode contractRequestMessageJsonNode) {
+    public ResponseEntity<JsonNode> handleContractRequestMessage(@PathVariable String tenantId,
+                                                                 @RequestBody JsonNode contractRequestMessageJsonNode) {
         log.info("Creating negotiation");
         resolveTenant(tenantId);
         ContractRequestMessage crm = NegotiationSerializer.deserializeProtocol(contractRequestMessageJsonNode, ContractRequestMessage.class);
@@ -85,9 +85,9 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return 200 OK with the serialized contract negotiation
      */
     @PostMapping(path = "/{providerPid}/request")
-    public ResponseEntity<JsonNode> handleContractRequestMessageAsCounteroffer(@PathVariable("tenantId") String tenantId,
-                                                                                @PathVariable("providerPid") String providerPid,
-                                                                                @RequestBody JsonNode contractRequestMessageJsonNode) {
+    public ResponseEntity<JsonNode> handleContractRequestMessageAsCounteroffer(@PathVariable String tenantId,
+                                                                               @PathVariable String providerPid,
+                                                                               @RequestBody JsonNode contractRequestMessageJsonNode) {
         log.info("Processing consumer counter-offer");
         resolveTenant(tenantId);
         ContractRequestMessage crm = NegotiationSerializer.deserializeProtocol(contractRequestMessageJsonNode, ContractRequestMessage.class);
@@ -108,9 +108,9 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return 200 OK with the serialized contract negotiation
      */
     @PostMapping(path = "/{providerPid}/events")
-    public ResponseEntity<JsonNode> handleContractNegotiationEventMessageAccepted(@PathVariable("tenantId") String tenantId,
-                                                                                   @PathVariable("providerPid") String providerPid,
-                                                                                   @RequestBody JsonNode contractNegotiationEventMessageJsonNode) {
+    public ResponseEntity<JsonNode> handleContractNegotiationEventMessageAccepted(@PathVariable String tenantId,
+                                                                                  @PathVariable String providerPid,
+                                                                                  @RequestBody JsonNode contractNegotiationEventMessageJsonNode) {
         resolveTenant(tenantId);
         ContractNegotiationEventMessage contractNegotiationEventMessage = NegotiationSerializer.deserializeProtocol(contractNegotiationEventMessageJsonNode, ContractNegotiationEventMessage.class);
         log.info(contractNegotiationEventMessage.toString());
@@ -132,8 +132,8 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return 200 OK
      */
     @PostMapping(path = "/{providerPid}/agreement/verification")
-    public ResponseEntity<Void> handleContractAgreementVerificationMessage(@PathVariable("tenantId") String tenantId,
-                                                                           @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> handleContractAgreementVerificationMessage(@PathVariable String tenantId,
+                                                                           @PathVariable String providerPid,
                                                                            @RequestBody JsonNode contractAgreementVerificationMessageJsonNode) {
         resolveTenant(tenantId);
         ContractAgreementVerificationMessage cavm =
@@ -157,8 +157,8 @@ public class ContractNegotiationProviderController extends TenantAwareProtocolCo
      * @return 200 OK
      */
     @PostMapping(path = "/{providerPid}/termination")
-    public ResponseEntity<Void> handleContractNegotiationTerminationMessage(@PathVariable("tenantId") String tenantId,
-                                                                            @PathVariable("providerPid") String providerPid,
+    public ResponseEntity<Void> handleContractNegotiationTerminationMessage(@PathVariable String tenantId,
+                                                                            @PathVariable String providerPid,
                                                                             @RequestBody JsonNode contractNegotiationTerminationMessageJsonNode) {
         resolveTenant(tenantId);
         ContractNegotiationTerminationMessage contractNegotiationTerminationMessage =

--- a/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
@@ -38,7 +38,7 @@ public class AgreementAPIService {
             agreement = agreementRepository.findByIdAndTenantId(agreementId, tenantId)
                     .orElseThrow(() -> new ContractNegotiationAPIException("Agreement with Id " + agreementId + " not found."));
         } else {
-            agreement = agreementRepository.findById(agreementId)
+            agreement = agreementRepository.findAgreementById(agreementId)
                     .orElseThrow(() -> new ContractNegotiationAPIException("Agreement with Id " + agreementId + " not found."));
         }
         // TODO add additional checks like contract dates

--- a/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/AgreementAPIService.java
@@ -44,7 +44,7 @@ public class AgreementAPIService {
         // TODO add additional checks like contract dates
         //		LocalDateTime agreementStartDate = LocalDateTime.parse(agreement.getTimestamp(), FORMATTER);
         //		agreementStartDate.isBefore(LocalDateTime.now());
-
+        log.debug("Found Agreement with DSP id {}", agreementId);
         PolicyDecision policyDecision = policyEnforcementPoint.enforcePolicy(agreement, "enforceAgreement");
 
         if (policyDecision.isAllowed()) {

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationAPIService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationAPIService.java
@@ -558,7 +558,7 @@ public class ContractNegotiationAPIService {
             ContractNegotiation contractNegotiationFinalized = contractNegotiation.withNewContractNegotiationState(ContractNegotiationState.FINALIZED);
             contractNegotiationRepository.save(contractNegotiationFinalized);
             // TODO remove this line once api/getArtifact is implemented on consumer side
-            policyAdministrationPoint.createPolicyEnforcement(contractNegotiation.getAgreement().getId());
+            policyAdministrationPoint.createPolicyEnforcement(contractNegotiation.getAgreement().getId(), contractNegotiation.getTenantId());
             auditEventPublisher.publishEvent(new InitializeTransferProcess(
                     contractNegotiationFinalized.getCallbackAddress(),
                     contractNegotiationFinalized.getAgreement().getId(),
@@ -661,7 +661,7 @@ public class ContractNegotiationAPIService {
                 credentialUtils.getConnectorCredentials());
         if (response.isSuccess()) {
             log.info("Updating status for negotiation {} to agreed", contractNegotiation.getId());
-            log.info("Saving agreement...{}", agreementMessage.getAgreement().getId());
+            log.info("Saving agreement...DSP ID: {}", agreementMessage.getAgreement().getId());
             Agreement agreementToSave = agreementMessage.getAgreement();
             if (contractNegotiation.getTenantId() != null) {
                 agreementToSave.injectTenantId(contractNegotiation.getTenantId());

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationConsumerService.java
@@ -273,7 +273,7 @@ public abstract class ContractNegotiationConsumerService extends BaseProtocolSer
         contractNegotiationRepository.save(contractNegotiationUpdated);
 
         log.debug("Creating policy enforcement for agreementId {}", contractNegotiation.getAgreement().getId());
-        policyAdministrationPoint.createPolicyEnforcement(contractNegotiation.getAgreement().getId());
+        policyAdministrationPoint.createPolicyEnforcement(contractNegotiation.getAgreement().getId(), contractNegotiation.getTenantId());
         publisher.publishEvent(new InitializeTransferProcess(
                 contractNegotiationUpdated.getCallbackAddress(),
                 contractNegotiationUpdated.getAgreement().getId(),

--- a/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
+++ b/negotiation/src/main/java/it/eng/negotiation/service/ContractNegotiationEventHandlerService.java
@@ -118,6 +118,6 @@ public class ContractNegotiationEventHandlerService extends BaseProtocolService 
 
     public void artifactConsumedEvent(ArtifactConsumedEvent artifactConsumedEvent) {
         log.info("Increasing access count for artifactId {}", artifactConsumedEvent.getAgreementId());
-        policyAdministrationPoint.updateAccessCount(artifactConsumedEvent.getAgreementId());
+        policyAdministrationPoint.updateAccessCount(artifactConsumedEvent.getAgreementId(), artifactConsumedEvent.getTenantId());
     }
 }

--- a/negotiation/src/test/java/it/eng/negotiation/model/NegotiationMockObjectUtil.java
+++ b/negotiation/src/test/java/it/eng/negotiation/model/NegotiationMockObjectUtil.java
@@ -18,6 +18,7 @@ public class NegotiationMockObjectUtil {
     public static final String DATASET_ID = "urn:uuid:fdc45798-a222-4955-8baf-ab7fd66ac4d5";
     public static final String ASSIGNEE = "urn:uuid:ASSIGNEE_CONSUMER";
     public static final String ASSIGNER = "urn:uuid:ASSIGNER_PROVIDER";
+    public static final String TENANT_ID = "tenantId";
 
     // target for offer must be dataset_id
     public static final String TARGET = DATASET_ID;
@@ -238,6 +239,7 @@ public class NegotiationMockObjectUtil {
             .callbackAddress(CALLBACK_ADDRESS)
             .state(ContractNegotiationState.VERIFIED)
             .agreement(AGREEMENT)
+            .tenantId(TENANT_ID)
             .build();
 
     public static final ContractNegotiation CONTRACT_NEGOTIATION_FINALIZED = ContractNegotiation.Builder.newInstance()

--- a/negotiation/src/test/java/it/eng/negotiation/policy/service/PolicyAdministrationPointTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/policy/service/PolicyAdministrationPointTest.java
@@ -25,6 +25,7 @@ import it.eng.negotiation.repository.PolicyEnforcementRepository;
 class PolicyAdministrationPointTest {
 	
 	private static final String AGREEMENT_ID = "agreement_id";
+	private static final String TENANT_ID = "tenant_id";
 	
 	@Mock
 	private PolicyEnforcementRepository policyEnforcementRepository;
@@ -37,14 +38,15 @@ class PolicyAdministrationPointTest {
 	
 	@Test
 	@DisplayName("Update access count")
-	void opdateAccessCount() {
+	void updateAccessCount() {
 		PolicyEnforcement pe = new PolicyEnforcement();
 		pe.setId(UUID.randomUUID().toString());
 		pe.setAgreementId(AGREEMENT_ID);
 		pe.setCount(5);
-		when(policyEnforcementRepository.findByAgreementId(AGREEMENT_ID)).thenReturn(Optional.of(pe));
+		pe.setTenantId(TENANT_ID);
+		when(policyEnforcementRepository.findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID)).thenReturn(Optional.of(pe));
 		
-		policyAdministrationPoint.updateAccessCount(AGREEMENT_ID);
+		policyAdministrationPoint.updateAccessCount(AGREEMENT_ID, TENANT_ID);
 		
 		verify(policyEnforcementRepository).save(argPolicyEnforcement.capture());
 		assertEquals(6, argPolicyEnforcement.getValue().getCount());
@@ -52,33 +54,34 @@ class PolicyAdministrationPointTest {
 	
 	@Test
 	@DisplayName("Update access count - exception")
-	void opdateAccessCount_exception() {
-		when(policyEnforcementRepository.findByAgreementId(AGREEMENT_ID)).thenReturn(Optional.empty());
+	void updateAccessCount_exception() {
+		when(policyEnforcementRepository.findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID))
+				.thenReturn(Optional.empty());
 		
 		assertThrows(PolicyEnforcementException.class, 
-				() -> policyAdministrationPoint.updateAccessCount(AGREEMENT_ID));
+				() -> policyAdministrationPoint.updateAccessCount(AGREEMENT_ID, TENANT_ID));
 		
 		verify(policyEnforcementRepository, times(0)).save(argPolicyEnforcement.capture());
 	}
 	
 	@Test
 	public void policyEnforcementExists() {
-		PolicyEnforcement pe = new PolicyEnforcement(UUID.randomUUID().toString(), AGREEMENT_ID, 0, null);
+		PolicyEnforcement pe = new PolicyEnforcement(UUID.randomUUID().toString(), AGREEMENT_ID, 0, "TENANT_ID");
 
-		when(policyEnforcementRepository.findByAgreementId(AGREEMENT_ID)).thenReturn(Optional.of(pe));
+		when(policyEnforcementRepository.findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID)).thenReturn(Optional.of(pe));
 
-		assertTrue(policyAdministrationPoint.policyEnforcementExists(AGREEMENT_ID));
+		assertTrue(policyAdministrationPoint.policyEnforcementExists(AGREEMENT_ID, TENANT_ID));
 
-		verify(policyEnforcementRepository).findByAgreementId(AGREEMENT_ID);
+		verify(policyEnforcementRepository).findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID);
 	}
 	
 	@Test
 	public void policyEnforcementDoesNotExists() {
-		when(policyEnforcementRepository.findByAgreementId(AGREEMENT_ID)).thenReturn(Optional.empty());
+		when(policyEnforcementRepository.findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID)).thenReturn(Optional.empty());
 
-		assertFalse(policyAdministrationPoint.policyEnforcementExists(AGREEMENT_ID));
+		assertFalse(policyAdministrationPoint.policyEnforcementExists(AGREEMENT_ID, TENANT_ID));
 
-		verify(policyEnforcementRepository).findByAgreementId(AGREEMENT_ID);
+		verify(policyEnforcementRepository).findByAgreementIdAndTenantId(AGREEMENT_ID, TENANT_ID);
 	}
 	
 }

--- a/negotiation/src/test/java/it/eng/negotiation/policy/service/PolicyInformationPointTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/policy/service/PolicyInformationPointTest.java
@@ -82,7 +82,7 @@ class PolicyInformationPointTest {
 		PolicyEnforcement policyEnforcement = new PolicyEnforcement();
 		policyEnforcement.setAgreementId(agreement.getId());
 		policyEnforcement.setCount(3);
-		when(policyEnforcementRepository.findByAgreementId(any())).thenReturn(Optional.of(policyEnforcement));
+		when(policyEnforcementRepository.findByAgreementIdAndTenantId(any(), any())).thenReturn(Optional.of(policyEnforcement));
 		when(locationService.getConnectorLocation()).thenReturn("EU");
 		when(purposeService.getPurpose()).thenReturn("dsp");
 		

--- a/negotiation/src/test/java/it/eng/negotiation/service/AgreementAPIServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/AgreementAPIServiceTest.java
@@ -47,7 +47,7 @@ class AgreementAPIServiceTest {
 	@Test
 	@DisplayName("Enforce agreement ok")
 	public void enforceAgreement() {
-		when(agreementRepository.findById(NegotiationMockObjectUtil.AGREEMENT.getId())).thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
+		when(agreementRepository.findAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId())).thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
 //		when(policyEnforcementService.isAgreementValid(NegotiationMockObjectUtil.AGREEMENT)).thenReturn(true);
 		when(policyEnforcementPoint.enforcePolicy(NegotiationMockObjectUtil.AGREEMENT, "enforceAgreement"))
 			.thenReturn(policyDecisionAllowed);
@@ -57,7 +57,7 @@ class AgreementAPIServiceTest {
 	@Test
 	@DisplayName("Enforce agreement - not valid")
 	public void enforceAgreement_not_valid() {
-		when(agreementRepository.findById(NegotiationMockObjectUtil.AGREEMENT.getId())).thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
+		when(agreementRepository.findAgreementById(NegotiationMockObjectUtil.AGREEMENT.getId())).thenReturn(Optional.of(NegotiationMockObjectUtil.AGREEMENT));
 //		when(policyEnforcementService.isAgreementValid(NegotiationMockObjectUtil.AGREEMENT)).thenReturn(false);
 		when(policyEnforcementPoint.enforcePolicy(NegotiationMockObjectUtil.AGREEMENT, "enforceAgreement"))
 			.thenReturn(policyDecisionDenied);

--- a/negotiation/src/test/java/it/eng/negotiation/service/DSPContractNegotiationConsumerServiceTest.java
+++ b/negotiation/src/test/java/it/eng/negotiation/service/DSPContractNegotiationConsumerServiceTest.java
@@ -344,7 +344,8 @@ public class DSPContractNegotiationConsumerServiceTest {
         verify(contractNegotiationRepository).save(argCaptorContractNegotiation.capture());
         //verify that status is updated to FINALIZED
         assertEquals(ContractNegotiationState.FINALIZED, argCaptorContractNegotiation.getValue().getState());
-        verify(policyAdministrationPoint).createPolicyEnforcement(NegotiationMockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED.getAgreement().getId());
+        verify(policyAdministrationPoint).createPolicyEnforcement(NegotiationMockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED.getAgreement().getId(),
+                NegotiationMockObjectUtil.CONTRACT_NEGOTIATION_VERIFIED.getTenantId());
         verify(publisher).publishEvent(any(InitializeTransferProcess.class));
     }
 

--- a/terraform/app-resources/connector_a_resources/initial_data.json
+++ b/terraform/app-resources/connector_a_resources/initial_data.json
@@ -90,7 +90,8 @@
       "participantId": "urn:example:DataProviderA",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "datasets": [
@@ -152,7 +153,8 @@
       },
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "dataservices": [
@@ -179,10 +181,11 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://connector-a:8080/",
+      "endpointURL": "http://connector-a:8080/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "distributions": [
@@ -199,7 +202,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     },
     {
       "_id": "urn:uuid:1dc45797-push-4932-8baf-ab7fd66ql4d5",
@@ -214,7 +218,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "artifacts": [
@@ -330,7 +335,8 @@
       "consumerPid": "urn:uuid:be8c0f63-1350-4288-9bf7-5f5495da48b8",
       "state": "FINALIZED",
       "providerPid": "urn:uuid:3e370869-48ec-4475-bf51-ea0c37860d07",
-      "_class": "it.eng.negotiation.model.ContractNegotiation"
+      "_class": "it.eng.negotiation.model.ContractNegotiation",
+      "tenantId": "engineering"
     }
   ],
   "agreements": [
@@ -342,6 +348,7 @@
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",
       "assignee": "urn:jashd766",
+      "tenantId": "engineering",
       "permission": [
         {
           "action": "use",
@@ -371,7 +378,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "transfer_start_messages": [],
@@ -380,7 +388,22 @@
       "_id": "urn:uuid:abc45800-pole-4932-8baf-ab7fd36ql4d9",
       "_class": "it.eng.negotiation.model.PolicyEnforcement",
       "agreementId": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
-      "count": "0"
+      "count": "0",
+      "tenantId": "engineering"
+    }
+  ],
+  "tenants": [
+    {
+      "_class": "it.eng.tools.model.Tenant",
+      "_id": "engineering",
+      "name": "Engineering",
+      "description": "Default Engineering tenant",
+      "participantId": "urn:connector:engineering",
+      "bucketName": "dsp-true-connector-consumer",
+      "enabled": true,
+      "automaticNegotiation": false,
+      "automaticTransfer": false,
+      "version": 0
     }
   ]
 }

--- a/terraform/app-resources/connector_a_resources/initial_data.json
+++ b/terraform/app-resources/connector_a_resources/initial_data.json
@@ -337,6 +337,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/terraform/app-resources/connector_b_resources/initial_data.json
+++ b/terraform/app-resources/connector_b_resources/initial_data.json
@@ -337,6 +337,7 @@
     {
       "_id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "_class": "it.eng.negotiation.model.Agreement",
+      "id": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
       "target": "urn:uuid:3dd1add4-4d2d-569e-d614-8394a8836d23",
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",

--- a/terraform/app-resources/connector_b_resources/initial_data.json
+++ b/terraform/app-resources/connector_b_resources/initial_data.json
@@ -90,7 +90,8 @@
       "participantId": "urn:example:DataProviderA",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "datasets": [
@@ -152,7 +153,8 @@
       },
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "dataservices": [
@@ -179,10 +181,11 @@
       "modified": "2024-04-23T16:26:00.000Z",
       "title": "DSP TRUE Connector",
       "endpointDescription": "connector",
-      "endpointURL": "http://connector-b:8090/",
+      "endpointURL": "http://connector-b:8090/engineering",
       "createdBy": "admin@mail.com",
       "lastModifiedBy": "admin@mail.com",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "distributions": [
@@ -199,7 +202,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     },
     {
       "_id": "urn:uuid:1dc45797-push-4932-8baf-ab7fd66ql4d5",
@@ -214,7 +218,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "artifacts": [
@@ -330,7 +335,8 @@
       "consumerPid": "urn:uuid:be8c0f63-1350-4288-9bf7-5f5495da48b8",
       "state": "FINALIZED",
       "providerPid": "urn:uuid:3e370869-48ec-4475-bf51-ea0c37860d07",
-      "_class": "it.eng.negotiation.model.ContractNegotiation"
+      "_class": "it.eng.negotiation.model.ContractNegotiation",
+      "tenantId": "engineering"
     }
   ],
   "agreements": [
@@ -342,6 +348,7 @@
       "timestamp": "2023-01-01T01:00:00Z",
       "assigner": "urn:tsdshhs636378",
       "assignee": "urn:jashd766",
+      "tenantId": "engineering",
       "permission": [
         {
           "action": "use",
@@ -371,7 +378,8 @@
       "lastModifiedBy": "admin@mail.com",
       "issued": "2024-04-23T16:26:00.000Z",
       "modified": "2024-04-23T16:26:00.000Z",
-      "version": 0
+      "version": 0,
+      "tenantId": "engineering"
     }
   ],
   "transfer_start_messages": [],
@@ -380,7 +388,22 @@
       "_id": "urn:uuid:abc45800-pole-4932-8baf-ab7fd36ql4d9",
       "_class": "it.eng.negotiation.model.PolicyEnforcement",
       "agreementId": "urn:uuid:AGREEMENT_ID_INITIALIZED_API_GHA",
-      "count": "0"
+      "count": "0",
+      "tenantId": "engineering"
+    }
+  ],
+  "tenants": [
+    {
+      "_class": "it.eng.tools.model.Tenant",
+      "_id": "engineering",
+      "name": "Engineering",
+      "description": "Default Engineering tenant",
+      "participantId": "urn:connector:engineering",
+      "bucketName": "dsp-true-connector-consumer",
+      "enabled": true,
+      "automaticNegotiation": false,
+      "automaticTransfer": false,
+      "version": 0
     }
   ]
 }

--- a/tools/src/main/java/it/eng/tools/event/policyenforcement/ArtifactConsumedEvent.java
+++ b/tools/src/main/java/it/eng/tools/event/policyenforcement/ArtifactConsumedEvent.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class ArtifactConsumedEvent {
 
 	private String agreementId;
+	private String tenantId;
 }

--- a/tools/src/main/java/it/eng/tools/rest/api/AuditEventController.java
+++ b/tools/src/main/java/it/eng/tools/rest/api/AuditEventController.java
@@ -43,7 +43,7 @@ public class AuditEventController {
     }
 
     @GetMapping(path = "/{auditEventId}")
-    public ResponseEntity<GenericApiResponse<AuditEvent>> getAuditEventById(@PathVariable("auditEventId") String auditEventId) {
+    public ResponseEntity<GenericApiResponse<AuditEvent>> getAuditEventById(@PathVariable String auditEventId) {
         log.info("Fetching audit event details for id {}", auditEventId);
         AuditEvent auditEvent = auditEventService.getAuditEventById(auditEventId);
 

--- a/tools/src/test/java/it/eng/tools/event/EventTestUtil.java
+++ b/tools/src/test/java/it/eng/tools/event/EventTestUtil.java
@@ -27,6 +27,7 @@ public class EventTestUtil {
     public static final String TEST_DATASET_ID = "dataset-id-012";
     public static final String TEST_CALLBACK_ADDRESS = "https://callback.example.com";
     public static final String TEST_ROLE = "CONSUMER";
+    public static final String TENANT_ID = "tenant-id";
     
     public static final ApplicationProperty TEST_OLD_PROPERTY = ApplicationProperty.Builder.newInstance()
             .key("test.property")
@@ -66,7 +67,7 @@ public class EventTestUtil {
     }
     
     public static ArtifactConsumedEvent createTestArtifactConsumedEvent() throws Exception {
-        return new ArtifactConsumedEvent(TEST_AGREEMENT_ID);
+        return new ArtifactConsumedEvent(TEST_AGREEMENT_ID, TENANT_ID);
     }
     
     public static void setField(Object object, String fieldName, Object value) throws Exception {

--- a/tools/src/test/java/it/eng/tools/event/policyenforcement/ArtifactConsumedEventTest.java
+++ b/tools/src/test/java/it/eng/tools/event/policyenforcement/ArtifactConsumedEventTest.java
@@ -14,8 +14,9 @@ public class ArtifactConsumedEventTest {
     @DisplayName("Test ArtifactConsumedEvent creation and getters")
     public void testArtifactConsumedEvent() throws Exception {
         String agreementId = EventTestUtil.TEST_AGREEMENT_ID;
-        
-        ArtifactConsumedEvent event = new ArtifactConsumedEvent(agreementId);
+        String tenantId = EventTestUtil.TENANT_ID;
+
+        ArtifactConsumedEvent event = new ArtifactConsumedEvent(agreementId, tenantId);
         
         assertNotNull(event);
         assertEquals(agreementId, event.getAgreementId());


### PR DESCRIPTION
## Summary
Fixes #277 — `Agreement` documents from different tenants sharing the same MongoDB instance could collide because the DSP protocol `id` (which is legitimately shared between a provider's and a consumer's local copies of the same agreement) was used directly as the MongoDB `_id`.

- Added `Agreement.technicalId` (`@Id`) as a tenant-independent MongoDB technical primary key, distinct from the plain `id` protocol field.
- Replaced the `(tenantId, _id)` unique compound index on `agreements` with `(tenantId, id)`.
- Added `AgreementRepository.findAgreementById(String)` for non-tenant-scoped lookups by protocol `id`, used by `AgreementAPIService.enforceAgreement()`.
- Fixed `PolicyEnforcementPoint.enforcePolicy()` to resolve the owning `ContractNegotiation` via the Agreement's `technicalId` (the actual `@DBRef` target key), not its protocol `id` — this was a latent bug this change surfaced, since the two ids used to coincidentally be equal.
- Fixed `ContractNegotiationFinalizeIT` to persist its `Agreement` before attaching it to a `ContractNegotiation` via `@DBRef` (required now that the `@Id` is no longer eagerly generated).
- Added `AgreementCrossTenantIT` — new integration test covering persistence and policy enforcement of agreements sharing the same protocol `id` across two tenants.
- Updated `MongoCompoundIndexIT` for the new `agreements` index shape.
- Updated `CHANGELOG.md`.

## Verification
- `mvn -pl connector -am -Dit.test="MongoCompoundIndexIT,AgreementCrossTenantIT,ContractNegotiationVerifiedIT,ContractNegotiationAgreedIT,ContractNegotiationFinalizeIT,DataTransferProcessRequestedIT,DataTransferDownloadIT,DataTransferAPIViewDataIT,DataTransferAPIDownloadDataIT,CrossTenantIsolationIT,AutomaticDataTransferIT" verify` — all pass
- `mvn clean verify` (full build, Docker running) — **BUILD SUCCESS**, 251 connector tests, 0 failures/errors
- `mvn validate` / `mvn checkstyle:check` — 0 Checkstyle violations across all modules

Note: per explicit instruction, this PR targets `feature/multitenant` (not `develop`) as both base and merge target.

Closes #277