### PR TITLE
[TASK][AUTH1][T289] AuthService + InternalAuthServiceImpl (INTERNAL-mode login/refresh/logout)

### DIFF
--- a/connector/src/main/java/it/eng/connector/service/AuthService.java
+++ b/connector/src/main/java/it/eng/connector/service/AuthService.java
@@ -1,0 +1,59 @@
+package it.eng.connector.service;
+
+/**
+ * Unified login/refresh/logout contract for the {@code /api/v1/auth/*} admin-zone endpoints.
+ *
+ * <p>Implementations authenticate against whichever authentication mode is active
+ * (for example {@code INTERNAL}, backed by MongoDB {@code User} credentials) and issue/rotate
+ * opaque refresh-token identifiers alongside signed JWT access tokens.
+ */
+public interface AuthService {
+
+	/**
+	 * Authenticates the given credentials and issues a new access/refresh token pair.
+	 *
+	 * @param email    the user's email address (used as the username)
+	 * @param password the user's plaintext password
+	 * @return the issued {@link AuthTokens}
+	 * @throws org.springframework.security.core.AuthenticationException if the credentials are
+	 *                                                                    invalid or the account is
+	 *                                                                    disabled, expired, or
+	 *                                                                    locked
+	 */
+	AuthTokens login(String email, String password);
+
+	/**
+	 * Rotates a valid refresh token id and mints a fresh access token for its owning subject.
+	 *
+	 * @param refreshTokenId the refresh token id presented for rotation
+	 * @return the newly issued {@link AuthTokens}
+	 * @throws org.springframework.security.authentication.BadCredentialsException if
+	 *                                                                              {@code refreshTokenId}
+	 *                                                                              is unknown,
+	 *                                                                              expired, or
+	 *                                                                              already rotated
+	 *                                                                              or revoked
+	 */
+	AuthTokens refresh(String refreshTokenId);
+
+	/**
+	 * Revokes a refresh token id. Idempotent: revoking an already-revoked or unknown id does not
+	 * throw, matching typical identity-provider logout semantics.
+	 *
+	 * @param refreshTokenId the refresh token id to revoke
+	 */
+	void logout(String refreshTokenId);
+
+	/**
+	 * Result of a successful login or refresh, ready for the {@code AuthController} layer to
+	 * shape into its HTTP response body (for example {@code {access_token, refresh_token,
+	 * token_type, expires_in}}).
+	 *
+	 * @param accessToken     the signed JWT access token
+	 * @param refreshToken    the opaque refresh token id (not a JWT) tracked by
+	 *                        {@code RefreshTokenStore}
+	 * @param expiresInSeconds the access token's remaining time-to-live, in seconds
+	 */
+	record AuthTokens(String accessToken, String refreshToken, long expiresInSeconds) {
+	}
+}

