### PR TITLE
[SLICE][TB3] Tenant update bucket rotation/migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ All notable changes to this project will be documented in this file.
     - `EXTERNAL_CREDENTIALS`: persists supplied credentials with `BucketCredentialsService` and skips auto-provisioning.
   - `verifyConnection=true` in external-credentials mode now enforces a pre-persistence bucket connectivity check through `BucketConnectionVerificationService`; failed verification rejects creation with HTTP 400 and no tenant/credentials persistence.
   - Added unit coverage for all three modes, conflict handling, and both `verifyConnection` outcomes (`TenantServiceTest`, `TenantCreateRequestTest`, `TenantAPIControllerTest`), plus end-to-end `TenantAPIIT` coverage for automatic, existing-bucket, external-credentials, verification success/failure, and bucket-conflict scenarios.
+- **TB3 — Tenant Update Bucket Rotation/Migration**
+  - `PUT /api/v1/tenants/{id}` now accepts optional `bucketName`/`accessKey`/`secretKey`/`verifyConnection` fields via `TenantUpdateRequest` and routes through `TenantService.updateTenant(id, updates, credentialsRequest)`.
+  - `TenantService.updateTenant(...)` now resolves `BucketProvisioningMode` and supports:
+    - ordinary update (`AUTOMATIC`) with unchanged bucket/credentials,
+    - bucket reconfirm or migration (`EXISTING_BUCKET`) with ownership-conflict checks excluding the tenant being updated,
+    - credential rotation or migration (`EXTERNAL_CREDENTIALS`) with optional `verifyConnection=true` pre-check.
+  - `BucketCredentialsService.saveBucketCredentials(...)` now carries forward the stored `@Version` on repeated writes to the same bucket, so sequential credential rotations update the existing document instead of failing on duplicate-key insert.
+  - `TENANT_UPDATED` audit details now include `changeType` (`ORDINARY_UPDATE`, `CREDENTIALS_ROTATED`, `BUCKET_MIGRATED`).
+  - Added unit and integration coverage for update-path reconfirm/migration/rotation flows, verification failures with no partial persistence, and double-rotation regression.
 
 ## [0.7.0] - 10.07.2026 - Multi-Tenant Support
 

