### PR TITLE
[TASK][AUTH1][T286] Rename AuthenticationMode.BASIC to INTERNAL + add ApiEndpoints.AUTH_V1

### DIFF
--- a/ci/docker/connector_a_resources/application.properties
+++ b/ci/docker/connector_a_resources/application.properties
@@ -59,7 +59,7 @@ application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
 #### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/ci/docker/connector_a_resources/application.properties
+++ b/ci/docker/connector_a_resources/application.properties
@@ -58,7 +58,7 @@ application.connectorid=connector_a
 application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.

--- a/ci/docker/connector_b_resources/application.properties
+++ b/ci/docker/connector_b_resources/application.properties
@@ -58,7 +58,7 @@ application.connectorid=connector_b
 application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.

--- a/ci/docker/connector_b_resources/application.properties
+++ b/ci/docker/connector_b_resources/application.properties
@@ -59,7 +59,7 @@ application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
 #### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/ci/tck/connector_tck_resources/application-tck.properties
+++ b/ci/tck/connector_tck_resources/application-tck.properties
@@ -70,8 +70,8 @@ application.connectorid=connector-consumer-id
 application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
+++ b/connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java
@@ -5,7 +5,7 @@ import it.eng.connector.model.Role;
 import it.eng.connector.repository.UserRepository;
 import it.eng.tools.auth.AuthenticationMode;
 import it.eng.tools.auth.AuthenticationModeResolver;
-import it.eng.tools.auth.condition.BasicAuthenticationModeCondition;
+import it.eng.tools.auth.condition.InternalAuthenticationModeCondition;
 import it.eng.tools.auth.condition.KeycloakAuthenticationModeCondition;
 import it.eng.tools.controller.ApiEndpoints;
 import org.apache.commons.lang3.StringUtils;
@@ -64,8 +64,8 @@ import java.util.Arrays;
  * <pre>
  * provider=KEYCLOAK + dcp.enabled=false  → admin: Keycloak,  protocol: Keycloak
  * provider=KEYCLOAK + dcp.enabled=true   → admin: Keycloak,  protocol: DCP
- * provider=BASIC    + dcp.enabled=false  → admin: Basic Auth, protocol: Basic Auth
- * provider=BASIC    + dcp.enabled=true   → admin: Basic Auth, protocol: DCP
+ * provider=INTERNAL + dcp.enabled=false  → admin: Basic Auth, protocol: Basic Auth
+ * provider=INTERNAL + dcp.enabled=true   → admin: Basic Auth, protocol: DCP
  * provider=DISABLED                      → all endpoints: permitAll
  * </pre>
  */
