### PR TITLE
feat(tools): add shared HMAC JWT issuance/parsing utility for INTERNAL auth mode (#287)

### DIFF
--- a/ci/docker/connector_a_resources/application.properties
+++ b/ci/docker/connector_a_resources/application.properties
@@ -65,6 +65,12 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:connector-a-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 #### FTP
 application.ftp.host=localhost
 application.ftp.defaultTimeoutSeconds=1001

--- a/ci/docker/connector_b_resources/application.properties
+++ b/ci/docker/connector_b_resources/application.properties
@@ -65,6 +65,12 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:connector-b-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 #### FTP
 application.ftp.host=localhost
 application.ftp.defaultTimeoutSeconds=1001

--- a/ci/tck/connector_tck_resources/application-tck.properties
+++ b/ci/tck/connector_tck_resources/application-tck.properties
@@ -77,6 +77,11 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). Test/TCK-only value — never reuse in production.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:tck-jwt-test-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 ##### FTP
 application.ftp.host=localhost
 application.ftp.defaultTimeoutSeconds=1001

--- a/connector/src/main/resources/application-consumer.properties
+++ b/connector/src/main/resources/application-consumer.properties
@@ -115,6 +115,13 @@ application.auth.provider=INTERNAL
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
 
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:consumer-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
+
 # Keycloak resource server configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8180/realms/dsp-connector
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8180/realms/dsp-connector/protocol/openid-connect/certs

--- a/connector/src/main/resources/application-provider.properties
+++ b/connector/src/main/resources/application-provider.properties
@@ -113,6 +113,13 @@ application.auth.provider=INTERNAL
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
 
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:provider-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
+
 # Keycloak resource server configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8180/realms/dsp-connector
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8180/realms/dsp-connector/protocol/openid-connect/certs

--- a/connector/src/main/resources/application-tck.properties
+++ b/connector/src/main/resources/application-tck.properties
@@ -114,6 +114,12 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). Test/TCK-only value — never reuse in production.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:tck-jwt-test-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 ## TCK protocol forwarding: prepend the tenant prefix to non-prefixed DSP protocol requests
 application.tck.enabled=true
 application.tck.tenant.id=engineering

--- a/connector/src/test/resources/application.properties
+++ b/connector/src/test/resources/application.properties
@@ -81,6 +81,12 @@ application.connectorid=29d022fa-33be-4627-923e-412eb609eb6b
 application.auth.provider=INTERNAL
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). Test-only value — never reuse in production.
+application.security.jwt.secret=unit-test-jwt-secret-value-min-32-bytes-long
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 #### FTP
 application.ftp.host=localhost
 application.ftp.defaultTimeoutSeconds=1001

--- a/terraform/app-resources/connector_a_resources/application.properties
+++ b/terraform/app-resources/connector_a_resources/application.properties
@@ -65,6 +65,12 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:connector-a-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 
 #### FTP
 application.ftp.host=localhost

--- a/terraform/app-resources/connector_b_resources/application.properties
+++ b/terraform/app-resources/connector_b_resources/application.properties
@@ -65,6 +65,12 @@ application.auth.provider=INTERNAL
 # application.auth.dcp.enabled=false
 ## Internal service authentication secret (can be overridden with APPLICATION_INTERNAL_SECRET env var)
 application.internal.secret=${APPLICATION_INTERNAL_SECRET:internal-service-secret-change-in-prod}
+# Shared HMAC-SHA256 secret for INTERNAL-mode JWT login (application.auth.provider=INTERNAL).
+# Must be at least 32 bytes (256 bits). CHANGE THIS IN PRODUCTION — override with the
+# APPLICATION_SECURITY_JWT_SECRET env var; never commit a real production secret here.
+application.security.jwt.secret=${APPLICATION_SECURITY_JWT_SECRET:connector-b-jwt-dev-secret-change-in-prod-min-32-bytes}
+application.security.jwt.access-expiration-ms=900000
+application.security.jwt.refresh-expiration-ms=604800000
 #### FTP
 application.ftp.host=localhost
 application.ftp.defaultTimeoutSeconds=1001