--- a/True_connector_DSP.postman_collection.json
+++ b/True_connector_DSP.postman_collection.json
@@ -679,6 +679,111 @@
               "response": []
             },
             {
+              "name": "Update Tenant - Bucket Migration",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{CONSUMER}}/api/v1/tenants/acme-corp",
+                  "host": [
+                    "{{CONSUMER}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "tenants",
+                    "acme-corp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"ACME Corporation Updated\",\n  \"description\": \"Migrate tenant bucket\",\n  \"automaticNegotiation\": true,\n  \"automaticTransfer\": false,\n  \"bucketName\": \"existing-bucket-name\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update a tenant and migrate to another existing bucket."
+              },
+              "response": []
+            },
+            {
+              "name": "Update Tenant - Credential Rotation",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{CONSUMER}}/api/v1/tenants/acme-corp",
+                  "host": [
+                    "{{CONSUMER}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "tenants",
+                    "acme-corp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"ACME Corporation Updated\",\n  \"description\": \"Rotate tenant credentials\",\n  \"automaticNegotiation\": true,\n  \"automaticTransfer\": false,\n  \"bucketName\": \"existing-bucket-name\",\n  \"accessKey\": \"rotated-access-key\",\n  \"secretKey\": \"rotated-secret-key\",\n  \"verifyConnection\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Update a tenant and rotate bucket credentials with pre-flight verification."
+              },
+              "response": []
+            },
+            {
+              "name": "Update Tenant - Bucket Conflict (expected 400)",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{CONSUMER}}/api/v1/tenants/acme-corp",
+                  "host": [
+                    "{{CONSUMER}}"
+                  ],
+                  "path": [
+                    "api",
+                    "v1",
+                    "tenants",
+                    "acme-corp"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"ACME Corporation Updated\",\n  \"description\": \"Expected conflict\",\n  \"automaticNegotiation\": true,\n  \"automaticTransfer\": false,\n  \"bucketName\": \"already-owned-bucket\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "description": "Negative example: migration to a bucket already owned by another tenant should return HTTP 400."
+              },
+              "response": []
+            },
+            {
               "name": "Enable Tenant",
               "request": {
                 "method": "PUT",

--- a/connector/documentation/users.md
+++ b/connector/documentation/users.md
@@ -189,18 +189,49 @@ Create-tenant validation errors return HTTP 400 in these cases:
 
 `PUT /api/v1/tenants/{id}`
 
-Mutable fields: `name`, `description`, `participantId`, `automaticNegotiation`, `automaticTransfer`, `bucketName`.
+Mutable fields: `name`, `description`, `automaticNegotiation`, `automaticTransfer`, and optional
+bucket-rotation/migration inputs (`bucketName`, `accessKey`, `secretKey`, `verifyConnection`).
 
-The `enabled` state is **not** changed by this endpoint — use the dedicated enable/disable endpoints instead.
+The `participantId` and `enabled` state are immutable in this endpoint.
 
 ```json
 {
   "name"                 : "Updated Tenant Name",
-  "participantId"        : "urn:connector:my-tenant-v2",
   "automaticNegotiation" : true,
   "automaticTransfer"    : true
 }
 ```
+
+Bucket migration (existing bucket mode):
+
+```json
+{
+  "name"                 : "Updated Tenant Name",
+  "automaticNegotiation" : true,
+  "automaticTransfer"    : true,
+  "bucketName"           : "existing-bucket-name"
+}
+```
+
+Credential rotation / migration with external credentials:
+
+```json
+{
+  "name"                 : "Updated Tenant Name",
+  "automaticNegotiation" : true,
+  "automaticTransfer"    : true,
+  "bucketName"           : "external-bucket-name",
+  "accessKey"            : "external-access-key",
+  "secretKey"            : "external-secret-key",
+  "verifyConnection"     : true
+}
+```
+
+Update validation errors return HTTP 400 in these cases:
+
+- invalid bucket-field combinations (for example only `accessKey`, or `bucketName` + `accessKey` without `secretKey`)
+- `bucketName` already owned by another tenant (self-reconfirm is allowed)
+- `verifyConnection=true` with external credentials that fail bucket connectivity verification
 
 ### Enable / disable tenant
 

--- a/connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java
+++ b/connector/src/test/java/it/eng/connector/integration/tenant/TenantAPIIT.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.jsonpath.JsonPath;
 import it.eng.connector.integration.BaseIntegrationTest;
 import it.eng.tools.controller.ApiEndpoints;
+import it.eng.tools.event.AuditEvent;
+import it.eng.tools.event.AuditEventType;
 import it.eng.tools.model.TenantCreateRequest;
 import it.eng.tools.model.Tenant;
+import it.eng.tools.model.TenantUpdateRequest;
+import it.eng.tools.repository.AuditEventRepository;
 import it.eng.tools.repository.TenantRepository;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.s3.model.BucketCredentialsEntity;
@@ -25,6 +29,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -50,6 +55,7 @@ public class TenantAPIIT extends BaseIntegrationTest {
 
     /** Tracks the server-generated UUID from API-created tenants for @AfterEach cleanup. */
     private String generatedTenantId;
+    private final Set<String> createdTenantIds = new HashSet<>();
     private final Set<String> createdBuckets = new HashSet<>();
 
     @Value("${application.callback.address:http://localhost:8080/}")
@@ -67,6 +73,9 @@ public class TenantAPIIT extends BaseIntegrationTest {
     @Autowired
     private BucketCredentialsRepository bucketCredentialsRepository;
 
+    @Autowired
+    private AuditEventRepository auditEventRepository;
+
     @AfterEach
     public void cleanup() {
         tenantRepository.deleteById(NEW_TENANT_ID);
@@ -74,6 +83,10 @@ public class TenantAPIIT extends BaseIntegrationTest {
             tenantRepository.deleteById(generatedTenantId);
             generatedTenantId = null;
         }
+        for (String createdTenantId : createdTenantIds) {
+            tenantRepository.deleteById(createdTenantId);
+        }
+        createdTenantIds.clear();
         for (String createdBucket : createdBuckets) {
             bucketCredentialsRepository.deleteById(createdBucket);
         }
@@ -99,6 +112,15 @@ public class TenantAPIIT extends BaseIntegrationTest {
                 .description("Integration test tenant")
                 .participantId(participantId)
                 .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+    }
+
+    private TenantUpdateRequest buildTenantUpdateRequest(String name, String description) {
+        return TenantUpdateRequest.Builder.newInstance()
+                .name(name)
+                .description(description)
                 .automaticNegotiation(false)
                 .automaticTransfer(false)
                 .build();
@@ -469,11 +491,9 @@ public class TenantAPIIT extends BaseIntegrationTest {
     public void updateTenant_asSuperAdmin_returns200() throws Exception {
         tenantRepository.save(buildNewTenant());
 
-        Tenant updates = Tenant.Builder.newInstance()
-                .id(NEW_TENANT_ID)
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
                 .name("Updated Name")
                 .description("Updated description")
-                .participantId("urn:connector:updated")
                 .automaticNegotiation(true)
                 .automaticTransfer(false)
                 .build();
@@ -481,7 +501,7 @@ public class TenantAPIIT extends BaseIntegrationTest {
         mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + NEW_TENANT_ID)
                         .with(user("super").roles("SUPER_ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(updates))))
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.success").value(true))
@@ -492,18 +512,334 @@ public class TenantAPIIT extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with no bucket fields keeps existing bucket and credentials")
+    public void updateTenant_withoutBucketFields_preservesBucketAndCredentials() throws Exception {
+        String tenantId = "tb3-ordinary-update";
+        String originalBucket = "tb3-ordinary-update-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(originalBucket);
+        createdBuckets.add(originalBucket);
+        BucketCredentialsEntity originalCredentials = bucketCredentialsService.getBucketCredentials(originalBucket);
+        Tenant existing = Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Ordinary Update")
+                .participantId("urn:connector:tb3-ordinary-update")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(originalBucket)
+                .build();
+        tenantRepository.save(existing);
+        createdTenantIds.add(tenantId);
+
+        TenantUpdateRequest request = buildTenantUpdateRequest("Ordinary Update Renamed", "Updated");
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bucketName").value(originalBucket));
+
+        BucketCredentialsEntity afterUpdate = bucketCredentialsService.getBucketCredentials(originalBucket);
+        assertThat(afterUpdate.getAccessKey()).isEqualTo(originalCredentials.getAccessKey());
+        assertThat(afterUpdate.getSecretKey()).isEqualTo(originalCredentials.getSecretKey());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with bucketName only migrates to available bucket")
+    public void updateTenant_bucketNameOnly_migrates() throws Exception {
+        String tenantId = "tb3-migrate-tenant";
+        String oldBucket = "tb3-migrate-old";
+        String newBucket = "tb3-migrate-new";
+        s3BucketProvisionService.ensureBucketCredentials(oldBucket);
+        s3BucketProvisionService.ensureBucketCredentials(newBucket);
+        createdBuckets.add(oldBucket);
+        createdBuckets.add(newBucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Migrate Tenant")
+                .participantId("urn:connector:tb3-migrate-tenant")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(oldBucket)
+                .build());
+        createdTenantIds.add(tenantId);
+
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Migrate Tenant")
+                .description("Migrated")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(newBucket)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bucketName").value(newBucket));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with bucket owned by another tenant returns 400 and preserves original bucket")
+    public void updateTenant_bucketConflict_returns400() throws Exception {
+        String ownerTenantId = "tb3-owner-tenant";
+        String targetTenantId = "tb3-target-tenant";
+        String ownerBucket = "tb3-owner-bucket";
+        String targetBucket = "tb3-target-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(ownerBucket);
+        s3BucketProvisionService.ensureBucketCredentials(targetBucket);
+        createdBuckets.add(ownerBucket);
+        createdBuckets.add(targetBucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(ownerTenantId)
+                .name("Owner")
+                .participantId("urn:connector:tb3-owner")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(ownerBucket)
+                .build());
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(targetTenantId)
+                .name("Target")
+                .participantId("urn:connector:tb3-target")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(targetBucket)
+                .build());
+        createdTenantIds.add(ownerTenantId);
+        createdTenantIds.add(targetTenantId);
+
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Target")
+                .description("Conflict")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(ownerBucket)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + targetTenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isBadRequest());
+
+        Tenant reloaded = tenantRepository.findById(targetTenantId).orElseThrow();
+        assertThat(reloaded.getBucketName()).isEqualTo(targetBucket);
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with external credentials verifyConnection false rotates credentials")
+    public void updateTenant_externalCredentialsVerifyFalse_rotatesCredentials() throws Exception {
+        String tenantId = "tb3-rotate-no-verify";
+        String bucket = "tb3-rotate-no-verify-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(bucket);
+        createdBuckets.add(bucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Rotate No Verify")
+                .participantId("urn:connector:tb3-rotate-no-verify")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .build());
+        createdTenantIds.add(tenantId);
+
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Rotate No Verify")
+                .description("Rotate")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .accessKey("rotated-access")
+                .secretKey("rotated-secret")
+                .verifyConnection(false)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bucketName").value(bucket));
+
+        BucketCredentialsEntity rotated = bucketCredentialsService.getBucketCredentials(bucket);
+        assertThat(rotated.getAccessKey()).isEqualTo("rotated-access");
+        assertThat(rotated.getSecretKey()).isEqualTo("rotated-secret");
+
+        List<AuditEvent> events = auditEventRepository.findAll().stream()
+                .filter(event -> event.getEventType() == AuditEventType.TENANT_UPDATED)
+                .toList();
+        assertThat(events).isNotEmpty();
+        AuditEvent latest = events.get(events.size() - 1);
+        assertThat(latest.getDetails()).containsEntry("changeType", "CREDENTIALS_ROTATED");
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with external credentials verifyConnection true valid succeeds")
+    public void updateTenant_externalCredentialsVerifyTrue_valid_returns200() throws Exception {
+        String tenantId = "tb3-verify-valid";
+        String bucket = "tb3-verify-valid-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(bucket);
+        createdBuckets.add(bucket);
+        BucketCredentialsEntity candidate = bucketCredentialsService.getBucketCredentials(bucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Verify Valid")
+                .participantId("urn:connector:tb3-verify-valid")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .build());
+        createdTenantIds.add(tenantId);
+
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Verify Valid")
+                .description("Rotate")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .accessKey(candidate.getAccessKey())
+                .secretKey(candidate.getSecretKey())
+                .verifyConnection(true)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bucketName").value(bucket));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} with external credentials verifyConnection true invalid returns 400 and does not leak secret")
+    public void updateTenant_externalCredentialsVerifyTrue_invalid_returns400(CapturedOutput output) throws Exception {
+        String tenantId = "tb3-verify-invalid";
+        String bucket = "tb3-verify-invalid-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(bucket);
+        createdBuckets.add(bucket);
+        BucketCredentialsEntity before = bucketCredentialsService.getBucketCredentials(bucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Verify Invalid")
+                .participantId("urn:connector:tb3-verify-invalid")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .build());
+        createdTenantIds.add(tenantId);
+        String secretKey = "invalid-secret-key-should-not-leak";
+
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Verify Invalid")
+                .description("Rotate")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .accessKey("invalid-access")
+                .secretKey(secretKey)
+                .verifyConnection(true)
+                .build();
+
+        MvcResult result = mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsString()).doesNotContain(secretKey);
+        assertThat(output.getAll()).doesNotContain(secretKey);
+        List<AuditEvent> events = auditEventRepository.findAll().stream()
+                .filter(event -> event.getEventType() == AuditEventType.TENANT_UPDATED)
+                .toList();
+        if (!events.isEmpty()) {
+            String detailsString = Objects.toString(events.get(events.size() - 1).getDetails(), "");
+            assertThat(detailsString).doesNotContain(secretKey);
+        }
+
+        BucketCredentialsEntity after = bucketCredentialsService.getBucketCredentials(bucket);
+        assertThat(after.getAccessKey()).isEqualTo(before.getAccessKey());
+        assertThat(after.getSecretKey()).isEqualTo(before.getSecretKey());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/tenants/{id} rotates credentials twice for same bucket")
+    public void updateTenant_externalCredentials_doubleRotation_succeeds() throws Exception {
+        String tenantId = "tb3-double-rotation";
+        String bucket = "tb3-double-rotation-bucket";
+        s3BucketProvisionService.ensureBucketCredentials(bucket);
+        createdBuckets.add(bucket);
+        BucketCredentialsEntity firstCandidate = bucketCredentialsService.getBucketCredentials(bucket);
+        tenantRepository.save(Tenant.Builder.newInstance()
+                .id(tenantId)
+                .name("Double Rotation")
+                .participantId("urn:connector:tb3-double-rotation")
+                .enabled(true)
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .build());
+        createdTenantIds.add(tenantId);
+
+        TenantUpdateRequest firstRotation = TenantUpdateRequest.Builder.newInstance()
+                .name("Double Rotation")
+                .description("First rotation")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .accessKey(firstCandidate.getAccessKey())
+                .secretKey(firstCandidate.getSecretKey())
+                .verifyConnection(true)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(firstRotation))))
+                .andExpect(status().isOk());
+
+        BucketCredentialsEntity afterFirstRotation = bucketCredentialsService.getBucketCredentials(bucket);
+
+        TenantUpdateRequest secondRotation = TenantUpdateRequest.Builder.newInstance()
+                .name("Double Rotation")
+                .description("Second rotation")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .bucketName(bucket)
+                .accessKey("second-rotated-access")
+                .secretKey("second-rotated-secret")
+                .verifyConnection(false)
+                .build();
+
+        mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + tenantId)
+                        .with(user("super").roles("SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(secondRotation))))
+                .andExpect(status().isOk());
+
+        BucketCredentialsEntity afterSecondRotation = bucketCredentialsService.getBucketCredentials(bucket);
+        assertThat(afterSecondRotation.getAccessKey()).isEqualTo("second-rotated-access");
+        assertThat(afterSecondRotation.getSecretKey()).isEqualTo("second-rotated-secret");
+        assertThat(afterSecondRotation.getVersion()).isGreaterThanOrEqualTo(afterFirstRotation.getVersion());
+    }
+
+    @Test
     @DisplayName("PUT /api/v1/tenants/{id} on non-existing tenant returns 404")
     public void updateTenant_nonExisting_returns404() throws Exception {
-        Tenant updates = Tenant.Builder.newInstance()
-                .id(NON_EXISTING_TENANT_ID)
-                .name("Should Not Update")
-                .participantId("urn:connector:test")
-                .build();
+        TenantUpdateRequest request = buildTenantUpdateRequest("Should Not Update", "Missing tenant");
 
         mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + NON_EXISTING_TENANT_ID)
                         .with(user("super").roles("SUPER_ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(updates))))
+                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(request))))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.success").value(false))
@@ -653,19 +989,20 @@ public class TenantAPIIT extends BaseIntegrationTest {
         tenantRepository.save(original);
         String originalParticipantId = original.getParticipantId();
 
-        Tenant updates = Tenant.Builder.newInstance()
-                .id(original.getId())
-                .name("Updated Name")
-                .description("Updated description")
-                .participantId("urn:connector:changed")
-                .automaticNegotiation(false)
-                .automaticTransfer(false)
-                .build();
+        String body = """
+                {
+                  "name": "Updated Name",
+                  "description": "Updated description",
+                  "participantId": "urn:connector:changed",
+                  "automaticNegotiation": false,
+                  "automaticTransfer": false
+                }
+                """;
 
         mockMvc.perform(put(ApiEndpoints.TENANTS_V1 + "/" + original.getId())
                         .with(user("super").roles("SUPER_ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(Objects.requireNonNull(ToolsSerializer.serializePlain(updates))))
+                        .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.participantId").value(originalParticipantId));

--- a/doc/security.md
+++ b/doc/security.md
@@ -266,6 +266,22 @@ All other `/api/**` endpoints require at minimum `ROLE_ADMIN`.
 
 **DISABLED mode**: The `DISABLED` authentication mode permits all requests including management endpoints. It is intended only for local development and must **not** be used in production.
 
+### Tenant S3 credential rotation guidance
+
+`PUT /api/v1/tenants/{id}` can rotate a tenant's S3 credentials (or migrate its bucket) when
+called by a `ROLE_SUPER_ADMIN` user with:
+
+- `bucketName` + `accessKey` + `secretKey`
+- and optionally `verifyConnection=true`
+
+For production operations, prefer `verifyConnection=true` so the connector validates the
+candidate credential set against the target bucket before persisting it. A failed verification
+returns HTTP 400 and leaves the existing tenant/bucket credential state unchanged.
+
+When migration moves a tenant to a new bucket, the connector intentionally does not delete data
+from the previous bucket automatically. Perform old-bucket cleanup as a separate, explicit
+operator step after confirming that no active transfers or artifact reads still depend on it.
+
 ### User Model (Internal Mode)
 
 Three distinct user roles are used in `initial_data.json` and at runtime:

--- a/tools/doc/tenant-s3-provisioning.md
+++ b/tools/doc/tenant-s3-provisioning.md
@@ -33,12 +33,28 @@ Validation is enforced inside `S3BucketProvisionService` before any S3 operation
 
 ## Tenant update
 
-`PUT /api/v1/tenants/{tenantId}` (via `TenantService.updateTenant()`) allows updating
-name, description, automaticNegotiation, and automaticTransfer.
+`PUT /api/v1/tenants/{tenantId}` (via `TenantService.updateTenant()`) supports the same
+three bucket-input modes as tenant creation, resolved from optional
+`bucketName`/`accessKey`/`secretKey` fields:
 
-The `bucketName` is **immutable** after tenant creation. Any `bucketName` value in the
-update body is silently ignored and the existing bucket name is always preserved.
-The `participantId` and `enabled` state are similarly immutable via this endpoint.
+| Input fields | Resolved mode | Behavior |
+|---|---|---|
+| no bucket fields supplied | `AUTOMATIC` | Existing `bucketName` and credentials are preserved (ordinary update) |
+| `bucketName` only | `EXISTING_BUCKET` | Reconfirm current bucket or migrate to a different existing bucket via `ensureBucketCredentials(bucketName)` |
+| `bucketName` + `accessKey` + `secretKey` | `EXTERNAL_CREDENTIALS` | Rotate credentials for the current bucket or migrate to a different bucket and persist supplied credentials |
+
+Additional update-path rules:
+
+- `participantId` and `enabled` remain immutable via this endpoint.
+- `verifyConnection=true` in `EXTERNAL_CREDENTIALS` mode enforces a pre-persistence
+  `HeadBucket` check through `BucketConnectionVerificationService`.
+- Bucket ownership conflicts are checked with `findByBucketNameAndIdNot(...)`, so a tenant
+  can reconfirm its own bucket but cannot migrate to a bucket already owned by another tenant.
+- Audit events keep using `TENANT_UPDATED` and add `details.changeType` with one of:
+  `ORDINARY_UPDATE`, `CREDENTIALS_ROTATED`, or `BUCKET_MIGRATED`.
+- Bucket data from a previous bucket is not deleted automatically after migration; this is
+  a deliberate safety choice aligned with tenant-deletion behavior. Clean up old buckets
+  manually when migration is complete.
 
 ## Per-tenant bucket isolation
 

--- a/tools/src/main/java/it/eng/tools/model/TenantUpdateRequest.java
+++ b/tools/src/main/java/it/eng/tools/model/TenantUpdateRequest.java
@@ -28,13 +28,14 @@ public class TenantUpdateRequest {
     /**
      * Converts this request to tenant updates consumed by {@link it.eng.tools.service.TenantService}.
      *
+     * @param existingTenant existing tenant used to preserve immutable and required fields
      * @return tenant containing the mutable, non-bucket update fields
      */
-    public Tenant toTenantUpdates() {
+    public Tenant toTenantUpdates(Tenant existingTenant) {
         return Tenant.Builder.newInstance()
-                .id("update-request")
-                .name(name)
-                .participantId("update-request")
+                .id(existingTenant.getId())
+                .name(name != null ? name : existingTenant.getName())
+                .participantId(existingTenant.getParticipantId())
                 .description(description)
                 .automaticNegotiation(automaticNegotiation)
                 .automaticTransfer(automaticTransfer)

--- a/tools/src/main/java/it/eng/tools/model/TenantUpdateRequest.java
+++ b/tools/src/main/java/it/eng/tools/model/TenantUpdateRequest.java
@@ -1,0 +1,177 @@
+package it.eng.tools.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request-only payload for updating a tenant and optionally rotating/migrating
+ * bucket credentials.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonDeserialize(builder = TenantUpdateRequest.Builder.class)
+public class TenantUpdateRequest {
+
+    private String name;
+    private String description;
+    private boolean automaticNegotiation;
+    private boolean automaticTransfer;
+    private String bucketName;
+    private String accessKey;
+    private String secretKey;
+    private boolean verifyConnection;
+
+    /**
+     * Converts this request to tenant updates consumed by {@link it.eng.tools.service.TenantService}.
+     *
+     * @return tenant containing the mutable, non-bucket update fields
+     */
+    public Tenant toTenantUpdates() {
+        return Tenant.Builder.newInstance()
+                .id("update-request")
+                .name(name)
+                .participantId("update-request")
+                .description(description)
+                .automaticNegotiation(automaticNegotiation)
+                .automaticTransfer(automaticTransfer)
+                .build();
+    }
+
+    /**
+     * Converts this request to optional bucket credential input.
+     *
+     * @return request-only bucket credential carrier
+     */
+    public TenantBucketCredentialsRequest toCredentialsRequest() {
+        return TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName(bucketName)
+                .accessKey(accessKey)
+                .secretKey(secretKey)
+                .verifyConnection(verifyConnection)
+                .build();
+    }
+
+    /**
+     * Builder for {@link TenantUpdateRequest}.
+     */
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Builder {
+
+        private final TenantUpdateRequest request;
+
+        private Builder() {
+            request = new TenantUpdateRequest();
+        }
+
+        /**
+         * Creates a new builder instance.
+         *
+         * @return a new builder
+         */
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        /**
+         * Sets tenant name.
+         *
+         * @param name tenant name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            request.name = name;
+            return this;
+        }
+
+        /**
+         * Sets tenant description.
+         *
+         * @param description tenant description
+         * @return this builder
+         */
+        public Builder description(String description) {
+            request.description = description;
+            return this;
+        }
+
+        /**
+         * Sets automatic negotiation flag.
+         *
+         * @param automaticNegotiation automatic negotiation flag
+         * @return this builder
+         */
+        public Builder automaticNegotiation(boolean automaticNegotiation) {
+            request.automaticNegotiation = automaticNegotiation;
+            return this;
+        }
+
+        /**
+         * Sets automatic transfer flag.
+         *
+         * @param automaticTransfer automatic transfer flag
+         * @return this builder
+         */
+        public Builder automaticTransfer(boolean automaticTransfer) {
+            request.automaticTransfer = automaticTransfer;
+            return this;
+        }
+
+        /**
+         * Sets candidate bucket name.
+         *
+         * @param bucketName candidate bucket name
+         * @return this builder
+         */
+        public Builder bucketName(String bucketName) {
+            request.bucketName = bucketName;
+            return this;
+        }
+
+        /**
+         * Sets candidate access key.
+         *
+         * @param accessKey candidate access key
+         * @return this builder
+         */
+        public Builder accessKey(String accessKey) {
+            request.accessKey = accessKey;
+            return this;
+        }
+
+        /**
+         * Sets candidate secret key.
+         *
+         * @param secretKey candidate secret key
+         * @return this builder
+         */
+        public Builder secretKey(String secretKey) {
+            request.secretKey = secretKey;
+            return this;
+        }
+
+        /**
+         * Sets connection verification flag.
+         *
+         * @param verifyConnection verification flag
+         * @return this builder
+         */
+        public Builder verifyConnection(boolean verifyConnection) {
+            request.verifyConnection = verifyConnection;
+            return this;
+        }
+
+        /**
+         * Builds request instance.
+         *
+         * @return built request
+         */
+        public TenantUpdateRequest build() {
+            return request;
+        }
+    }
+}

--- a/tools/src/main/java/it/eng/tools/repository/TenantRepository.java
+++ b/tools/src/main/java/it/eng/tools/repository/TenantRepository.java
@@ -32,6 +32,17 @@ public interface TenantRepository extends MongoRepository<Tenant, String>,
     Optional<Tenant> findByBucketName(String bucketName);
 
     /**
+     * Finds a tenant by bucket name excluding the provided tenant id.
+     * Used during tenant updates to detect ownership conflicts while allowing
+     * a tenant to keep or reconfirm its own bucket.
+     *
+     * @param bucketName the S3 bucket name to search for
+     * @param id the tenant id to exclude from the lookup
+     * @return an optional containing the conflicting tenant, if any
+     */
+    Optional<Tenant> findByBucketNameAndIdNot(String bucketName, String id);
+
+    /**
      * Finds a tenant by its DSP participant identity.
      * Used to enforce uniqueness of participant IDs across tenants.
      *

--- a/tools/src/main/java/it/eng/tools/rest/api/TenantAPIController.java
+++ b/tools/src/main/java/it/eng/tools/rest/api/TenantAPIController.java
@@ -139,7 +139,8 @@ public class TenantAPIController {
             @PathVariable String id,
             @RequestBody TenantUpdateRequest request) {
         log.info("Updating tenant: {}", id);
-        Tenant updated = tenantService.updateTenant(id, request.toTenantUpdates(), request.toCredentialsRequest());
+        Tenant existingTenant = tenantService.findById(id);
+        Tenant updated = tenantService.updateTenant(id, request.toTenantUpdates(existingTenant), request.toCredentialsRequest());
         return ResponseEntity.ok(GenericApiResponse.success(updated, "Tenant updated"));
     }
 

--- a/tools/src/main/java/it/eng/tools/rest/api/TenantAPIController.java
+++ b/tools/src/main/java/it/eng/tools/rest/api/TenantAPIController.java
@@ -3,6 +3,7 @@ package it.eng.tools.rest.api;
 import it.eng.tools.controller.ApiEndpoints;
 import it.eng.tools.model.Tenant;
 import it.eng.tools.model.TenantCreateRequest;
+import it.eng.tools.model.TenantUpdateRequest;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.service.GenericFilterBuilder;
 import it.eng.tools.service.TenantService;
@@ -130,15 +131,15 @@ public class TenantAPIController {
      * body is silently ignored and the stored value is preserved.
      *
      * @param id      the tenant identifier
-     * @param updates the tenant body with the fields to update
+     * @param request the update request body
      * @return 200 OK with the updated tenant
      */
     @PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GenericApiResponse<Tenant>> updateTenant(
             @PathVariable String id,
-            @RequestBody Tenant updates) {
+            @RequestBody TenantUpdateRequest request) {
         log.info("Updating tenant: {}", id);
-        Tenant updated = tenantService.updateTenant(id, updates);
+        Tenant updated = tenantService.updateTenant(id, request.toTenantUpdates(), request.toCredentialsRequest());
         return ResponseEntity.ok(GenericApiResponse.success(updated, "Tenant updated"));
     }
 

--- a/tools/src/main/java/it/eng/tools/s3/service/BucketCredentialsService.java
+++ b/tools/src/main/java/it/eng/tools/s3/service/BucketCredentialsService.java
@@ -30,15 +30,20 @@ public class BucketCredentialsService {
                 .accessKey(bucketCredentials.getAccessKey())
                 .secretKey(fieldEncryptionService.decrypt(bucketCredentials.getSecretKey()))
                 .bucketName(bucketCredentials.getBucketName())
+                .version(bucketCredentials.getVersion())
                 .build();
     }
 
     public BucketCredentialsEntity saveBucketCredentials(BucketCredentialsEntity bucketCredentials) {
         log.info("Saving bucket credentials for bucket: {}", bucketCredentials.getBucketName());
+        Long existingVersion = bucketCredentialsRepository.findByBucketName(bucketCredentials.getBucketName())
+                .map(BucketCredentialsEntity::getVersion)
+                .orElse(null);
         BucketCredentialsEntity savedBucketCredentials = BucketCredentialsEntity.Builder.newInstance()
                 .accessKey(bucketCredentials.getAccessKey())
                 .secretKey(fieldEncryptionService.encrypt(bucketCredentials.getSecretKey()))
                 .bucketName(bucketCredentials.getBucketName())
+                .version(existingVersion)
                 .build();
         return bucketCredentialsRepository.save(savedBucketCredentials);
     }

--- a/tools/src/main/java/it/eng/tools/service/TenantService.java
+++ b/tools/src/main/java/it/eng/tools/service/TenantService.java
@@ -18,7 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -35,6 +37,10 @@ public class TenantService {
 
     /** Prefix used when auto-deriving an S3 bucket name from the tenant identifier. */
     static final String BUCKET_NAME_PREFIX = "dsp-";
+    private static final String CHANGE_TYPE_KEY = "changeType";
+    private static final String CHANGE_TYPE_ORDINARY_UPDATE = "ORDINARY_UPDATE";
+    private static final String CHANGE_TYPE_CREDENTIALS_ROTATED = "CREDENTIALS_ROTATED";
+    private static final String CHANGE_TYPE_BUCKET_MIGRATED = "BUCKET_MIGRATED";
 
     private final TenantRepository tenantRepository;
     private final AuditEventPublisher auditEventPublisher;
@@ -283,9 +289,10 @@ public class TenantService {
     /**
      * Updates the mutable settings of an existing tenant (name, description,
      * automaticNegotiation, automaticTransfer).
-     * The {@code enabled} state, {@code participantId}, and {@code bucketName} are always
-     * preserved from the existing tenant; any values for these fields in {@code updates} are
-     * silently ignored.
+     *
+     * <p>This overload preserves the historical update behavior and always applies
+     * automatic mode for bucket handling, meaning bucket credentials are untouched and
+     * the current bucket assignment is preserved.
      *
      * @param tenantId the tenant identifier
      * @param updates  the tenant containing the new values to apply
@@ -293,9 +300,51 @@ public class TenantService {
      * @throws TenantNotFoundException  if the tenant does not exist
      */
     public Tenant updateTenant(String tenantId, Tenant updates) {
+        TenantBucketCredentialsRequest automaticRequest = TenantBucketCredentialsRequest.Builder.newInstance()
+                .verifyConnection(false)
+                .build();
+        return updateTenant(tenantId, updates, automaticRequest);
+    }
+
+    /**
+     * Updates the mutable settings of an existing tenant and applies tenant bucket
+     * credential provisioning according to the resolved {@link BucketProvisioningMode}.
+     *
+     * <p>The {@code enabled} state and {@code participantId} are immutable in this endpoint
+     * and are always preserved from the existing tenant.
+     *
+     * <p>Mode behavior:
+     * <ul>
+     *     <li>{@link BucketProvisioningMode#AUTOMATIC}: existing bucket and credentials are preserved</li>
+     *     <li>{@link BucketProvisioningMode#EXISTING_BUCKET}: supplied bucket is ensured/generated via
+     *     {@link S3BucketProvisionService#ensureBucketCredentials(String)} after ownership checks</li>
+     *     <li>{@link BucketProvisioningMode#EXTERNAL_CREDENTIALS}: supplied credentials are optionally verified
+     *     ({@code verifyConnection=true}) and then saved via
+     *     {@link BucketCredentialsService#saveBucketCredentials(BucketCredentialsEntity)}</li>
+     * </ul>
+     *
+     * @param tenantId the tenant identifier
+     * @param updates tenant fields to apply
+     * @param credentialsRequest request-only optional bucket credential fields
+     * @return the saved, updated tenant
+     * @throws TenantNotFoundException if tenant does not exist
+     * @throws IllegalArgumentException if bucket ownership conflicts, bucket format is invalid,
+     *                                  credential input is invalid, or verification fails
+     */
+    public Tenant updateTenant(String tenantId, Tenant updates, TenantBucketCredentialsRequest credentialsRequest) {
         Tenant existing = findById(tenantId);
-        // bucketName is immutable after creation; any value in updates is silently ignored
-        String preservedBucketName = existing.getBucketName();
+        BucketProvisioningMode provisioningMode = bucketProvisioningModeResolver.resolve(credentialsRequest);
+
+        String effectiveBucketName = resolveEffectiveUpdateBucketName(existing, credentialsRequest, provisioningMode);
+        String changeType = resolveUpdateChangeType(existing.getBucketName(), effectiveBucketName, provisioningMode);
+
+        if (provisioningMode != BucketProvisioningMode.AUTOMATIC) {
+            validateBucketNameFormat(effectiveBucketName);
+            validateBucketOwnershipForUpdate(effectiveBucketName, tenantId);
+        }
+
+        applyUpdateBucketProvisioning(tenantId, existing, credentialsRequest, effectiveBucketName, provisioningMode);
+
         Tenant updated = Tenant.Builder.newInstance()
                 .id(existing.getId())
                 .version(existing.getVersion())
@@ -305,13 +354,17 @@ public class TenantService {
                 .automaticNegotiation(updates.isAutomaticNegotiation())
                 .automaticTransfer(updates.isAutomaticTransfer())
                 .enabled(existing.isEnabled())
-                .bucketName(preservedBucketName)
+                .bucketName(effectiveBucketName)
                 .build();
         Tenant saved = tenantRepository.save(updated);
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("tenantId", tenantId);
+        details.put("tenantName", saved.getName());
+        details.put(CHANGE_TYPE_KEY, changeType);
         auditEventPublisher.publishEvent(AuditEvent.Builder.newInstance()
                 .eventType(AuditEventType.TENANT_UPDATED)
                 .description("Tenant updated: " + tenantId)
-                .details(Map.of("tenantId", tenantId, "tenantName", saved.getName()))
+                .details(details)
                 .build());
         log.info("Updated tenant: {}", tenantId);
         return saved;
@@ -356,6 +409,14 @@ public class TenantService {
                 });
     }
 
+    private void validateBucketOwnershipForUpdate(String bucketName, String tenantId) {
+        tenantRepository.findByBucketNameAndIdNot(bucketName, tenantId)
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException(
+                            "Bucket '" + bucketName + "' is already assigned to tenant: " + existing.getId());
+                });
+    }
+
     private void validateBucketNameFormat(String bucketName) {
         if (!BUCKET_NAME_PATTERN.matcher(bucketName).matches()) {
             throw new IllegalArgumentException(
@@ -387,5 +448,64 @@ public class TenantService {
 
         log.info("Provisioning S3 bucket '{}' for new tenant '{}'", effectiveBucketName, tenantId);
         s3BucketProvisionService.ensureBucketCredentials(effectiveBucketName);
+    }
+
+    private String resolveEffectiveUpdateBucketName(
+            Tenant existing,
+            TenantBucketCredentialsRequest credentialsRequest,
+            BucketProvisioningMode provisioningMode) {
+        if (provisioningMode == BucketProvisioningMode.AUTOMATIC) {
+            return existing.getBucketName();
+        }
+        return credentialsRequest.getBucketName();
+    }
+
+    private String resolveUpdateChangeType(
+            String existingBucketName,
+            String effectiveBucketName,
+            BucketProvisioningMode provisioningMode) {
+        if (!Objects.equals(existingBucketName, effectiveBucketName)) {
+            return CHANGE_TYPE_BUCKET_MIGRATED;
+        }
+        if (provisioningMode == BucketProvisioningMode.EXTERNAL_CREDENTIALS) {
+            return CHANGE_TYPE_CREDENTIALS_ROTATED;
+        }
+        return CHANGE_TYPE_ORDINARY_UPDATE;
+    }
+
+    private void applyUpdateBucketProvisioning(
+            String tenantId,
+            Tenant existing,
+            TenantBucketCredentialsRequest credentialsRequest,
+            String effectiveBucketName,
+            BucketProvisioningMode provisioningMode) {
+        if (provisioningMode == BucketProvisioningMode.AUTOMATIC) {
+            return;
+        }
+
+        if (provisioningMode == BucketProvisioningMode.EXISTING_BUCKET) {
+            if (Objects.equals(existing.getBucketName(), effectiveBucketName)) {
+                log.info("Reconfirming existing S3 bucket '{}' for tenant '{}'", effectiveBucketName, tenantId);
+            } else {
+                log.info("Migrating tenant '{}' bucket from '{}' to '{}'",
+                        tenantId, existing.getBucketName(), effectiveBucketName);
+            }
+            s3BucketProvisionService.ensureBucketCredentials(effectiveBucketName);
+            return;
+        }
+
+        if (credentialsRequest.isVerifyConnection()
+                && !bucketConnectionVerificationService.verify(
+                effectiveBucketName,
+                credentialsRequest.getAccessKey(),
+                credentialsRequest.getSecretKey())) {
+            throw new IllegalArgumentException(
+                    "Bucket credentials verification failed for bucket '" + effectiveBucketName + "'.");
+        }
+        bucketCredentialsService.saveBucketCredentials(BucketCredentialsEntity.Builder.newInstance()
+                .bucketName(effectiveBucketName)
+                .accessKey(credentialsRequest.getAccessKey())
+                .secretKey(credentialsRequest.getSecretKey())
+                .build());
     }
 }

--- a/tools/src/test/java/it/eng/tools/model/TenantUpdateRequestTest.java
+++ b/tools/src/test/java/it/eng/tools/model/TenantUpdateRequestTest.java
@@ -1,0 +1,59 @@
+package it.eng.tools.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantUpdateRequestTest {
+
+    @Test
+    @DisplayName("TenantUpdateRequest toTenantUpdates maps mutable tenant fields")
+    void toTenantUpdates_mapsMutableFields() {
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Updated tenant")
+                .description("Updated description")
+                .automaticNegotiation(true)
+                .automaticTransfer(false)
+                .build();
+
+        Tenant updates = request.toTenantUpdates();
+
+        assertEquals("Updated tenant", updates.getName());
+        assertEquals("Updated description", updates.getDescription());
+        assertTrue(updates.isAutomaticNegotiation());
+        assertFalse(updates.isAutomaticTransfer());
+    }
+
+    @Test
+    @DisplayName("TenantUpdateRequest toCredentialsRequest maps optional credentials")
+    void toCredentialsRequest_mapsCredentialsFields() {
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .bucketName("tenant-bucket")
+                .accessKey("provided-access")
+                .secretKey("provided-secret")
+                .verifyConnection(true)
+                .build();
+
+        TenantBucketCredentialsRequest credentialsRequest = request.toCredentialsRequest();
+
+        assertEquals("tenant-bucket", credentialsRequest.getBucketName());
+        assertEquals("provided-access", credentialsRequest.getAccessKey());
+        assertEquals("provided-secret", credentialsRequest.getSecretKey());
+        assertTrue(credentialsRequest.isVerifyConnection());
+    }
+
+    @Test
+    @DisplayName("TenantUpdateRequest verifyConnection defaults to false")
+    void verifyConnection_defaultIsFalse() {
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .name("Updated tenant")
+                .build();
+
+        TenantBucketCredentialsRequest credentialsRequest = request.toCredentialsRequest();
+
+        assertFalse(credentialsRequest.isVerifyConnection());
+    }
+}

--- a/tools/src/test/java/it/eng/tools/model/TenantUpdateRequestTest.java
+++ b/tools/src/test/java/it/eng/tools/model/TenantUpdateRequestTest.java
@@ -18,13 +18,23 @@ class TenantUpdateRequestTest {
                 .automaticNegotiation(true)
                 .automaticTransfer(false)
                 .build();
+        Tenant existing = Tenant.Builder.newInstance()
+                .id("tenant-id")
+                .name("Existing name")
+                .participantId("urn:connector:tenant")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .enabled(true)
+                .build();
 
-        Tenant updates = request.toTenantUpdates();
+        Tenant updates = request.toTenantUpdates(existing);
 
         assertEquals("Updated tenant", updates.getName());
         assertEquals("Updated description", updates.getDescription());
         assertTrue(updates.isAutomaticNegotiation());
         assertFalse(updates.isAutomaticTransfer());
+        assertEquals("tenant-id", updates.getId());
+        assertEquals("urn:connector:tenant", updates.getParticipantId());
     }
 
     @Test
@@ -55,5 +65,28 @@ class TenantUpdateRequestTest {
         TenantBucketCredentialsRequest credentialsRequest = request.toCredentialsRequest();
 
         assertFalse(credentialsRequest.isVerifyConnection());
+    }
+
+    @Test
+    @DisplayName("TenantUpdateRequest toTenantUpdates keeps existing name when omitted")
+    void toTenantUpdates_withoutName_preservesExistingName() {
+        Tenant existing = Tenant.Builder.newInstance()
+                .id("tenant-id")
+                .name("Existing name")
+                .participantId("urn:connector:tenant")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .enabled(true)
+                .build();
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
+                .description("Only description changes")
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+
+        Tenant updates = request.toTenantUpdates(existing);
+
+        assertEquals("Existing name", updates.getName());
+        assertEquals("Only description changes", updates.getDescription());
     }
 }

--- a/tools/src/test/java/it/eng/tools/rest/api/TenantAPIControllerTest.java
+++ b/tools/src/test/java/it/eng/tools/rest/api/TenantAPIControllerTest.java
@@ -4,6 +4,7 @@ import it.eng.tools.exception.TenantNotFoundException;
 import it.eng.tools.model.Tenant;
 import it.eng.tools.model.TenantBucketCredentialsRequest;
 import it.eng.tools.model.TenantCreateRequest;
+import it.eng.tools.model.TenantUpdateRequest;
 import it.eng.tools.response.GenericApiResponse;
 import it.eng.tools.service.GenericFilterBuilder;
 import it.eng.tools.service.TenantService;
@@ -182,31 +183,30 @@ class TenantAPIControllerTest {
     @Test
     @DisplayName("Update tenant returns updated tenant")
     void updateTenant_success() {
-        Tenant updates = Tenant.Builder.newInstance()
-                .id(TENANT_ID)
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
                 .name("Updated Name")
-                .participantId("urn:connector:updated")
                 .build();
         Tenant updated = buildTenant();
-        when(tenantService.updateTenant(TENANT_ID, updates)).thenReturn(updated);
+        when(tenantService.updateTenant(eq(TENANT_ID), any(Tenant.class), any(TenantBucketCredentialsRequest.class)))
+                .thenReturn(updated);
 
-        ResponseEntity<GenericApiResponse<Tenant>> response = controller.updateTenant(TENANT_ID, updates);
+        ResponseEntity<GenericApiResponse<Tenant>> response = controller.updateTenant(TENANT_ID, request);
 
         assertNotNull(response.getBody());
         assertEquals(TENANT_ID, response.getBody().getData().getId());
+        verify(tenantService).updateTenant(eq(TENANT_ID), any(Tenant.class), any(TenantBucketCredentialsRequest.class));
     }
 
     @Test
     @DisplayName("Update tenant throws when not found")
     void updateTenant_notFound() {
-        Tenant updates = Tenant.Builder.newInstance()
-                .id(TENANT_ID)
+        TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
                 .name("Updated Name")
-                .participantId("urn:connector:updated")
                 .build();
-        when(tenantService.updateTenant(TENANT_ID, updates)).thenThrow(new TenantNotFoundException("Not found"));
+        when(tenantService.updateTenant(eq(TENANT_ID), any(Tenant.class), any(TenantBucketCredentialsRequest.class)))
+                .thenThrow(new TenantNotFoundException("Not found"));
 
-        assertThrows(TenantNotFoundException.class, () -> controller.updateTenant(TENANT_ID, updates));
+        assertThrows(TenantNotFoundException.class, () -> controller.updateTenant(TENANT_ID, request));
     }
 
     @Test

--- a/tools/src/test/java/it/eng/tools/rest/api/TenantAPIControllerTest.java
+++ b/tools/src/test/java/it/eng/tools/rest/api/TenantAPIControllerTest.java
@@ -186,7 +186,9 @@ class TenantAPIControllerTest {
         TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
                 .name("Updated Name")
                 .build();
+        Tenant existing = buildTenant();
         Tenant updated = buildTenant();
+        when(tenantService.findById(TENANT_ID)).thenReturn(existing);
         when(tenantService.updateTenant(eq(TENANT_ID), any(Tenant.class), any(TenantBucketCredentialsRequest.class)))
                 .thenReturn(updated);
 
@@ -203,8 +205,7 @@ class TenantAPIControllerTest {
         TenantUpdateRequest request = TenantUpdateRequest.Builder.newInstance()
                 .name("Updated Name")
                 .build();
-        when(tenantService.updateTenant(eq(TENANT_ID), any(Tenant.class), any(TenantBucketCredentialsRequest.class)))
-                .thenThrow(new TenantNotFoundException("Not found"));
+        when(tenantService.findById(TENANT_ID)).thenThrow(new TenantNotFoundException("Not found"));
 
         assertThrows(TenantNotFoundException.class, () -> controller.updateTenant(TENANT_ID, request));
     }

--- a/tools/src/test/java/it/eng/tools/s3/service/BucketCredentialsServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/s3/service/BucketCredentialsServiceTest.java
@@ -1,0 +1,98 @@
+package it.eng.tools.s3.service;
+
+import it.eng.tools.s3.model.BucketCredentialsEntity;
+import it.eng.tools.s3.repository.BucketCredentialsRepository;
+import it.eng.tools.service.FieldEncryptionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BucketCredentialsServiceTest {
+
+    @Mock
+    private FieldEncryptionService fieldEncryptionService;
+
+    @Mock
+    private BucketCredentialsRepository bucketCredentialsRepository;
+
+    @InjectMocks
+    private BucketCredentialsService bucketCredentialsService;
+
+    @Test
+    @DisplayName("saveBucketCredentials keeps version null for first insert")
+    void saveBucketCredentials_newBucket_keepsVersionNull() {
+        BucketCredentialsEntity input = BucketCredentialsEntity.Builder.newInstance()
+                .bucketName("new-bucket")
+                .accessKey("access")
+                .secretKey("secret")
+                .build();
+        when(bucketCredentialsRepository.findByBucketName("new-bucket")).thenReturn(Optional.empty());
+        when(fieldEncryptionService.encrypt("secret")).thenReturn("encrypted-secret");
+        when(bucketCredentialsRepository.save(any(BucketCredentialsEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        BucketCredentialsEntity saved = bucketCredentialsService.saveBucketCredentials(input);
+
+        assertNull(saved.getVersion());
+        assertEquals("encrypted-secret", saved.getSecretKey());
+    }
+
+    @Test
+    @DisplayName("saveBucketCredentials carries existing version for updates")
+    void saveBucketCredentials_existingBucket_carriesVersionForward() {
+        BucketCredentialsEntity existing = BucketCredentialsEntity.Builder.newInstance()
+                .bucketName("existing-bucket")
+                .accessKey("old-access")
+                .secretKey("old-secret")
+                .version(3L)
+                .build();
+        BucketCredentialsEntity input = BucketCredentialsEntity.Builder.newInstance()
+                .bucketName("existing-bucket")
+                .accessKey("new-access")
+                .secretKey("new-secret")
+                .build();
+        when(bucketCredentialsRepository.findByBucketName("existing-bucket")).thenReturn(Optional.of(existing));
+        when(fieldEncryptionService.encrypt("new-secret")).thenReturn("encrypted-new-secret");
+        when(bucketCredentialsRepository.save(any(BucketCredentialsEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        bucketCredentialsService.saveBucketCredentials(input);
+
+        ArgumentCaptor<BucketCredentialsEntity> captor = ArgumentCaptor.forClass(BucketCredentialsEntity.class);
+        verify(bucketCredentialsRepository).save(captor.capture());
+        assertEquals(3L, captor.getValue().getVersion());
+        assertEquals("encrypted-new-secret", captor.getValue().getSecretKey());
+    }
+
+    @Test
+    @DisplayName("getBucketCredentials decrypts and returns stored version")
+    void getBucketCredentials_decryptsAndReturnsVersion() {
+        BucketCredentialsEntity stored = BucketCredentialsEntity.Builder.newInstance()
+                .bucketName("bucket")
+                .accessKey("stored-access")
+                .secretKey("encrypted-secret")
+                .version(7L)
+                .build();
+        when(bucketCredentialsRepository.findByBucketName("bucket")).thenReturn(Optional.of(stored));
+        when(fieldEncryptionService.decrypt("encrypted-secret")).thenReturn("plain-secret");
+
+        BucketCredentialsEntity result = bucketCredentialsService.getBucketCredentials("bucket");
+
+        assertEquals("stored-access", result.getAccessKey());
+        assertEquals("plain-secret", result.getSecretKey());
+        assertEquals(7L, result.getVersion());
+    }
+}

--- a/tools/src/test/java/it/eng/tools/service/TenantServiceTest.java
+++ b/tools/src/test/java/it/eng/tools/service/TenantServiceTest.java
@@ -80,6 +80,16 @@ class TenantServiceTest {
                 .build();
     }
 
+    private Tenant buildTenantWithBucket(boolean enabled, String bucketName) {
+        return Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("Engineering")
+                .participantId("urn:connector:engineering")
+                .enabled(enabled)
+                .bucketName(bucketName)
+                .build();
+    }
+
     @Test
     @DisplayName("findEnabledTenantById returns tenant when present and enabled")
     void findEnabledTenantById_success() {
@@ -318,6 +328,8 @@ class TenantServiceTest {
         Tenant existing = buildTenant(true);
         when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
         when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(bucketProvisioningModeResolver.resolve(any(TenantBucketCredentialsRequest.class)))
+                .thenReturn(BucketProvisioningMode.AUTOMATIC);
 
         String existingParticipantId = existing.getParticipantId();
 
@@ -339,10 +351,12 @@ class TenantServiceTest {
     @Test
     @DisplayName("updateTenant preserves existing bucketName, silently ignoring any bucketName in update body")
     void updateTenant_bucketNameIsImmutable() {
-        Tenant existing = buildTenant(true);
+        Tenant existing = buildTenantWithBucket(true, "existing-bucket");
         String existingBucket = existing.getBucketName();
         when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
         when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(bucketProvisioningModeResolver.resolve(any(TenantBucketCredentialsRequest.class)))
+                .thenReturn(BucketProvisioningMode.AUTOMATIC);
 
         Tenant updates = Tenant.Builder.newInstance()
                 .id(TENANT_ID)
@@ -358,6 +372,151 @@ class TenantServiceTest {
         assertEquals(existingBucket, result.getBucketName(),
                 "bucketName must remain unchanged regardless of update body");
         verify(s3BucketProvisionService, never()).ensureBucketCredentials(any());
+    }
+
+    @Test
+    @DisplayName("updateTenant with EXISTING_BUCKET same bucket reconfirms and keeps bucket")
+    void updateTenant_existingBucket_sameBucket_reconfirm() {
+        Tenant existing = buildTenantWithBucket(true, "existing-bucket");
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId(existing.getParticipantId())
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("existing-bucket")
+                .build();
+        when(bucketProvisioningModeResolver.resolve(request)).thenReturn(BucketProvisioningMode.EXISTING_BUCKET);
+        when(tenantRepository.findByBucketNameAndIdNot("existing-bucket", TENANT_ID)).thenReturn(Optional.empty());
+
+        Tenant result = tenantService.updateTenant(TENANT_ID, updates, request);
+
+        assertEquals("existing-bucket", result.getBucketName());
+        verify(s3BucketProvisionService).ensureBucketCredentials("existing-bucket");
+    }
+
+    @Test
+    @DisplayName("updateTenant with EXISTING_BUCKET different bucket migrates")
+    void updateTenant_existingBucket_differentBucket_migrates() {
+        Tenant existing = buildTenantWithBucket(true, "old-bucket");
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId(existing.getParticipantId())
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("new-bucket")
+                .build();
+        when(bucketProvisioningModeResolver.resolve(request)).thenReturn(BucketProvisioningMode.EXISTING_BUCKET);
+        when(tenantRepository.findByBucketNameAndIdNot("new-bucket", TENANT_ID)).thenReturn(Optional.empty());
+
+        Tenant result = tenantService.updateTenant(TENANT_ID, updates, request);
+
+        assertEquals("new-bucket", result.getBucketName());
+        verify(s3BucketProvisionService).ensureBucketCredentials("new-bucket");
+        ArgumentCaptor<AuditEvent> eventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(auditEventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals("BUCKET_MIGRATED", eventCaptor.getValue().getDetails().get("changeType"));
+    }
+
+    @Test
+    @DisplayName("updateTenant with bucket conflict throws IllegalArgumentException")
+    void updateTenant_bucketConflict_throwsIllegalArgumentException() {
+        Tenant existing = buildTenantWithBucket(true, "old-bucket");
+        Tenant conflicting = Tenant.Builder.newInstance()
+                .id("other-tenant")
+                .name("Other")
+                .participantId("urn:connector:other")
+                .enabled(true)
+                .bucketName("shared-bucket")
+                .build();
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+        when(tenantRepository.findByBucketNameAndIdNot("shared-bucket", TENANT_ID))
+                .thenReturn(Optional.of(conflicting));
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId(existing.getParticipantId())
+                .build();
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("shared-bucket")
+                .build();
+        when(bucketProvisioningModeResolver.resolve(request)).thenReturn(BucketProvisioningMode.EXISTING_BUCKET);
+
+        assertThrows(IllegalArgumentException.class, () -> tenantService.updateTenant(TENANT_ID, updates, request));
+        verify(tenantRepository, never()).save(any(Tenant.class));
+    }
+
+    @Test
+    @DisplayName("updateTenant with EXTERNAL_CREDENTIALS verifyConnection false rotates credentials")
+    void updateTenant_externalCredentials_verifyFalse_rotatesCredentials() {
+        Tenant existing = buildTenantWithBucket(true, "existing-bucket");
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(bucketCredentialsService.saveBucketCredentials(any(BucketCredentialsEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId(existing.getParticipantId())
+                .automaticNegotiation(false)
+                .automaticTransfer(false)
+                .build();
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("existing-bucket")
+                .accessKey("rotated-access")
+                .secretKey("rotated-secret")
+                .verifyConnection(false)
+                .build();
+        when(bucketProvisioningModeResolver.resolve(request)).thenReturn(BucketProvisioningMode.EXTERNAL_CREDENTIALS);
+        when(tenantRepository.findByBucketNameAndIdNot("existing-bucket", TENANT_ID)).thenReturn(Optional.empty());
+
+        tenantService.updateTenant(TENANT_ID, updates, request);
+
+        verify(bucketCredentialsService).saveBucketCredentials(any(BucketCredentialsEntity.class));
+        verify(bucketConnectionVerificationService, never()).verify(anyString(), anyString(), anyString());
+        ArgumentCaptor<AuditEvent> eventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(auditEventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals("CREDENTIALS_ROTATED", eventCaptor.getValue().getDetails().get("changeType"));
+    }
+
+    @Test
+    @DisplayName("updateTenant with EXTERNAL_CREDENTIALS verifyConnection true fails before persistence")
+    void updateTenant_externalCredentials_verifyTrue_failure() {
+        Tenant existing = buildTenantWithBucket(true, "existing-bucket");
+        when(tenantRepository.findById(TENANT_ID)).thenReturn(Optional.of(existing));
+
+        Tenant updates = Tenant.Builder.newInstance()
+                .id(TENANT_ID)
+                .name("New Name")
+                .participantId(existing.getParticipantId())
+                .build();
+        TenantBucketCredentialsRequest request = TenantBucketCredentialsRequest.Builder.newInstance()
+                .bucketName("existing-bucket")
+                .accessKey("invalid-access")
+                .secretKey("invalid-secret")
+                .verifyConnection(true)
+                .build();
+        when(bucketProvisioningModeResolver.resolve(request)).thenReturn(BucketProvisioningMode.EXTERNAL_CREDENTIALS);
+        when(tenantRepository.findByBucketNameAndIdNot("existing-bucket", TENANT_ID)).thenReturn(Optional.empty());
+        when(bucketConnectionVerificationService.verify("existing-bucket", "invalid-access", "invalid-secret"))
+                .thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> tenantService.updateTenant(TENANT_ID, updates, request));
+        verify(tenantRepository, never()).save(any(Tenant.class));
+        verify(bucketCredentialsService, never()).saveBucketCredentials(any(BucketCredentialsEntity.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- implement TB3 tenant-update bucket branching with reconfirm, migration, and external-credential rotation flows
- add update request DTO wiring for PUT /api/v1/tenants/{id} and extend unit/integration coverage (including double-rotation regression)
- update tenant/S3/security docs, changelog, and Postman tenant-update examples

## Verification
- mvn -pl tools -am test
- mvn -pl connector -am -Dit.test=TenantAPIIT -Dfailsafe.failIfNoSpecifiedTests=false verify
- mvn -pl tools -am validate
- mvn clean verify

## Slice completion
Parent slice:
- Closes #325

Child tasks:
- Closes #334
- Closes #335
- Closes #336
- Closes #337