--- a/connector/src/main/java/it/eng/connector/service/InternalAuthServiceImpl.java
+++ b/connector/src/main/java/it/eng/connector/service/InternalAuthServiceImpl.java
@@ -1,0 +1,106 @@
+package it.eng.connector.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import it.eng.connector.model.User;
+import it.eng.connector.repository.UserRepository;
+import it.eng.tools.auth.condition.InternalAuthenticationModeCondition;
+import it.eng.tools.auth.jwt.JwtService;
+import it.eng.tools.auth.jwt.RefreshTokenRecord;
+import it.eng.tools.auth.jwt.RefreshTokenStore;
+import it.eng.tools.auth.jwt.TokenPair;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@code INTERNAL}-mode {@link AuthService} implementation, authenticating against MongoDB-backed
+ * {@code User} credentials.
+ *
+ * <p>Credential verification is fully delegated to the existing {@link AuthenticationManager} /
+ * {@code DaoAuthenticationProvider} / {@code UserDetailsService} wiring registered in
+ * {@code ConnectorSecurityConfig} for {@code INTERNAL} mode, so the {@code enabled} / {@code expired}
+ * / {@code locked} semantics already enforced there are preserved without duplication here.
+ *
+ * <p>Unlike {@code UserService}, this service is active strictly in {@code INTERNAL} mode: it has
+ * nothing to offer in {@code DISABLED} mode.
+ *
+ * <p>Passwords, tokens, and the JWT signing secret are never logged, including at {@code DEBUG}
+ * level.
+ */
+@Service
+@Slf4j
+@Conditional(InternalAuthenticationModeCondition.class)
+public class InternalAuthServiceImpl implements AuthService {
+
+	private final AuthenticationManager authenticationManager;
+	private final UserRepository userRepository;
+	private final JwtService jwtService;
+	private final RefreshTokenStore refreshTokenStore;
+
+	/**
+	 * Creates the service with its required dependencies.
+	 *
+	 * @param authenticationManager the {@code INTERNAL}-mode authentication manager
+	 * @param userRepository        the user repository
+	 * @param jwtService            the JWT issuing/verification service
+	 * @param refreshTokenStore     the refresh-token id tracker
+	 */
+	public InternalAuthServiceImpl(AuthenticationManager authenticationManager, UserRepository userRepository,
+			JwtService jwtService, RefreshTokenStore refreshTokenStore) {
+		this.authenticationManager = authenticationManager;
+		this.userRepository = userRepository;
+		this.jwtService = jwtService;
+		this.refreshTokenStore = refreshTokenStore;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AuthTokens login(String email, String password) {
+		Authentication authentication =
+				authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
+		User user = userRepository.findByEmail(authentication.getName())
+				.orElseThrow(() -> new BadCredentialsException("Bad credentials"));
+
+		TokenPair tokenPair = jwtService.issueTokenPair(user.getId(), user.getEmail(),
+				List.of(user.getRole().authorityName()), user.getTenantId(), Map.of());
+		String refreshTokenId = refreshTokenStore.issue(user.getId());
+
+		log.info("User '{}' logged in successfully", user.getEmail());
+		return new AuthTokens(tokenPair.accessToken(), refreshTokenId, tokenPair.accessExpiresInSeconds());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AuthTokens refresh(String refreshTokenId) {
+		RefreshTokenRecord rotated = refreshTokenStore.rotate(refreshTokenId)
+				.orElseThrow(() -> new BadCredentialsException("Bad credentials"));
+		User user = userRepository.findById(rotated.subject())
+				.orElseThrow(() -> new BadCredentialsException("Bad credentials"));
+
+		TokenPair tokenPair = jwtService.issueTokenPair(user.getId(), user.getEmail(),
+				List.of(user.getRole().authorityName()), user.getTenantId(), Map.of());
+
+		log.info("Refresh token rotated successfully for user '{}'", user.getEmail());
+		return new AuthTokens(tokenPair.accessToken(), rotated.tokenId(), tokenPair.accessExpiresInSeconds());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void logout(String refreshTokenId) {
+		refreshTokenStore.revoke(refreshTokenId);
+		log.info("Refresh token revoked on logout");
+	}
+}

--- a/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
+++ b/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
@@ -177,7 +177,6 @@ class InternalAuthServiceImplTest {
 	@Test
 	@DisplayName("logout() on an already-revoked/unknown id does not throw")
 	void logoutOnUnknownIdDoesNotThrow() {
-		authService.logout("unknown-id");
 
 		assertDoesNotThrow(() -> {
 			authService.logout("unknown-id");

--- a/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
+++ b/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +99,7 @@ class InternalAuthServiceImplTest {
 		assertEquals("access-token", tokens.accessToken());
 		assertEquals("refresh-id-1", tokens.refreshToken());
 		assertEquals(900L, tokens.expiresInSeconds());
-		verify(jwtService).issueTokenPair(USER_ID, EMAIL, List.of(Role.ADMIN.authorityName()), TENANT_ID, java.util.Map.of());
+		verify(jwtService).issueTokenPair(USER_ID, EMAIL, List.of(Role.ADMIN.authorityName()), TENANT_ID, Map.of());
 	}
 
 	@Test
@@ -140,7 +142,7 @@ class InternalAuthServiceImplTest {
 	@Test
 	@DisplayName("refresh() with a valid refresh token id returns a new access token and rotates the refresh id")
 	void refreshWithValidTokenRotatesAndReturnsNewAccessToken() {
-		RefreshTokenRecord rotated = new RefreshTokenRecord("new-refresh-id", USER_ID, java.time.Instant.now());
+		RefreshTokenRecord rotated = new RefreshTokenRecord("new-refresh-id", USER_ID, Instant.now());
 		when(refreshTokenStore.rotate("old-refresh-id")).thenReturn(Optional.of(rotated));
 		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
 		TokenPair tokenPair = new TokenPair("new-access-token", "unused-refresh-jwt", 900L);
@@ -177,6 +179,10 @@ class InternalAuthServiceImplTest {
 	void logoutOnUnknownIdDoesNotThrow() {
 		authService.logout("unknown-id");
 
-		assertDoesNotThrow(() -> authService.logout("unknown-id"));
+		assertDoesNotThrow(() -> {
+			authService.logout("unknown-id");
+			authService.logout("unknown-id");
+		});
+		verify(refreshTokenStore, times(2)).revoke("unknown-id");
 	}
 }

--- a/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
+++ b/connector/src/test/java/it/eng/connector/service/InternalAuthServiceImplTest.java
@@ -1,0 +1,182 @@
+package it.eng.connector.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import it.eng.connector.model.Role;
+import it.eng.connector.model.User;
+import it.eng.connector.repository.UserRepository;
+import it.eng.connector.service.AuthService.AuthTokens;
+import it.eng.tools.auth.jwt.JwtService;
+import it.eng.tools.auth.jwt.RefreshTokenRecord;
+import it.eng.tools.auth.jwt.RefreshTokenStore;
+import it.eng.tools.auth.jwt.TokenPair;
+
+/**
+ * Unit tests for {@link InternalAuthServiceImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+class InternalAuthServiceImplTest {
+
+	private static final String EMAIL = "user@test.com";
+	private static final String PASSWORD = "password";
+	private static final String USER_ID = "user-1";
+	private static final String TENANT_ID = "tenant-1";
+
+	@Mock
+	private AuthenticationManager authenticationManager;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private JwtService jwtService;
+	@Mock
+	private RefreshTokenStore refreshTokenStore;
+	@Mock
+	private Authentication authentication;
+
+	private InternalAuthServiceImpl authService;
+	private User user;
+
+	@BeforeEach
+	void setUp() {
+		authService = new InternalAuthServiceImpl(authenticationManager, userRepository, jwtService,
+				refreshTokenStore);
+		user = User.builder()
+				.id(USER_ID)
+				.email(EMAIL)
+				.password("encoded")
+				.role(Role.ADMIN)
+				.tenantId(TENANT_ID)
+				.enabled(true)
+				.expired(false)
+				.locked(false)
+				.build();
+	}
+
+	@Test
+	@DisplayName("login() with correct credentials returns a token pair matching the authenticated user's claims")
+	void loginWithCorrectCredentialsReturnsTokenPair() {
+		when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+				.thenReturn(authentication);
+		when(authentication.getName()).thenReturn(EMAIL);
+		when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+		TokenPair tokenPair = new TokenPair("access-token", "unused-refresh-jwt", 900L);
+		when(jwtService.issueTokenPair(eq(USER_ID), eq(EMAIL), anyList(), eq(TENANT_ID), anyMap()))
+				.thenReturn(tokenPair);
+		when(refreshTokenStore.issue(USER_ID)).thenReturn("refresh-id-1");
+
+		AuthTokens tokens = authService.login(EMAIL, PASSWORD);
+
+		assertEquals("access-token", tokens.accessToken());
+		assertEquals("refresh-id-1", tokens.refreshToken());
+		assertEquals(900L, tokens.expiresInSeconds());
+		verify(jwtService).issueTokenPair(USER_ID, EMAIL, List.of(Role.ADMIN.authorityName()), TENANT_ID, java.util.Map.of());
+	}
+
+	@Test
+	@DisplayName("login() with wrong password throws BadCredentialsException")
+	void loginWithWrongPasswordThrowsBadCredentialsException() {
+		when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+				.thenThrow(new BadCredentialsException("Bad credentials"));
+
+		assertThrows(BadCredentialsException.class, () -> authService.login(EMAIL, "wrong-password"));
+		verify(userRepository, never()).findByEmail(anyString());
+	}
+
+	@Test
+	@DisplayName("login() for a disabled user throws DisabledException")
+	void loginForDisabledUserThrowsDisabledException() {
+		when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+				.thenThrow(new DisabledException("User is disabled"));
+
+		assertThrows(DisabledException.class, () -> authService.login(EMAIL, PASSWORD));
+	}
+
+	@Test
+	@DisplayName("login() for a locked user throws LockedException")
+	void loginForLockedUserThrowsLockedException() {
+		when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+				.thenThrow(new LockedException("User is locked"));
+
+		assertThrows(LockedException.class, () -> authService.login(EMAIL, PASSWORD));
+	}
+
+	@Test
+	@DisplayName("login() for an expired account throws AccountExpiredException")
+	void loginForExpiredAccountThrowsAccountExpiredException() {
+		when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+				.thenThrow(new AccountExpiredException("Account expired"));
+
+		assertThrows(AccountExpiredException.class, () -> authService.login(EMAIL, PASSWORD));
+	}
+
+	@Test
+	@DisplayName("refresh() with a valid refresh token id returns a new access token and rotates the refresh id")
+	void refreshWithValidTokenRotatesAndReturnsNewAccessToken() {
+		RefreshTokenRecord rotated = new RefreshTokenRecord("new-refresh-id", USER_ID, java.time.Instant.now());
+		when(refreshTokenStore.rotate("old-refresh-id")).thenReturn(Optional.of(rotated));
+		when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+		TokenPair tokenPair = new TokenPair("new-access-token", "unused-refresh-jwt", 900L);
+		when(jwtService.issueTokenPair(eq(USER_ID), eq(EMAIL), anyList(), eq(TENANT_ID), anyMap()))
+				.thenReturn(tokenPair);
+
+		AuthTokens tokens = authService.refresh("old-refresh-id");
+
+		assertEquals("new-access-token", tokens.accessToken());
+		assertEquals("new-refresh-id", tokens.refreshToken());
+		assertEquals(900L, tokens.expiresInSeconds());
+	}
+
+	@Test
+	@DisplayName("refresh() with an unknown/expired/already-rotated refresh token id throws BadCredentialsException")
+	void refreshWithInvalidTokenThrowsBadCredentialsException() {
+		when(refreshTokenStore.rotate("unknown-id")).thenReturn(Optional.empty());
+
+		assertThrows(BadCredentialsException.class, () -> authService.refresh("unknown-id"));
+		verify(userRepository, never()).findById(anyString());
+		verify(jwtService, never()).issueTokenPair(anyString(), anyString(), anyList(), anyString(), anyMap());
+	}
+
+	@Test
+	@DisplayName("logout() revokes the refresh token id")
+	void logoutRevokesRefreshTokenId() {
+		authService.logout("refresh-id-1");
+
+		verify(refreshTokenStore, times(1)).revoke("refresh-id-1");
+	}
+
+	@Test
+	@DisplayName("logout() on an already-revoked/unknown id does not throw")
+	void logoutOnUnknownIdDoesNotThrow() {
+		authService.logout("unknown-id");
+
+		assertDoesNotThrow(() -> authService.logout("unknown-id"));
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `AuthService` interface (`login`/`refresh`/`logout` + `AuthTokens` record) describing the unified `/api/v1/auth/*` contract.
- Adds `InternalAuthServiceImpl`, `@Service` + `@Conditional(InternalAuthenticationModeCondition.class)`, delegating credential verification to the existing `AuthenticationManager`/`DaoAuthenticationProvider`/`UserDetailsService` wiring, and issuing/rotating tokens via `JwtService` and `RefreshTokenStore`.
- Adds `InternalAuthServiceImplTest` covering login success/failure (bad password, disabled, locked, expired), refresh success/failure, and logout idempotency.

## Design notes
- `AuthTokens(accessToken, refreshToken, expiresInSeconds)` surfaces `JwtService`'s access token together with the opaque refresh-token id from `RefreshTokenStore` (the JWT-side refresh half from `JwtService.issueTokenPair` is intentionally discarded) — leaves full response DTO shaping to the sibling `AuthController` task.
- Invalid/expired/unknown refresh token ids reuse `BadCredentialsException` for consistency with the existing Basic Auth failure path, documented in Javadoc for the sibling task's exception advice.
- `logout()` is idempotent by delegating directly to `RefreshTokenStore.revoke()`.
- No new configuration properties.

## Verification
- `mvn -pl connector -am -Dtest=InternalAuthServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test` → 9/9 tests passing.
- Manual check: only `user.getEmail()` is logged; no password/token/secret values in any log statement.
- `mvn clean verify` (Docker) and SpotBugs scan intentionally left to the requester per this task's agreed verification scope; not run by the agent.

## Scope note
Per branch-strategy agreement for this task, base branch is `feature/multitenant` (not `develop`) — no diff against `develop` was requested or performed.

Closes #289