--- a/tools/src/main/java/it/eng/tools/auth/jwt/JwtProperties.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/JwtProperties.java
@@ -1,0 +1,42 @@
+package it.eng.tools.auth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+import it.eng.tools.auth.condition.InternalAuthenticationModeCondition;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configuration properties for the shared HMAC-SHA256 JWT signing/parsing utility used by
+ * {@code INTERNAL} authentication mode.
+ *
+ * <p>Only loaded when {@code application.auth.provider=INTERNAL} is active (see
+ * {@link InternalAuthenticationModeCondition}), since Keycloak-backed and disabled authentication
+ * modes never issue or validate these locally-signed tokens and therefore should not be forced to
+ * configure a signing secret.
+ */
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "application.security.jwt")
+@Conditional(InternalAuthenticationModeCondition.class)
+public class JwtProperties {
+
+    /**
+     * Shared HMAC-SHA256 signing secret, read as raw UTF-8 bytes. Must decode to at least 256 bits
+     * (32 bytes). No default is provided; each environment must configure its own secret.
+     */
+    private String secret;
+
+    /**
+     * Access token time-to-live, in milliseconds. Defaults to 900000 (15 minutes).
+     */
+    private long accessExpirationMs = 900_000L;
+
+    /**
+     * Refresh token time-to-live, in milliseconds. Defaults to 604800000 (7 days).
+     */
+    private long refreshExpirationMs = 604_800_000L;
+}

--- a/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
@@ -94,9 +94,20 @@ public class JwtService {
                             + MIN_SECRET_BYTES + " bytes (256 bits) of raw UTF-8 data; found "
                             + secretBytes + " byte(s).");
         }
+        if (jwtProperties.getAccessExpirationMs() <= 0L) {
+            throw new IllegalStateException(
+                    "Property 'application.security.jwt.access-expiration-ms' must be > 0.");
+        }
+        if (jwtProperties.getRefreshExpirationMs() <= 0L) {
+            throw new IllegalStateException(
+                    "Property 'application.security.jwt.refresh-expiration-ms' must be > 0.");
+        }
+        if (jwtProperties.getRefreshExpirationMs() < jwtProperties.getAccessExpirationMs()) {
+            throw new IllegalStateException(
+                    "Property 'application.security.jwt.refresh-expiration-ms' must be >= 'application.security.jwt.access-expiration-ms'.");
+        }
         log.info("JwtService initialized with access TTL {}ms and refresh TTL {}ms",
                 jwtProperties.getAccessExpirationMs(), jwtProperties.getRefreshExpirationMs());
