### PR TITLE
[SLICE][TB1] Tenant Bucket Credential Request Contract & Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **TB1 — Tenant Bucket Credential Request Contract & Verification** (foundation only; not yet wired into `POST`/`PUT /api/v1/tenants`)
+  - `TenantBucketCredentialsRequest` (`tools`) — a request-only carrier for optional `bucketName`/`accessKey`/`secretKey`/`verifyConnection` fields, never persisted and never returned from any controller.
+  - `BucketProvisioningMode` (`AUTOMATIC`/`EXISTING_BUCKET`/`EXTERNAL_CREDENTIALS`) and `BucketProvisioningModeResolver` (`tools`) — classify the optional fields above into one of the three valid provisioning modes, or reject invalid combinations with `IllegalArgumentException`.
+  - `BucketConnectionVerificationService` (`tools`) — verifies candidate external bucket credentials against S3/MinIO via a `HeadBucket` probe, with no persistence side effects, backing the opt-in `verifyConnection` pre-flight check. See [tools/doc/tenant-s3-provisioning.md](tools/doc/tenant-s3-provisioning.md#bring-your-own-bucket-foundation-tb1).
+
 ## [0.7.0] - 10.07.2026 - Multi-Tenant Support
 
 - **Updated java from 17 to 21**

--- a/tools/doc/tenant-s3-provisioning.md
+++ b/tools/doc/tenant-s3-provisioning.md
@@ -68,6 +68,52 @@ See the S3 Architecture reference instruction (`.github/instructions/s3-architec
 for the full admin-client vs bucket-scoped-client distinction and for the `BucketCredentialsEntity`
 encryption details.
 
+## Bring-Your-Own-Bucket Foundation (TB1)
+
+> **Status**: foundation only. The classes described below are not yet wired into
+> `POST`/`PUT /api/v1/tenants`. Wiring into tenant creation and update is tracked by the
+> sibling slices TB2 and TB3 under [#322](https://github.com/Engineering-Research-and-Development/dsp-true-connector/issues/322).
+
+To let an admin optionally supply an existing bucket and/or external credentials instead of
+always relying on automatic provisioning, the following shared contract exists in `tools`:
+
+- **`TenantBucketCredentialsRequest`** (`it.eng.tools.model`) — a request-only carrier for
+  `bucketName`, `accessKey`, `secretKey`, and `verifyConnection` (defaults to `false`). It has
+  no Spring Data annotations and is **never** persisted or returned from any controller —
+  responses and the persisted `Tenant` document never carry raw credentials.
+- **`BucketProvisioningMode`** (`it.eng.tools.model`) — an enum describing the resolved intent:
+  `AUTOMATIC`, `EXISTING_BUCKET`, or `EXTERNAL_CREDENTIALS`.
+- **`BucketProvisioningModeResolver`** (`it.eng.tools.service`) — classifies a
+  `TenantBucketCredentialsRequest` into exactly one `BucketProvisioningMode`, using this
+  partial-input matrix:
+
+  | `bucketName` | `accessKey` | `secretKey` | Resolved mode |
+  |---|---|---|---|
+  | absent | absent | absent | `AUTOMATIC` |
+  | present | absent | absent | `EXISTING_BUCKET` |
+  | present | present | present | `EXTERNAL_CREDENTIALS` |
+  | any other combination | | | throws `IllegalArgumentException` |
+
+- **`BucketConnectionVerificationService`** (`it.eng.tools.s3.service`) — an opt-in
+  (`verifyConnection=true`) pre-flight check that probes a candidate `bucketName` +
+  `accessKey` + `secretKey` with a `HeadBucket` request via `S3ClientProvider`, returning
+  `true`/`false` without ever calling `BucketCredentialsService.saveBucketCredentials()`.
+  The ad-hoc client used for the probe is evicted from `S3ClientProvider`'s cache
+  (`clearBucketCache`) after use, on both the success and failure paths, so a
+  rejected/candidate credential set can never linger and be reused by a later call for the
+  same bucket name.
+
+These two services compose directly: `BucketProvisioningModeResolver.resolve()` output for
+`EXTERNAL_CREDENTIALS` mode feeds the same `bucketName`/`accessKey`/`secretKey` values
+straight into `BucketConnectionVerificationService.verify(...)`, with no adapter needed.
+Invalid combinations are rejected by the resolver before any S3 call would ever be attempted.
+
+**Reusable pattern**: separating a request-only "intent" carrier
+(`TenantBucketCredentialsRequest`) from the persisted/response domain model (`Tenant`) is the
+safe way to accept sensitive optional input without touching the existing Jackson-serialized
+response shape. Future "bring your own X" admin-input features should follow this same
+separation.
+
 ## Related
 
 - [s3_configuration.md](../../doc/s3_configuration.md) — S3 property reference

--- a/tools/src/main/java/it/eng/tools/model/BucketProvisioningMode.java
+++ b/tools/src/main/java/it/eng/tools/model/BucketProvisioningMode.java
@@ -1,0 +1,27 @@
+package it.eng.tools.model;
+
+/**
+ * Represents the resolved bucket-provisioning strategy for a tenant create/update request,
+ * derived from the optional {@code bucketName}/{@code accessKey}/{@code secretKey} fields
+ * carried by {@link TenantBucketCredentialsRequest}.
+ */
+public enum BucketProvisioningMode {
+
+    /**
+     * No bucket-related fields were supplied; the bucket and credentials are fully
+     * auto-provisioned by the existing automatic provisioning flow.
+     */
+    AUTOMATIC,
+
+    /**
+     * Only {@code bucketName} was supplied; the existing bucket is reused and credentials
+     * are auto-generated for it.
+     */
+    EXISTING_BUCKET,
+
+    /**
+     * {@code bucketName}, {@code accessKey}, and {@code secretKey} were all supplied; the
+     * externally provided credentials are persisted as-is for the given bucket.
+     */
+    EXTERNAL_CREDENTIALS
+}

--- a/tools/src/main/java/it/eng/tools/model/TenantBucketCredentialsRequest.java
+++ b/tools/src/main/java/it/eng/tools/model/TenantBucketCredentialsRequest.java
@@ -1,0 +1,118 @@
+package it.eng.tools.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request-only carrier for the optional "bring your own bucket" fields that an admin may
+ * supply when creating or updating a tenant. This class is never persisted (no Spring Data
+ * annotations) and must never be returned from any controller method, since it may carry a
+ * plaintext {@code secretKey}.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonDeserialize(builder = TenantBucketCredentialsRequest.Builder.class)
+public class TenantBucketCredentialsRequest {
+
+    /**
+     * The candidate or existing S3 bucket name, or {@code null} for fully automatic provisioning.
+     */
+    private String bucketName;
+
+    /**
+     * The candidate external S3 access key, or {@code null} when not supplying external credentials.
+     */
+    private String accessKey;
+
+    /**
+     * The candidate external S3 secret key, or {@code null} when not supplying external credentials.
+     */
+    private String secretKey;
+
+    /**
+     * Whether the supplied candidate credentials should be verified against S3 before being
+     * persisted. Defaults to {@code false} when not explicitly set.
+     */
+    private boolean verifyConnection;
+
+    /**
+     * Builder for creating {@link TenantBucketCredentialsRequest} instances.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Builder {
+
+        private final TenantBucketCredentialsRequest request;
+
+        private Builder() {
+            request = new TenantBucketCredentialsRequest();
+        }
+
+        /**
+         * Creates a new {@link Builder} instance.
+         *
+         * @return a new builder
+         */
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        /**
+         * Sets the candidate or existing S3 bucket name.
+         *
+         * @param bucketName the S3 bucket name, or {@code null} for fully automatic provisioning
+         * @return this builder
+         */
+        public Builder bucketName(String bucketName) {
+            request.bucketName = bucketName;
+            return this;
+        }
+
+        /**
+         * Sets the candidate external S3 access key.
+         *
+         * @param accessKey the S3 access key, or {@code null} when not supplying external credentials
+         * @return this builder
+         */
+        public Builder accessKey(String accessKey) {
+            request.accessKey = accessKey;
+            return this;
+        }
+
+        /**
+         * Sets the candidate external S3 secret key.
+         *
+         * @param secretKey the S3 secret key, or {@code null} when not supplying external credentials
+         * @return this builder
+         */
+        public Builder secretKey(String secretKey) {
+            request.secretKey = secretKey;
+            return this;
+        }
+
+        /**
+         * Sets whether the supplied candidate credentials should be verified against S3
+         * before being persisted.
+         *
+         * @param verifyConnection the verify-connection flag
+         * @return this builder
+         */
+        public Builder verifyConnection(boolean verifyConnection) {
+            request.verifyConnection = verifyConnection;
+            return this;
+        }
+
+        /**
+         * Builds the {@link TenantBucketCredentialsRequest} instance.
+         *
+         * @return the built request
+         */
+        public TenantBucketCredentialsRequest build() {
+            return request;
+        }
+    }
+}

--- a/tools/src/main/java/it/eng/tools/s3/service/BucketConnectionVerificationService.java
+++ b/tools/src/main/java/it/eng/tools/s3/service/BucketConnectionVerificationService.java
@@ -1,0 +1,77 @@
+package it.eng.tools.s3.service;
+
+import it.eng.tools.s3.configuration.S3ClientProvider;
+import it.eng.tools.s3.model.BucketCredentialsEntity;
+import it.eng.tools.s3.model.S3ClientRequest;
+import it.eng.tools.s3.properties.S3Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Verifies that a candidate set of external S3 credentials actually grant access to a given
+ * bucket, without persisting the candidate credentials. This is used to back the opt-in
+ * {@code verifyConnection} pre-flight check when an admin supplies "bring your own bucket"
+ * credentials for a tenant.
+ */
+@Service
+@Slf4j
+public class BucketConnectionVerificationService {
+
+    private final S3ClientProvider s3ClientProvider;
+    private final S3Properties s3Properties;
+
+    /**
+     * Creates a new {@link BucketConnectionVerificationService}.
+     *
+     * @param s3ClientProvider the provider used to build a bucket-scoped S3 client for the candidate credentials
+     * @param s3Properties the S3 configuration properties used to resolve region and endpoint
+     */
+    public BucketConnectionVerificationService(S3ClientProvider s3ClientProvider, S3Properties s3Properties) {
+        this.s3ClientProvider = s3ClientProvider;
+        this.s3Properties = s3Properties;
+    }
+
+    /**
+     * Verifies that the given candidate credentials grant access to the given bucket via a
+     * {@code HeadBucket} probe. The candidate credentials are never persisted; the ad-hoc
+     * client built for the probe is evicted from the {@link S3ClientProvider} cache after use,
+     * regardless of outcome.
+     *
+     * @param bucketName the bucket name to probe
+     * @param accessKey the candidate S3 access key
+     * @param secretKey the candidate S3 secret key
+     * @return {@code true} if the candidate credentials successfully access the bucket, {@code false} otherwise
+     */
+    public boolean verify(String bucketName, String accessKey, String secretKey) {
+        try {
+            BucketCredentialsEntity candidateCredentials = BucketCredentialsEntity.Builder.newInstance()
+                    .bucketName(bucketName)
+                    .accessKey(accessKey)
+                    .secretKey(secretKey)
+                    .build();
+
+            String endpointOverride = StringUtils.isNotBlank(s3Properties.getExternalPresignedEndpoint())
+                    ? s3Properties.getExternalPresignedEndpoint()
+                    : s3Properties.getEndpoint();
+
+            S3ClientRequest s3ClientRequest =
+                    S3ClientRequest.from(s3Properties.getRegion(), endpointOverride, candidateCredentials);
+            S3Client s3Client = s3ClientProvider.s3Client(s3ClientRequest);
+
+            HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
+                    .bucket(bucketName)
+                    .build();
+            s3Client.headBucket(headBucketRequest);
+            return true;
+        } catch (S3Exception e) {
+            log.warn("Bucket connectivity verification failed for bucket '{}': {}", bucketName, e.getMessage());
+            return false;
+        } finally {
+            s3ClientProvider.clearBucketCache(bucketName);
+        }
+    }
+}

--- a/tools/src/main/java/it/eng/tools/service/BucketProvisioningModeResolver.java
+++ b/tools/src/main/java/it/eng/tools/service/BucketProvisioningModeResolver.java
@@ -1,0 +1,47 @@
+package it.eng.tools.service;
+
+import it.eng.tools.model.BucketProvisioningMode;
+import it.eng.tools.model.TenantBucketCredentialsRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves the {@link BucketProvisioningMode} implied by the optional
+ * {@code bucketName}/{@code accessKey}/{@code secretKey} fields of a
+ * {@link TenantBucketCredentialsRequest}, applying the partial-input classification matrix
+ * agreed for tenant bucket credential onboarding.
+ */
+@Service
+public class BucketProvisioningModeResolver {
+
+    /**
+     * Classifies the given request into one of the valid {@link BucketProvisioningMode} values.
+     *
+     * @param request the tenant bucket credentials request to classify
+     * @return {@link BucketProvisioningMode#AUTOMATIC} when no fields are supplied,
+     *         {@link BucketProvisioningMode#EXISTING_BUCKET} when only {@code bucketName} is supplied,
+     *         or {@link BucketProvisioningMode#EXTERNAL_CREDENTIALS} when {@code bucketName},
+     *         {@code accessKey}, and {@code secretKey} are all supplied
+     * @throws IllegalArgumentException if the supplied fields form any other, invalid combination
+     */
+    public BucketProvisioningMode resolve(TenantBucketCredentialsRequest request) {
+        boolean hasBucketName = StringUtils.isNotBlank(request.getBucketName());
+        boolean hasAccessKey = StringUtils.isNotBlank(request.getAccessKey());
+        boolean hasSecretKey = StringUtils.isNotBlank(request.getSecretKey());
+
+        if (!hasBucketName && !hasAccessKey && !hasSecretKey) {
+            return BucketProvisioningMode.AUTOMATIC;
+        }
+        if (hasBucketName && !hasAccessKey && !hasSecretKey) {
+            return BucketProvisioningMode.EXISTING_BUCKET;
+        }
+        if (hasBucketName && hasAccessKey && hasSecretKey) {
+            return BucketProvisioningMode.EXTERNAL_CREDENTIALS;
+        }
+
+        throw new IllegalArgumentException("Invalid bucket credentials request combination: " +
+                "bucketName=" + (hasBucketName ? "present" : "absent") +
+                ", accessKey=" + (hasAccessKey ? "present" : "absent") +
+                ", secretKey=" + (hasSecretKey ? "present" : "absent"));
+    }
+}

--- a/tools/src/test/java/it/eng/tools/model/TenantBucketCredentialsRequestTest.java
+++ b/tools/src/test/java/it/eng/tools/model/TenantBucketCredentialsRequestTest.java
@@ -1,0 +1,49 @@
+package it.eng.tools.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantBucketCredentialsRequestTest {
+
+    @Test
+    @DisplayName("Build request with all fields set")
+    void buildWithAllFieldsSet() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("my-bucket")
+                .accessKey("my-access-key")
+                .secretKey("my-secret-key")
+                .verifyConnection(true)
+                .build();
+
+        assertEquals("my-bucket", request.getBucketName());
+        assertEquals("my-access-key", request.getAccessKey());
+        assertEquals("my-secret-key", request.getSecretKey());
+        assertTrue(request.isVerifyConnection());
+    }
+
+    @Test
+    @DisplayName("verifyConnection defaults to false when not explicitly set")
+    void verifyConnectionDefaultsToFalse() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("my-bucket")
+                .build();
+
+        assertFalse(request.isVerifyConnection());
+    }
+
+    @Test
+    @DisplayName("Build request with no fields set")
+    void buildWithNoFieldsSet() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance().build();
+
+        assertNull(request.getBucketName());
+        assertNull(request.getAccessKey());
+        assertNull(request.getSecretKey());
+        assertFalse(request.isVerifyConnection());
+    }
+}

--- a/tools/src/test/java/it/eng/tools/s3/service/BucketConnectionVerificationServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/s3/service/BucketConnectionVerificationServiceTest.java
@@ -1,0 +1,82 @@
+package it.eng.tools.s3.service;
+
+import it.eng.tools.s3.configuration.S3ClientProvider;
+import it.eng.tools.s3.model.S3ClientRequest;
+import it.eng.tools.s3.properties.S3Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BucketConnectionVerificationServiceTest {
+
+    private static final String BUCKET_NAME = "my-bucket";
+    private static final String ACCESS_KEY = "candidate-access-key";
+    private static final String SECRET_KEY = "candidate-secret-key";
+
+    @Mock
+    private S3ClientProvider s3ClientProvider;
+
+    @Mock
+    private S3Properties s3Properties;
+
+    @Mock
+    private S3Client s3Client;
+
+    private BucketConnectionVerificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BucketConnectionVerificationService(s3ClientProvider, s3Properties);
+        when(s3Properties.getRegion()).thenReturn("us-east-1");
+        when(s3Properties.getExternalPresignedEndpoint()).thenReturn("http://minio:9000");
+        when(s3ClientProvider.s3Client(any(S3ClientRequest.class))).thenReturn(s3Client);
+    }
+
+    @Test
+    @DisplayName("Returns true when headBucket succeeds")
+    void returnsTrueWhenHeadBucketSucceeds() {
+        boolean result = service.verify(BUCKET_NAME, ACCESS_KEY, SECRET_KEY);
+
+        assertTrue(result);
+        verify(s3Client).headBucket(any(HeadBucketRequest.class));
+        verify(s3ClientProvider).clearBucketCache(BUCKET_NAME);
+    }
+
+    @Test
+    @DisplayName("Returns false when the bucket does not exist")
+    void returnsFalseWhenBucketDoesNotExist() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class)))
+                .thenThrow(NoSuchBucketException.builder().message("no such bucket").build());
+
+        boolean result = service.verify(BUCKET_NAME, ACCESS_KEY, SECRET_KEY);
+
+        assertFalse(result);
+        verify(s3ClientProvider).clearBucketCache(BUCKET_NAME);
+    }
+
+    @Test
+    @DisplayName("Returns false when access is denied or credentials are rejected")
+    void returnsFalseWhenAccessDenied() {
+        when(s3Client.headBucket(any(HeadBucketRequest.class)))
+                .thenThrow((S3Exception) S3Exception.builder().message("access denied").statusCode(403).build());
+
+        boolean result = service.verify(BUCKET_NAME, ACCESS_KEY, SECRET_KEY);
+
+        assertFalse(result);
+        verify(s3ClientProvider).clearBucketCache(BUCKET_NAME);
+    }
+}

--- a/tools/src/test/java/it/eng/tools/service/BucketProvisioningCompositionTest.java
+++ b/tools/src/test/java/it/eng/tools/service/BucketProvisioningCompositionTest.java
@@ -1,0 +1,159 @@
+package it.eng.tools.service;
+
+import it.eng.tools.model.BucketProvisioningMode;
+import it.eng.tools.model.TenantBucketCredentialsRequest;
+import it.eng.tools.s3.configuration.S3ClientProvider;
+import it.eng.tools.s3.properties.S3Properties;
+import it.eng.tools.s3.service.BucketConnectionVerificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Slice-level QA test for TB1 (#323): verifies that {@link BucketProvisioningModeResolver}'s
+ * classification composes directly with {@link BucketConnectionVerificationService}'s
+ * verification, with no adapter/glue code needed, and that no invalid combination ever
+ * reaches a verification call.
+ */
+@ExtendWith(MockitoExtension.class)
+class BucketProvisioningCompositionTest {
+
+    private static final String BUCKET_NAME = "my-bucket";
+    private static final String ACCESS_KEY = "candidate-access-key";
+    private static final String SECRET_KEY = "candidate-secret-key";
+
+    @Mock
+    private S3ClientProvider s3ClientProvider;
+
+    @Mock
+    private S3Properties s3Properties;
+
+    @Mock
+    private S3Client s3Client;
+
+    private final BucketProvisioningModeResolver resolver = new BucketProvisioningModeResolver();
+    private BucketConnectionVerificationService verificationService;
+
+    @BeforeEach
+    void setUp() {
+        verificationService = new BucketConnectionVerificationService(s3ClientProvider, s3Properties);
+    }
+
+    @Test
+    @DisplayName("AUTOMATIC mode resolves without any verification call being attempted")
+    void automaticModeRequiresNoVerificationCall() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance().build();
+
+        assertEquals(BucketProvisioningMode.AUTOMATIC, resolver.resolve(request));
+        verifyNoInteractionsWithS3();
+    }
+
+    @Test
+    @DisplayName("EXISTING_BUCKET mode resolves without any verification call being attempted")
+    void existingBucketModeRequiresNoVerificationCall() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName(BUCKET_NAME)
+                .build();
+
+        assertEquals(BucketProvisioningMode.EXISTING_BUCKET, resolver.resolve(request));
+        verifyNoInteractionsWithS3();
+    }
+
+    @Test
+    @DisplayName("EXTERNAL_CREDENTIALS mode composes directly into a successful verification call")
+    void externalCredentialsModeComposesIntoSuccessfulVerification() {
+        when(s3Properties.getRegion()).thenReturn("us-east-1");
+        when(s3ClientProvider.s3Client(any())).thenReturn(s3Client);
+
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName(BUCKET_NAME)
+                .accessKey(ACCESS_KEY)
+                .secretKey(SECRET_KEY)
+                .verifyConnection(true)
+                .build();
+
+        BucketProvisioningMode mode = resolver.resolve(request);
+        assertEquals(BucketProvisioningMode.EXTERNAL_CREDENTIALS, mode);
+
+        boolean verified = verificationService.verify(
+                request.getBucketName(), request.getAccessKey(), request.getSecretKey());
+
+        assertTrue(verified);
+        verify(s3Client).headBucket(any(HeadBucketRequest.class));
+    }
+
+    @Test
+    @DisplayName("EXTERNAL_CREDENTIALS mode composes directly into a rejected verification call")
+    void externalCredentialsModeComposesIntoRejectedVerification() {
+        when(s3Properties.getRegion()).thenReturn("us-east-1");
+        when(s3ClientProvider.s3Client(any())).thenReturn(s3Client);
+        when(s3Client.headBucket(any(HeadBucketRequest.class)))
+                .thenThrow((S3Exception) S3Exception.builder().message("access denied").statusCode(403).build());
+
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName(BUCKET_NAME)
+                .accessKey(ACCESS_KEY)
+                .secretKey(SECRET_KEY)
+                .verifyConnection(true)
+                .build();
+
+        BucketProvisioningMode mode = resolver.resolve(request);
+        assertEquals(BucketProvisioningMode.EXTERNAL_CREDENTIALS, mode);
+
+        boolean verified = verificationService.verify(
+                request.getBucketName(), request.getAccessKey(), request.getSecretKey());
+
+        assertFalse(verified);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCombinations")
+    @DisplayName("Invalid combinations are rejected before any verification call could ever occur")
+    void invalidCombinationsNeverReachVerification(TenantBucketCredentialsRequest request) {
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(request));
+        verifyNoInteractionsWithS3();
+    }
+
+    private void verifyNoInteractionsWithS3() {
+        verify(s3ClientProvider, never()).s3Client(any());
+        verify(s3Client, never()).headBucket(any(HeadBucketRequest.class));
+    }
+
+    private static Stream<TenantBucketCredentialsRequest> invalidCombinations() {
+        return Stream.of(
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .accessKey(ACCESS_KEY)
+                        .build(),
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .secretKey(SECRET_KEY)
+                        .build(),
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .bucketName(BUCKET_NAME)
+                        .accessKey(ACCESS_KEY)
+                        .build(),
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .bucketName(BUCKET_NAME)
+                        .secretKey(SECRET_KEY)
+                        .build()
+        );
+    }
+}

--- a/tools/src/test/java/it/eng/tools/service/BucketProvisioningModeResolverTest.java
+++ b/tools/src/test/java/it/eng/tools/service/BucketProvisioningModeResolverTest.java
@@ -1,0 +1,83 @@
+package it.eng.tools.service;
+
+import it.eng.tools.model.BucketProvisioningMode;
+import it.eng.tools.model.TenantBucketCredentialsRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BucketProvisioningModeResolverTest {
+
+    private final BucketProvisioningModeResolver resolver = new BucketProvisioningModeResolver();
+
+    @Test
+    @DisplayName("Resolves AUTOMATIC when no fields are set")
+    void resolvesAutomaticWhenNoFieldsSet() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance().build();
+
+        assertEquals(BucketProvisioningMode.AUTOMATIC, resolver.resolve(request));
+    }
+
+    @Test
+    @DisplayName("Resolves EXISTING_BUCKET when only bucketName is set")
+    void resolvesExistingBucketWhenOnlyBucketNameSet() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("my-bucket")
+                .build();
+
+        assertEquals(BucketProvisioningMode.EXISTING_BUCKET, resolver.resolve(request));
+    }
+
+    @Test
+    @DisplayName("Resolves EXTERNAL_CREDENTIALS when bucketName, accessKey, and secretKey are all set")
+    void resolvesExternalCredentialsWhenAllFieldsSet() {
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("my-bucket")
+                .accessKey("my-access-key")
+                .secretKey("my-secret-key")
+                .build();
+
+        assertEquals(BucketProvisioningMode.EXTERNAL_CREDENTIALS, resolver.resolve(request));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCombinations")
+    @DisplayName("Throws IllegalArgumentException for every invalid field combination")
+    void throwsForInvalidCombination(TenantBucketCredentialsRequest request) {
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(request));
+    }
+
+    private static Stream<TenantBucketCredentialsRequest> invalidCombinations() {
+        return Stream.of(
+                // accessKey present without bucketName
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .accessKey("my-access-key")
+                        .build(),
+                // secretKey present without bucketName
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .secretKey("my-secret-key")
+                        .build(),
+                // accessKey present without secretKey
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .bucketName("my-bucket")
+                        .accessKey("my-access-key")
+                        .build(),
+                // secretKey present without accessKey
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .bucketName("my-bucket")
+                        .secretKey("my-secret-key")
+                        .build(),
+                // accessKey and secretKey present without bucketName
+                TenantBucketCredentialsRequest.Builder.newInstance()
+                        .accessKey("my-access-key")
+                        .secretKey("my-secret-key")
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the TB1 functional slice: a shared request contract, partial-input classification, and S3 connectivity-verification helper that will let an admin optionally supply an existing bucket/credentials for a tenant. This is foundation-only work — it is **not yet wired into** `POST`/`PUT /api/v1/tenants`; that wiring is covered by sibling slices TB2 (#324) and TB3 (#325).

### What's included

- `TenantBucketCredentialsRequest` (`tools/model`) — request-only carrier for `bucketName`/`accessKey`/`secretKey`/`verifyConnection` (default `false`), never persisted, never returned by any controller.
- `BucketProvisioningMode` (`AUTOMATIC` / `EXISTING_BUCKET` / `EXTERNAL_CREDENTIALS`) and `BucketProvisioningModeResolver` (`tools/service`) — classifies the partial-input matrix, throwing `IllegalArgumentException` for any invalid combination.
- `BucketConnectionVerificationService` (`tools/s3/service`) — verifies candidate external bucket credentials via a `HeadBucket` probe using `S3ClientProvider`, with no persistence side effects and no secret logging; always clears the ad-hoc client cache afterward.
- Slice-level QA composition test (`BucketProvisioningCompositionTest`) proving the resolver's output composes directly into the verification service with no adapter code, and that invalid combinations never reach a verification call.
- Documentation: new "Bring-Your-Own-Bucket Foundation (TB1)" section in `tools/doc/tenant-s3-provisioning.md`, and a `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

- `mvn -pl tools -am test` — pass (new unit + composition tests)
- `mvn -pl tools -am validate` — Checkstyle pass
- `mvn clean verify` (Docker running, full multi-module suite including Testcontainers ITs) — **BUILD SUCCESS**
- Manual review: no log line, exception message, or `toString()`/`equals()` output in the new classes exposes `secretKey`/`accessKey`
- Not protocol-facing — no TCK run required

## Slice completion

Parent slice:
- Closes #323

Child tasks:
- Closes #326
- Closes #327
- Closes #328
- Closes #329

## Notes

- Base branch is `feature/multitenant` (current active branch) rather than `develop`, per explicit instruction for this PR.