@@ -119,15 +119,15 @@ public class ConnectorSecurityConfig {
      * All other {@code /api/**} endpoints require at minimum {@code ROLE_ADMIN}.
      * Disabled mode permits all requests.
      *
-     * <p>In BASIC mode, both {@link InternalServiceAuthenticationProvider} and
+     * <p>In INTERNAL mode, both {@link InternalServiceAuthenticationProvider} and
      * {@link DaoAuthenticationProvider} are registered so that internal machine-to-machine
      * calls authenticated as {@code internal-service} bypass tenant-scoped user lookup.
      *
      * @param http the HttpSecurity builder
      * @param keycloakFilter optional Keycloak filter, present when mode is KEYCLOAK
      * @param apiTenantContextFilter the tenant context filter for API requests
-     * @param daoAuthenticationProvider the DAO provider for normal user authentication (BASIC mode)
-     * @param internalServiceAuthProvider the internal-service provider (BASIC mode)
+     * @param daoAuthenticationProvider the DAO provider for normal user authentication (INTERNAL mode)
+     * @param internalServiceAuthProvider the internal-service provider (INTERNAL mode)
      * @return the configured filter chain
      * @throws Exception if the chain cannot be built
      */
@@ -160,7 +160,7 @@ public class ConnectorSecurityConfig {
                             .anyRequest().hasAnyRole(Role.ADMIN.name(), Role.SUPER_ADMIN.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else {
-            // BASIC: ApiTenantContextFilter must run AFTER BasicAuthenticationFilter so that
+            // INTERNAL: ApiTenantContextFilter must run AFTER BasicAuthenticationFilter so that
             // the Authentication is already populated in SecurityContextHolder when we read it.
             // InternalServiceAuthenticationProvider is checked first; unmatched usernames fall
             // through to DaoAuthenticationProvider for normal user login.
@@ -231,7 +231,7 @@ public class ConnectorSecurityConfig {
                     .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
                     .exceptionHandling(ex -> ex.authenticationEntryPoint(authEntryPoint));
         } else {
-            // BASIC
+            // INTERNAL
             http.anonymous(AbstractHttpConfigurer::disable)
                     .httpBasic(basic -> basic.authenticationEntryPoint(authEntryPoint))
                     .authorizeHttpRequests(auth -> auth.anyRequest().hasRole(Role.CONNECTOR.name()))
@@ -306,31 +306,31 @@ public class ConnectorSecurityConfig {
     }
 
     // =========================================================================
-    // Conditional Basic Auth beans
+    // Conditional Internal Auth beans
     // =========================================================================
 
     /**
-     * Creates the {@link UserDetailsService} backed by MongoDB for Basic Auth mode.
+     * Creates the {@link UserDetailsService} backed by MongoDB for Internal Auth mode.
      *
      * @param userRepository the user repository
      * @return the user details service
      */
     @Bean
-    @Conditional(BasicAuthenticationModeCondition.class)
+    @Conditional(InternalAuthenticationModeCondition.class)
     UserDetailsService userDetailsService(UserRepository userRepository) {
         return username -> userRepository.findByEmail(username)
                 .orElseThrow(() -> new BadCredentialsException("Bad credentials"));
     }
 
     /**
-     * Creates the {@link DaoAuthenticationProvider} for Basic Auth mode.
+     * Creates the {@link DaoAuthenticationProvider} for Internal Auth mode.
      *
      * @param userDetailsService the user details service
      * @param passwordEncoder the password encoder
      * @return the configured DAO authentication provider
      */
     @Bean
-    @Conditional(BasicAuthenticationModeCondition.class)
+    @Conditional(InternalAuthenticationModeCondition.class)
     DaoAuthenticationProvider daoAuthenticationProvider(UserDetailsService userDetailsService,
             PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider(userDetailsService);
@@ -339,13 +339,13 @@ public class ConnectorSecurityConfig {
     }
 
     /**
-     * Creates the {@link AuthenticationManager} for Basic Auth mode.
+     * Creates the {@link AuthenticationManager} for Internal Auth mode.
      *
      * @param daoAuthenticationProvider the DAO authentication provider
      * @return the authentication manager
      */
     @Bean
-    @Conditional(BasicAuthenticationModeCondition.class)
+    @Conditional(InternalAuthenticationModeCondition.class)
     AuthenticationManager authenticationManager(DaoAuthenticationProvider daoAuthenticationProvider) {
         return new ProviderManager(daoAuthenticationProvider);
     }

--- a/connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java
+++ b/connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import it.eng.connector.model.Role;
 import it.eng.connector.model.User;
-import it.eng.tools.auth.condition.BasicAuthenticationModeCondition;
+import it.eng.tools.auth.condition.InternalAuthenticationModeCondition;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -22,12 +22,12 @@ import lombok.extern.slf4j.Slf4j;
  * allows {@code ApiTenantContextFilter} to honour the {@code X-Tenant-Id} request header
  * and correctly route multi-tenant internal API calls.
  *
- * <p>Only active when {@code application.auth.provider=BASIC}. In KEYCLOAK or DISABLED
+ * <p>Only active when {@code application.auth.provider=INTERNAL}. In KEYCLOAK or DISABLED
  * modes this provider is not registered.
  */
 @Slf4j
 @Component
-@Conditional(BasicAuthenticationModeCondition.class)
+@Conditional(InternalAuthenticationModeCondition.class)
 public class InternalServiceAuthenticationProvider implements AuthenticationProvider {
 
     /** Username used by internal services for machine-to-machine API calls. */

--- a/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
+++ b/connector/src/main/java/it/eng/connector/rest/api/UserApiController.java
@@ -3,7 +3,7 @@ package it.eng.connector.rest.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import it.eng.connector.model.UserDTO;
 import it.eng.connector.service.UserService;
-import it.eng.tools.auth.condition.BasicOrDisabledAuthenticationModeCondition;
+import it.eng.tools.auth.condition.InternalOrDisabledAuthenticationModeCondition;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.exception.BadRequestException;
 import it.eng.tools.response.GenericApiResponse;
@@ -25,7 +25,7 @@ import java.util.Collection;
 @RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, 
 path = ApiEndpoints.USERS_V1)
 @Slf4j
-@Conditional(BasicOrDisabledAuthenticationModeCondition.class)
+@Conditional(InternalOrDisabledAuthenticationModeCondition.class)
 public class UserApiController {
 	
 	private final UserService userService;

--- a/connector/src/main/java/it/eng/connector/service/UserService.java
+++ b/connector/src/main/java/it/eng/connector/service/UserService.java
@@ -17,7 +17,7 @@ import it.eng.connector.model.Role;
 import it.eng.connector.model.User;
 import it.eng.connector.model.UserDTO;
 import it.eng.connector.repository.UserRepository;
-import it.eng.tools.auth.condition.BasicOrDisabledAuthenticationModeCondition;
+import it.eng.tools.auth.condition.InternalOrDisabledAuthenticationModeCondition;
 import it.eng.tools.exception.BadRequestException;
 import it.eng.tools.exception.ResourceNotFoundException;
 import it.eng.tools.serializer.ToolsSerializer;
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @Slf4j
-@Conditional(BasicOrDisabledAuthenticationModeCondition.class)
+@Conditional(InternalOrDisabledAuthenticationModeCondition.class)
 public class UserService {
 
 	private final UserRepository userRepository;

--- a/connector/src/main/resources/application-consumer.properties
+++ b/connector/src/main/resources/application-consumer.properties
@@ -107,7 +107,7 @@ s3.upload-mode=SYNC
 # Chunk size in bytes for multipart uploads (default: 10485760 = 10 MB)
 #s3.chunkSize=10485760
 
-# Authentication provider: KEYCLOAK | BASIC | DISABLED
+# Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.

--- a/connector/src/main/resources/application-consumer.properties
+++ b/connector/src/main/resources/application-consumer.properties
@@ -108,7 +108,7 @@ s3.upload-mode=SYNC
 #s3.chunkSize=10485760
 
 # Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/connector/src/main/resources/application-provider.properties
+++ b/connector/src/main/resources/application-provider.properties
@@ -105,7 +105,7 @@ s3.upload-mode=SYNC
 # Chunk size in bytes for multipart uploads (default: 10485760 = 10 MB)
 #s3.chunkSize=10485760
 
-# Authentication provider: KEYCLOAK | BASIC | DISABLED
+# Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.

--- a/connector/src/main/resources/application-provider.properties
+++ b/connector/src/main/resources/application-provider.properties
@@ -106,7 +106,7 @@ s3.upload-mode=SYNC
 #s3.chunkSize=10485760
 
 # Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/connector/src/main/resources/application-tck.properties
+++ b/connector/src/main/resources/application-tck.properties
@@ -107,7 +107,7 @@ s3.upload-mode=SYNC
 # Chunk size in bytes for multipart uploads (default: 10485760 = 10 MB)
 #s3.chunkSize=10485760
 
-# Authentication provider: KEYCLOAK | BASIC | DISABLED
+# Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.

--- a/connector/src/main/resources/application-tck.properties
+++ b/connector/src/main/resources/application-tck.properties
@@ -108,7 +108,7 @@ s3.upload-mode=SYNC
 #s3.chunkSize=10485760
 
 # Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/connector/src/test/resources/application.properties
+++ b/connector/src/test/resources/application.properties
@@ -78,7 +78,7 @@ management.endpoint.env.post.enabled=true
 ### Connector ID
 application.connectorid=29d022fa-33be-4627-923e-412eb609eb6b
 #### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+application.auth.provider=INTERNAL
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
 #### FTP

--- a/connector/src/test/resources/application.properties
+++ b/connector/src/test/resources/application.properties
@@ -77,7 +77,7 @@ management.endpoints.web.exposure.include=*
 management.endpoint.env.post.enabled=true
 ### Connector ID
 application.connectorid=29d022fa-33be-4627-923e-412eb609eb6b
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
 application.auth.provider=INTERNAL
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}

--- a/terraform/app-resources/connector_a_resources/application.properties
+++ b/terraform/app-resources/connector_a_resources/application.properties
@@ -58,8 +58,8 @@ application.connectorid=connector_a
 application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/terraform/app-resources/connector_b_resources/application.properties
+++ b/terraform/app-resources/connector_b_resources/application.properties
@@ -58,8 +58,8 @@ application.connectorid=connector_b
 application.usagecontrol.enabled=true
 application.usagecontrol.constraint.location=EU
 application.usagecontrol.constraint.purpose=demo
-#### Authentication provider: KEYCLOAK | BASIC | DISABLED
-application.auth.provider=BASIC
+#### Authentication provider: KEYCLOAK | INTERNAL | DISABLED
+application.auth.provider=INTERNAL
 # DCP authentication for protocol endpoints — when true, /connector /catalog /negotiations /transfers
 # use DCP instead of the provider above. Not valid when provider=DISABLED.
 # application.auth.dcp.enabled=false

--- a/tools/src/main/java/it/eng/tools/auth/AuthenticationMode.java
+++ b/tools/src/main/java/it/eng/tools/auth/AuthenticationMode.java
@@ -8,8 +8,8 @@ public enum AuthenticationMode {
     /** OAuth2/OIDC authentication via Keycloak. */
     KEYCLOAK,
 
-    /** Username and password authentication using locally stored credentials. */
-    BASIC,
+    /** Username and password authentication using internally-managed, locally stored credentials. */
+    INTERNAL,
 
     /** All endpoints are unprotected. For development and testing only. */
     DISABLED

--- a/tools/src/main/java/it/eng/tools/auth/AuthenticationModeResolver.java
+++ b/tools/src/main/java/it/eng/tools/auth/AuthenticationModeResolver.java
@@ -10,7 +10,7 @@ import org.springframework.util.StringUtils;
  * Resolves the active authentication mode from application properties.
  *
  * <p>The {@code application.auth.provider} property controls the authentication mode.
- * Supported values are {@code KEYCLOAK}, {@code BASIC}, and {@code DISABLED}.
+ * Supported values are {@code KEYCLOAK}, {@code INTERNAL}, and {@code DISABLED}.
  *
  * <p>When {@code application.auth.dcp.enabled=true}, protocol endpoints use DCP authentication
  * instead of the configured provider. This flag is invalid when combined with {@code DISABLED}
@@ -61,10 +61,10 @@ public final class AuthenticationModeResolver {
     private static AuthenticationMode parseProvider(String configuredProvider) {
         return switch (configuredProvider.trim().toUpperCase(Locale.ROOT)) {
             case "KEYCLOAK" -> AuthenticationMode.KEYCLOAK;
-            case "BASIC" -> AuthenticationMode.BASIC;
+            case "INTERNAL" -> AuthenticationMode.INTERNAL;
             case "DISABLED" -> AuthenticationMode.DISABLED;
             default -> throw new IllegalStateException(
-                    "Unsupported value '%s' for property '%s'. Supported values are KEYCLOAK, BASIC and DISABLED."
+                    "Unsupported value '%s' for property '%s'. Supported values are KEYCLOAK, INTERNAL and DISABLED."
                             .formatted(configuredProvider, AUTH_PROVIDER_PROPERTY)
             );
         };

--- a/tools/src/main/java/it/eng/tools/auth/condition/InternalAuthenticationModeCondition.java
+++ b/tools/src/main/java/it/eng/tools/auth/condition/InternalAuthenticationModeCondition.java
@@ -8,19 +8,19 @@ import it.eng.tools.auth.AuthenticationMode;
 import it.eng.tools.auth.AuthenticationModeResolver;
 
 /**
- * Matches when Basic authentication mode is active.
+ * Matches when Internal authentication mode is active.
  */
-public class BasicAuthenticationModeCondition implements Condition {
+public class InternalAuthenticationModeCondition implements Condition {
 
     /**
-     * Evaluates whether the current environment resolves to Basic mode.
+     * Evaluates whether the current environment resolves to Internal mode.
      *
      * @param context the condition context
      * @param metadata the annotated type metadata
-     * @return {@code true} when Basic mode is active
+     * @return {@code true} when Internal mode is active
      */
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-        return AuthenticationModeResolver.resolve(context.getEnvironment()) == AuthenticationMode.BASIC;
+        return AuthenticationModeResolver.resolve(context.getEnvironment()) == AuthenticationMode.INTERNAL;
     }
 }

--- a/tools/src/main/java/it/eng/tools/auth/condition/InternalOrDisabledAuthenticationModeCondition.java
+++ b/tools/src/main/java/it/eng/tools/auth/condition/InternalOrDisabledAuthenticationModeCondition.java
@@ -8,21 +8,21 @@ import it.eng.tools.auth.AuthenticationMode;
 import it.eng.tools.auth.AuthenticationModeResolver;
 
 /**
- * Matches when the application is running in Basic or Disabled authentication mode.
+ * Matches when the application is running in Internal or Disabled authentication mode.
  * Used to conditionally load MongoDB-based user management which is not available in Keycloak mode.
  */
-public class BasicOrDisabledAuthenticationModeCondition implements Condition {
+public class InternalOrDisabledAuthenticationModeCondition implements Condition {
 
     /**
-     * Evaluates whether the current environment resolves to Basic or Disabled mode.
+     * Evaluates whether the current environment resolves to Internal or Disabled mode.
      *
      * @param context the condition context
      * @param metadata the annotated type metadata
-     * @return {@code true} when Basic or Disabled mode is active
+     * @return {@code true} when Internal or Disabled mode is active
      */
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         AuthenticationMode mode = AuthenticationModeResolver.resolve(context.getEnvironment());
-        return mode == AuthenticationMode.BASIC || mode == AuthenticationMode.DISABLED;
+        return mode == AuthenticationMode.INTERNAL || mode == AuthenticationMode.DISABLED;
     }
 }

--- a/tools/src/main/java/it/eng/tools/controller/ApiEndpoints.java
+++ b/tools/src/main/java/it/eng/tools/controller/ApiEndpoints.java
@@ -65,4 +65,9 @@ public interface ApiEndpoints {
      * Tools module - v1 API endpoint for tenant management.
      */
     public static final String TENANTS_V1 = "/api/v1/tenants";
+
+    /**
+     * Connector module - v1 API endpoint for the unified auth contract (login/refresh/logout).
+     */
+    public static final String AUTH_V1 = "/api/v1/auth";
 }

--- a/tools/src/main/java/it/eng/tools/util/CredentialUtils.java
+++ b/tools/src/main/java/it/eng/tools/util/CredentialUtils.java
@@ -32,7 +32,7 @@ public class CredentialUtils {
 
 	/**
 	 * Retrieves connector credentials for connector-to-connector communication.
-	 * Uses JWT token from Keycloak/BASIC/DISABLED.
+	 * Uses JWT token from Keycloak/INTERNAL/DISABLED.
 	 *
 	 * @return Bearer token authorization header
 	 */
@@ -54,7 +54,7 @@ public class CredentialUtils {
 	 * {@code Authorization: Bearer} header value. Otherwise, Basic Auth credentials are
 	 * built using the {@code internal-service} username and the configured shared secret,
 	 * which maps to {@link it.eng.connector.configuration.InternalServiceAuthenticationProvider}
-	 * in BASIC mode. Using the internal-service account ensures the principal has
+	 * in INTERNAL mode. Using the internal-service account ensures the principal has
 	 * {@code tenantId=null}, allowing {@code ApiTenantContextFilter} to honour the
 	 * {@code X-Tenant-Id} request header for correct multi-tenant routing.
 	 *

--- a/tools/src/test/java/it/eng/tools/auth/AuthenticationModeResolverTest.java
+++ b/tools/src/test/java/it/eng/tools/auth/AuthenticationModeResolverTest.java
@@ -19,12 +19,12 @@ class AuthenticationModeResolverTest {
     }
 
     @Test
-    @DisplayName("Should resolve Basic mode from the provider property")
-    void resolveBasicModeFromProviderProperty() {
+    @DisplayName("Should resolve Internal mode from the provider property")
+    void resolveInternalModeFromProviderProperty() {
         MockEnvironment environment = new MockEnvironment()
-                .withProperty(AuthenticationModeResolver.AUTH_PROVIDER_PROPERTY, "BASIC");
+                .withProperty(AuthenticationModeResolver.AUTH_PROVIDER_PROPERTY, "INTERNAL");
 
-        assertEquals(AuthenticationMode.BASIC, AuthenticationModeResolver.resolve(environment));
+        assertEquals(AuthenticationMode.INTERNAL, AuthenticationModeResolver.resolve(environment));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Pure mechanical rename ahead of the AUTH1 unified login contract slice — no behavioral change.

- `AuthenticationMode.BASIC` → `INTERNAL` (enum constant + Javadoc)
- `AuthenticationModeResolver`: `parseProvider()` switch case + Javadoc + `IllegalStateException` message updated
- `BasicAuthenticationModeCondition` → `InternalAuthenticationModeCondition` (file + class rename)
- `BasicOrDisabledAuthenticationModeCondition` → `InternalOrDisabledAuthenticationModeCondition` (file + class rename)
- Updated `@Conditional` references, imports, Javadoc auth-matrix table, and inline comments in `ConnectorSecurityConfig`, `InternalServiceAuthenticationProvider`, `UserService`, `UserApiController`
- Added `ApiEndpoints.AUTH_V1 = "/api/v1/auth"` constant for sibling AUTH1 tasks
- `application.auth.provider=BASIC` → `INTERNAL` in `application-provider.properties`, `application-consumer.properties`, `application-tck.properties` (connector/src/main), and `application.properties` (connector/src/test)
- Updated `AuthenticationModeResolverTest` for the renamed value
- Fixed stale "BASIC" Javadoc mentions in `CredentialUtils.java`

## Scope note: `ci/docker/**`, `ci/tck/**`, `terraform/**`

The issue originally scoped these to AUTH4 (Newman auth-header switch lands together with that rename). However, because this rename has **no backward-compatibility alias** for the old `BASIC` value, any environment still configured with `application.auth.provider=BASIC` fails immediately at Spring context startup (`IllegalStateException`). This surfaced first as a hard CI failure (`ci/docker` Newman suites — connector containers failed to boot), and was then confirmed as a broader risk by self-review (`ci/tck`, `terraform`). After confirming with the user, scope was expanded to include:

- `ci/docker/connector_a_resources/application.properties`, `ci/docker/connector_b_resources/application.properties`
- `ci/tck/connector_tck_resources/application-tck.properties`
- `terraform/app-resources/connector_a_resources/application.properties`, `terraform/app-resources/connector_b_resources/application.properties`
- Plus the matching `#### Authentication provider: KEYCLOAK | BASIC | DISABLED` comment lines updated to `INTERNAL` in every touched properties file

This was necessary to keep every seeded/deployed environment bootable after merge; it does not change or expand AUTH4's own Newman auth-header work.

Closes #286

## Branch note

Per explicit instruction, this branch was cut from `feature/multitenant` (not a freshly synced `develop`), and this PR targets `feature/multitenant` to match the actual branch point.

## Verification results

Local sandbox has neither Docker nor JDK 21 installed, so the official `mvn clean verify` (Java 21 + Testcontainers) and `spotbugs-scan.sh` could not run here. As a substitute, ran full builds/tests with a local `-Dmaven.compiler.release=17` override (diagnostic only) plus the exact repo-scope grep from the issue's checklist:

- ✅ `mvn -pl tools -am clean test` (Java 17 override) — all tests pass, including updated `AuthenticationModeResolverTest` (9/9)
- ✅ `mvn -pl connector -am clean test` (Java 17 override, ITs skipped) — all unit tests across `tools`, `catalog`, `negotiation`, `data-transfer`, `connector` pass
- ✅ `mvn -pl tools,connector -am checkstyle:check` (Java 17 override) — 0 violations
- ✅ `grep -rn "AuthenticationMode\.BASIC\|BasicAuthenticationModeCondition\|BasicOrDisabledAuthenticationModeCondition\|application.auth.provider=BASIC" --include=*.java --include=*.properties .` — zero matches (excluding gitignored `connector/target/**` build output)
- ✅ GitHub Actions CI (Docker-based Newman suites + connector-tests): all 8 checks pass — `build-and-push-image`, `api-endpoints-tests`, `connector-tests`, `dataset-api-tests`, `datatransfer-api-http-pull-tests`, `datatransfer-api-http-push-tests`, `negotiation-api-with-counteroffer-tests`, `negotiation-api-without-counteroffer-tests`
- ✅ Self-review (`/code-review`, high effort) findings addressed — see PR comments for the detailed breakdown
- ⚠️ `mvn clean verify` (Java 21 + Docker, Testcontainers ITs) and `./spotbugs-scan.sh` — **not run locally** (environment lacks Docker and JDK 21); GitHub Actions CI served as the authoritative gate for the Docker-dependent checks per the shared verification policy

## Files changed

- `tools/src/main/java/it/eng/tools/auth/AuthenticationMode.java`
- `tools/src/main/java/it/eng/tools/auth/AuthenticationModeResolver.java`
- `tools/src/main/java/it/eng/tools/auth/condition/BasicAuthenticationModeCondition.java` → `InternalAuthenticationModeCondition.java`
- `tools/src/main/java/it/eng/tools/auth/condition/BasicOrDisabledAuthenticationModeCondition.java` → `InternalOrDisabledAuthenticationModeCondition.java`
- `tools/src/main/java/it/eng/tools/controller/ApiEndpoints.java`
- `tools/src/main/java/it/eng/tools/util/CredentialUtils.java`
- `tools/src/test/java/it/eng/tools/auth/AuthenticationModeResolverTest.java`
- `connector/src/main/java/it/eng/connector/configuration/ConnectorSecurityConfig.java`
- `connector/src/main/java/it/eng/connector/configuration/InternalServiceAuthenticationProvider.java`
- `connector/src/main/java/it/eng/connector/service/UserService.java`
- `connector/src/main/java/it/eng/connector/rest/api/UserApiController.java`
- `connector/src/main/resources/application-provider.properties`
- `connector/src/main/resources/application-consumer.properties`
- `connector/src/main/resources/application-tck.properties`
- `connector/src/test/resources/application.properties`
- `ci/docker/connector_a_resources/application.properties`
- `ci/docker/connector_b_resources/application.properties`
- `ci/tck/connector_tck_resources/application-tck.properties`
- `terraform/app-resources/connector_a_resources/application.properties`
- `terraform/app-resources/connector_b_resources/application.properties`