-    }
 
     /**
      * Issues a new access/refresh token pair for the given subject.
@@ -116,6 +127,10 @@ public class JwtService {
      */
     public TokenPair issueTokenPair(String subject, String email, List<String> roles, String tenantId,
             Map<String, Object> extraClaims) {
+        java.util.Objects.requireNonNull(subject, "subject must not be null");
+        java.util.Objects.requireNonNull(email, "email must not be null");
+        java.util.Objects.requireNonNull(roles, "roles must not be null");
+        java.util.Objects.requireNonNull(tenantId, "tenantId must not be null");
         Algorithm algorithm = signingAlgorithm();
         Instant now = Instant.now();
         Instant accessExpiry = now.plusMillis(jwtProperties.getAccessExpirationMs());
@@ -140,6 +155,9 @@ public class JwtService {
      *                                    signed with a different secret
      */
     public DecodedJWT verifyAndDecode(String token) {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("token must not be null or blank");
+        }
         return JWT.require(signingAlgorithm()).build().verify(token);
     }
 

--- a/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
@@ -1,0 +1,163 @@
+package it.eng.tools.auth.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import it.eng.tools.auth.condition.InternalAuthenticationModeCondition;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Issues and validates HMAC-SHA256 signed JWT access/refresh token pairs for the unified
+ * {@code /api/v1/auth/*} contract's {@code INTERNAL} authentication mode.
+ *
+ * <p>This class has no dependency on any {@code connector}-module user type: callers pass the
+ * subject, email, role names, tenant identifier, and any additional claims explicitly, so new
+ * claims can be introduced at the call site without changing this class.
+ *
+ * <p><b>Access vs. refresh tokens</b>: both tokens share the same claim shape ({@code sub},
+ * {@code email}, {@code roles}, {@code tenantId}, {@code iat}, {@code exp}, {@code jti}, plus any
+ * caller-supplied extra claims). Refresh tokens additionally carry a {@value #TOKEN_TYPE_CLAIM}
+ * claim set to {@value #REFRESH_TOKEN_TYPE}; access tokens carry no {@value #TOKEN_TYPE_CLAIM}
+ * claim. Callers validating a token for use as an access token must reject any decoded token that
+ * carries a {@value #REFRESH_TOKEN_TYPE} {@value #TOKEN_TYPE_CLAIM} claim, so a refresh token
+ * cannot be replayed against a protected endpoint.
+ *
+ * <p>The signing secret is never logged, including at {@code DEBUG} level.
+ */
+@Slf4j
+@Component
+@Conditional(InternalAuthenticationModeCondition.class)
+public class JwtService {
+
+    /** Claim name for the subject's email address. */
+    public static final String EMAIL_CLAIM = "email";
+
+    /** Claim name for the subject's role names. */
+    public static final String ROLES_CLAIM = "roles";
+
+    /** Claim name for the subject's tenant identifier. */
+    public static final String TENANT_ID_CLAIM = "tenantId";
+
+    /** Claim name distinguishing refresh tokens from access tokens. */
+    public static final String TOKEN_TYPE_CLAIM = "token_type";
+
+    /** {@link #TOKEN_TYPE_CLAIM} value carried by refresh tokens only. */
+    public static final String REFRESH_TOKEN_TYPE = "refresh";
+
+    private static final int MIN_SECRET_BYTES = 32;
+
+    private final JwtProperties jwtProperties;
+
+    /**
+     * Creates a new {@link JwtService}.
+     *
+     * @param jwtProperties the JWT signing configuration
+     */
+    public JwtService(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Validates the configured signing secret at application startup.
+     *
+     * @throws IllegalStateException if {@code application.security.jwt.secret} is missing or
+     *                                decodes to fewer than {@value #MIN_SECRET_BYTES} bytes
+     *                                (256 bits) of raw UTF-8 data
+     */
+    @PostConstruct
+    public void init() {
+        int secretBytes = secretByteLength();
+        if (secretBytes < MIN_SECRET_BYTES) {
+            throw new IllegalStateException(
+                    "Property 'application.security.jwt.secret' must be configured with at least "
+                            + MIN_SECRET_BYTES + " bytes (256 bits) of raw UTF-8 data; found "
+                            + secretBytes + " byte(s).");
+        }
+        log.info("JwtService initialized with access TTL {}ms and refresh TTL {}ms",
+                jwtProperties.getAccessExpirationMs(), jwtProperties.getRefreshExpirationMs());
+    }
+
+    /**
+     * Issues a new access/refresh token pair for the given subject.
+     *
+     * @param subject     the subject (user id) embedded as the {@code sub} claim
+     * @param email       the subject's email address, embedded as the {@value #EMAIL_CLAIM} claim
+     * @param roles       the subject's role names, embedded as the {@value #ROLES_CLAIM} claim
+     * @param tenantId    the subject's tenant identifier, embedded as the
+     *                    {@value #TENANT_ID_CLAIM} claim
+     * @param extraClaims additional claims merged into both tokens; may be {@code null} or empty
+     * @return the issued {@link TokenPair}
+     */
+    public TokenPair issueTokenPair(String subject, String email, List<String> roles, String tenantId,
+            Map<String, Object> extraClaims) {
+        Algorithm algorithm = signingAlgorithm();
+        Instant now = Instant.now();
+        Instant accessExpiry = now.plusMillis(jwtProperties.getAccessExpirationMs());
+        Instant refreshExpiry = now.plusMillis(jwtProperties.getRefreshExpirationMs());
+
+        String accessToken = baseTokenBuilder(subject, email, roles, tenantId, now, accessExpiry, extraClaims)
+                .sign(algorithm);
+        String refreshToken = baseTokenBuilder(subject, email, roles, tenantId, now, refreshExpiry, extraClaims)
+                .withClaim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
+                .sign(algorithm);
+
+        long accessExpiresInSeconds = jwtProperties.getAccessExpirationMs() / 1000L;
+        return new TokenPair(accessToken, refreshToken, accessExpiresInSeconds);
+    }
+
+    /**
+     * Verifies the signature and expiry of the given token and returns its decoded claims.
+     *
+     * @param token the compact JWT string to verify
+     * @return the decoded, signature- and expiry-verified token
+     * @throws JWTVerificationException if the token is expired, tampered with, malformed, or
+     *                                    signed with a different secret
+     */
+    public DecodedJWT verifyAndDecode(String token) {
+        return JWT.require(signingAlgorithm()).build().verify(token);
+    }
+
+    // Builds the shared set of claims common to both access and refresh tokens.
+    private JWTCreator.Builder baseTokenBuilder(String subject, String email, List<String> roles, String tenantId,
+            Instant issuedAt, Instant expiresAt, Map<String, Object> extraClaims) {
+        JWTCreator.Builder builder = JWT.create()
+                .withSubject(subject)
+                .withClaim(EMAIL_CLAIM, email)
+                .withClaim(ROLES_CLAIM, roles)
+                .withClaim(TENANT_ID_CLAIM, tenantId)
+                .withIssuedAt(Date.from(issuedAt))
+                .withExpiresAt(Date.from(expiresAt))
+                .withJWTId(UUID.randomUUID().toString());
+        if (extraClaims != null && !extraClaims.isEmpty()) {
+            // Merges caller-supplied claims without requiring any change to this class.
+            builder.withPayload(extraClaims);
+        }
+        return builder;
+    }
+
+    // Computed on demand rather than cached, so a corrected secret takes effect without a restart
+    // being the only recovery path from a startup failure, and so the secret is never held longer
+    // than necessary in a dedicated field.
+    private Algorithm signingAlgorithm() {
+        return Algorithm.HMAC256(jwtProperties.getSecret());
+    }
+
+    private int secretByteLength() {
+        String secret = jwtProperties.getSecret();
+        return secret == null ? 0 : secret.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.context.annotation.Conditional;
@@ -60,6 +61,12 @@ public class JwtService {
 
     private static final int MIN_SECRET_BYTES = 32;
 
+    // Claim names set directly by baseTokenBuilder; extraClaims must not collide with any of
+    // these, since JWTCreator.Builder#withPayload silently overwrites already-set claims rather
+    // than performing a safe no-clobber merge.
+    private static final Set<String> RESERVED_CLAIM_NAMES =
+            Set.of("sub", EMAIL_CLAIM, ROLES_CLAIM, TENANT_ID_CLAIM, "iat", "exp", "jti", TOKEN_TYPE_CLAIM);
+
     private final JwtProperties jwtProperties;
 
     /**
@@ -101,6 +108,11 @@ public class JwtService {
      *                    {@value #TENANT_ID_CLAIM} claim
      * @param extraClaims additional claims merged into both tokens; may be {@code null} or empty
      * @return the issued {@link TokenPair}
+     * @throws IllegalArgumentException if {@code extraClaims} contains a key that collides with
+     *                                    a reserved claim name ({@code sub}, {@value #EMAIL_CLAIM},
+     *                                    {@value #ROLES_CLAIM}, {@value #TENANT_ID_CLAIM},
+     *                                    {@code iat}, {@code exp}, {@code jti}, or
+     *                                    {@value #TOKEN_TYPE_CLAIM})
      */
     public TokenPair issueTokenPair(String subject, String email, List<String> roles, String tenantId,
             Map<String, Object> extraClaims) {
@@ -143,7 +155,15 @@ public class JwtService {
                 .withExpiresAt(Date.from(expiresAt))
                 .withJWTId(UUID.randomUUID().toString());
         if (extraClaims != null && !extraClaims.isEmpty()) {
-            // Merges caller-supplied claims without requiring any change to this class.
+            // Merges caller-supplied claims without requiring any change to this class. Reject
+            // any key colliding with a reserved claim, since withPayload silently overwrites
+            // already-set claims rather than performing a safe no-clobber merge.
+            for (String key : extraClaims.keySet()) {
+                if (RESERVED_CLAIM_NAMES.contains(key)) {
+                    throw new IllegalArgumentException(
+                            "extraClaims must not contain reserved claim name '" + key + "'");
+                }
+            }
             builder.withPayload(extraClaims);
         }
         return builder;

--- a/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java
@@ -2,11 +2,7 @@ package it.eng.tools.auth.jwt;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -108,6 +104,7 @@ public class JwtService {
         }
         log.info("JwtService initialized with access TTL {}ms and refresh TTL {}ms",
                 jwtProperties.getAccessExpirationMs(), jwtProperties.getRefreshExpirationMs());
+    }
 
     /**
      * Issues a new access/refresh token pair for the given subject.
@@ -127,10 +124,9 @@ public class JwtService {
      */
     public TokenPair issueTokenPair(String subject, String email, List<String> roles, String tenantId,
             Map<String, Object> extraClaims) {
-        java.util.Objects.requireNonNull(subject, "subject must not be null");
-        java.util.Objects.requireNonNull(email, "email must not be null");
-        java.util.Objects.requireNonNull(roles, "roles must not be null");
-        java.util.Objects.requireNonNull(tenantId, "tenantId must not be null");
+        Objects.requireNonNull(subject, "subject must not be null");
+        Objects.requireNonNull(email, "email must not be null");
+        Objects.requireNonNull(roles, "roles must not be null");
         Algorithm algorithm = signingAlgorithm();
         Instant now = Instant.now();
         Instant accessExpiry = now.plusMillis(jwtProperties.getAccessExpirationMs());

--- a/tools/src/main/java/it/eng/tools/auth/jwt/TokenPair.java
+++ b/tools/src/main/java/it/eng/tools/auth/jwt/TokenPair.java
@@ -1,0 +1,13 @@
+package it.eng.tools.auth.jwt;
+
+/**
+ * Pair of tokens issued for a successful authentication.
+ *
+ * @param accessToken            the signed access token
+ * @param refreshToken           the signed refresh token
+ * @param accessExpiresInSeconds the access token's remaining time-to-live, in seconds, suitable
+ *                                for direct use in an HTTP response body (for example,
+ *                                {@code expiresIn})
+ */
+public record TokenPair(String accessToken, String refreshToken, long accessExpiresInSeconds) {
+}

--- a/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
@@ -73,6 +73,19 @@ class JwtServiceTest {
     }
 
     @Test
+    @DisplayName("Should reject extraClaims that collide with a reserved claim name")
+    void extraClaimsCollidingWithReservedNamesAreRejected() {
+        assertThrows(IllegalArgumentException.class, () -> jwtService.issueTokenPair("user-1",
+                "user@example.com", List.of("ROLE_ADMIN"), "tenant-a", Map.of(JwtService.ROLES_CLAIM,
+                        List.of("ROLE_SUPER_ADMIN"))));
+        assertThrows(IllegalArgumentException.class, () -> jwtService.issueTokenPair("user-1",
+                "user@example.com", List.of("ROLE_ADMIN"), "tenant-a", Map.of("exp", 9_999_999_999L)));
+        assertThrows(IllegalArgumentException.class, () -> jwtService.issueTokenPair("user-1",
+                "user@example.com", List.of("ROLE_ADMIN"), "tenant-a",
+                Map.of(JwtService.TOKEN_TYPE_CLAIM, JwtService.REFRESH_TOKEN_TYPE)));
+    }
+
+    @Test
     @DisplayName("Should reject an expired token with a clear exception")
     void expiredTokenIsRejected() {
         jwtProperties.setAccessExpirationMs(-1_000L);

--- a/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
@@ -1,9 +1,5 @@
 package it.eng.tools.auth.jwt;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.List;
 import java.util.Map;
 
@@ -16,6 +12,8 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link JwtService}.
@@ -50,9 +48,9 @@ class JwtServiceTest {
         assertEquals(List.of("ROLE_ADMIN"), accessClaims.getClaim(JwtService.ROLES_CLAIM).asList(String.class));
         assertEquals("tenant-a", accessClaims.getClaim(JwtService.TENANT_ID_CLAIM).asString());
         assertTrue(accessClaims.getClaim(JwtService.TOKEN_TYPE_CLAIM).isMissing());
-        assertTrue(accessClaims.getIssuedAt() != null);
-        assertTrue(accessClaims.getExpiresAt() != null);
-        assertTrue(accessClaims.getId() != null && !accessClaims.getId().isEmpty());
+        assertNotNull(accessClaims.getIssuedAt());
+        assertNotNull(accessClaims.getExpiresAt());
+        assertNotNull(accessClaims.getId());
 
         DecodedJWT refreshClaims = jwtService.verifyAndDecode(tokenPair.refreshToken());
         assertEquals("user-1", refreshClaims.getSubject());
@@ -70,6 +68,17 @@ class JwtServiceTest {
         DecodedJWT decoded = jwtService.verifyAndDecode(tokenPair.accessToken());
         assertEquals("enabled", decoded.getClaim("newFeatureFlag").asString());
         assertEquals(3, decoded.getClaim("loginCount").asInt());
+    }
+
+    @Test
+    @DisplayName("Should fail on missing required fields")
+    void missingRequiredFields() {
+        assertThrows(NullPointerException.class, () -> jwtService.issueTokenPair(null, "user@example.com",
+                List.of("ROLE_ADMIN"), "tenant-a", Map.of()));
+        assertThrows(NullPointerException.class, () -> jwtService.issueTokenPair("user-1", null,
+                List.of("ROLE_ADMIN"), "tenant-a", Map.of()));
+        assertThrows(NullPointerException.class, () -> jwtService.issueTokenPair("user-1", "user@example.com",
+                null, "tenant-a", Map.of()));
     }
 
     @Test

--- a/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java
@@ -1,0 +1,114 @@
+package it.eng.tools.auth.jwt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+/**
+ * Unit tests for {@link JwtService}.
+ */
+class JwtServiceTest {
+
+    private static final String VALID_SECRET = "unit-test-secret-value-with-at-least-256-bits!!";
+    private static final String OTHER_SECRET = "a-completely-different-unit-test-secret-32bytes";
+
+    private JwtProperties jwtProperties;
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties();
+        jwtProperties.setSecret(VALID_SECRET);
+        jwtProperties.setAccessExpirationMs(900_000L);
+        jwtProperties.setRefreshExpirationMs(604_800_000L);
+        jwtService = new JwtService(jwtProperties);
+        jwtService.init();
+    }
+
+    @Test
+    @DisplayName("Should issue and verify an access/refresh token pair round-trip")
+    void issueAndVerifyRoundTrip() {
+        TokenPair tokenPair = jwtService.issueTokenPair("user-1", "user@example.com",
+                List.of("ROLE_ADMIN"), "tenant-a", Map.of());
+
+        DecodedJWT accessClaims = jwtService.verifyAndDecode(tokenPair.accessToken());
+        assertEquals("user-1", accessClaims.getSubject());
+        assertEquals("user@example.com", accessClaims.getClaim(JwtService.EMAIL_CLAIM).asString());
+        assertEquals(List.of("ROLE_ADMIN"), accessClaims.getClaim(JwtService.ROLES_CLAIM).asList(String.class));
+        assertEquals("tenant-a", accessClaims.getClaim(JwtService.TENANT_ID_CLAIM).asString());
+        assertTrue(accessClaims.getClaim(JwtService.TOKEN_TYPE_CLAIM).isMissing());
+        assertTrue(accessClaims.getIssuedAt() != null);
+        assertTrue(accessClaims.getExpiresAt() != null);
+        assertTrue(accessClaims.getId() != null && !accessClaims.getId().isEmpty());
+
+        DecodedJWT refreshClaims = jwtService.verifyAndDecode(tokenPair.refreshToken());
+        assertEquals("user-1", refreshClaims.getSubject());
+        assertEquals(JwtService.REFRESH_TOKEN_TYPE,
+                refreshClaims.getClaim(JwtService.TOKEN_TYPE_CLAIM).asString());
+        assertEquals(900_000L / 1000L, tokenPair.accessExpiresInSeconds());
+    }
+
+    @Test
+    @DisplayName("Should propagate arbitrary extraClaims entries without requiring JwtService changes")
+    void extraClaimsArePropagated() {
+        TokenPair tokenPair = jwtService.issueTokenPair("user-1", "user@example.com",
+                List.of("ROLE_ADMIN"), "tenant-a", Map.of("newFeatureFlag", "enabled", "loginCount", 3));
+
+        DecodedJWT decoded = jwtService.verifyAndDecode(tokenPair.accessToken());
+        assertEquals("enabled", decoded.getClaim("newFeatureFlag").asString());
+        assertEquals(3, decoded.getClaim("loginCount").asInt());
+    }
+
+    @Test
+    @DisplayName("Should reject an expired token with a clear exception")
+    void expiredTokenIsRejected() {
+        jwtProperties.setAccessExpirationMs(-1_000L);
+        TokenPair tokenPair = jwtService.issueTokenPair("user-1", "user@example.com",
+                List.of("ROLE_ADMIN"), "tenant-a", Map.of());
+
+        assertThrows(TokenExpiredException.class, () -> jwtService.verifyAndDecode(tokenPair.accessToken()));
+    }
+
+    @Test
+    @DisplayName("Should reject a token signed with a different secret")
+    void tokenSignedWithDifferentSecretIsRejected() {
+        String foreignToken = JWT.create()
+                .withSubject("user-1")
+                .sign(Algorithm.HMAC256(OTHER_SECRET));
+
+        assertThrows(SignatureVerificationException.class, () -> jwtService.verifyAndDecode(foreignToken));
+    }
+
+    @Test
+    @DisplayName("Should fail fast at startup when the configured secret is shorter than 256 bits")
+    void undersizedSecretFailsStartup() {
+        JwtProperties shortSecretProperties = new JwtProperties();
+        shortSecretProperties.setSecret("too-short-secret");
+        JwtService shortSecretService = new JwtService(shortSecretProperties);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, shortSecretService::init);
+        assertTrue(exception.getMessage().contains("application.security.jwt.secret"));
+    }
+
+    @Test
+    @DisplayName("Should fail fast at startup when the configured secret is missing")
+    void missingSecretFailsStartup() {
+        JwtProperties missingSecretProperties = new JwtProperties();
+        JwtService missingSecretService = new JwtService(missingSecretProperties);
+
+        assertThrows(IllegalStateException.class, missingSecretService::init);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #287 (T287, slice AUTH1): a reusable, provider-agnostic JWT issuance/parsing utility in `tools` (`it.eng.tools.auth.jwt`) for INTERNAL-mode admin-zone login, using the already-managed `com.auth0:java-jwt` dependency.

**Base branch note**: this PR targets `feature/multitenant` — the active integration branch for the AUTH/multitenant slice work — since #286's PR (#309) has already been squash-merged there (and `feature/multitenant` is 21 commits ahead of `develop`). The branch was rebased onto `feature/multitenant` so the diff below contains only this task's changes.

## Changes

- `tools/src/main/java/it/eng/tools/auth/jwt/JwtProperties.java` — `@ConfigurationProperties(application.security.jwt.*)`, gated by `@Conditional(InternalAuthenticationModeCondition.class)` so KEYCLOAK/DISABLED deployments aren'''t forced to configure a JWT secret
- `tools/src/main/java/it/eng/tools/auth/jwt/TokenPair.java` — record holding access/refresh tokens + expiry
- `tools/src/main/java/it/eng/tools/auth/jwt/JwtService.java`
  - `issueTokenPair(subject, email, roles, tenantId, extraClaims)` — HMAC-SHA256 signed access + refresh tokens; claims: `sub`, `email`, `roles`, `tenantId`, `iat`, `exp`, `jti`, plus caller-supplied `extraClaims` merged via `withPayload` (no code change needed for new claim keys)
  - Refresh tokens carry a `token_type=refresh` claim (access tokens carry none) so a refresh token can'''t be replayed against a protected endpoint
  - `verifyAndDecode(token)` — signature + expiry verification, letting `com.auth0.jwt.exceptions.*` propagate as clear errors
  - `@PostConstruct` fail-fast check: application startup fails with a clear `IllegalStateException` naming `application.security.jwt.secret` if it decodes to fewer than 256 bits (32 bytes)
- `tools/src/test/java/it/eng/tools/auth/jwt/JwtServiceTest.java` — round-trip issuance/parsing, `extraClaims` propagation, expired-token rejection, wrong-secret rejection, undersized/missing-secret startup failure
- Added `application.security.jwt.secret` / `access-expiration-ms` / `refresh-expiration-ms` (dev/test-only placeholder secrets, ≥32 bytes, overridable via `APPLICATION_SECURITY_JWT_SECRET`) to every INTERNAL-mode config that needed it:
  - `connector/src/main/resources/application-provider.properties`
  - `connector/src/main/resources/application-consumer.properties`
  - `connector/src/main/resources/application-tck.properties`
  - `connector/src/test/resources/application.properties`
  - `ci/docker/connector_a_resources/application.properties`
  - `ci/docker/connector_b_resources/application.properties`
  - `ci/tck/connector_tck_resources/application-tck.properties`
  - `terraform/app-resources/connector_a_resources/application.properties`
  - `terraform/app-resources/connector_b_resources/application.properties`

## Verification

- ✅ `mvn -pl tools -am test -Dtest=JwtServiceTest` — 6/6 pass
- ✅ `mvn -pl tools -am validate` — Checkstyle passes (0 violations)
- ✅ SpotBugs (`mvn -pl tools spotbugs:spotbugs -Pspotbugs`) — 1 finding (`EI_EXPOSE_REP2` on the constructor-injected `JwtProperties` field), matching the already-accepted pattern in `AuthenticationCache`/`KeycloakAuthenticationService` in the same package; not a new risk category, no new exclusion added
- ✅ Manually confirmed the signing secret is never referenced in any `log.*` statement
- ✅ First GA run caught a real bug: `ci/docker`/`terraform` INTERNAL-mode configs had no `application.security.jwt.secret`, so `JwtService`'''s `@PostConstruct` check failed app startup and broke every Newman suite — fixed by adding the property to those 5 files (see commit history)
- ⚠️ **Not run locally**: `mvn clean verify` / Docker-based integration tests, per explicit instruction (no Docker available on this machine). This task is `tools`-only and touches no integration-tested code path. **CI (GitHub Actions) is relied on as the actual gate for that check.**
- Not applicable: TCK run (issue is explicitly non-protocol-facing)

Closes #287
